### PR TITLE
policy/support/obj_perm_sets.spt: modify indentation of mmap_file_per…

### DIFF
--- a/policy/support/obj_perm_sets.spt
+++ b/policy/support/obj_perm_sets.spt
@@ -154,7 +154,11 @@ define(`relabel_dir_perms',`{ getattr relabelfrom relabelto }')
 define(`getattr_file_perms',`{ getattr }')
 define(`setattr_file_perms',`{ setattr }')
 define(`read_file_perms',`{ getattr open read lock ioctl }')
-define(`mmap_file_perms',`{ getattr open map read execute ioctl } refpolicywarn(`mmap_file_perms is deprecated, please use mmap_exec_file_perms instead')') # deprecated 20171213
+# deprecated 20171213
+define(`mmap_file_perms',`
+	{ getattr open map read execute ioctl }
+	refpolicywarn(`mmap_file_perms is deprecated, please use mmap_exec_file_perms instead')
+')
 define(`mmap_read_inherited_file_perms',`{ getattr map read ioctl }')
 define(`mmap_read_file_perms',`{ getattr open map read ioctl }')
 define(`mmap_exec_inherited_file_perms',`{ getattr map read execute ioctl }')


### PR DESCRIPTION
…ms to make sepolgen-ifgen happy

Currently, sepolgen-ifgen fails with the following error:
  /usr/share/selinux/refpolicy/include/support/obj_perm_sets.spt: Syntax error on line 157 ` [type=TICK]
  error parsing headers
  error parsing file /usr/share/selinux/refpolicy/include/support/obj_perm_sets.spt: could not parse text: "/usr/share/selinux/refpolicy/include/support/obj_perm_sets.spt: Syntax error on line 157 ` [type=TICK]"