### PR TITLE
sysstat: allow sysstat_t to getattr on mountpoints

### DIFF
--- a/policy/modules/services/sysstat.te
+++ b/policy/modules/services/sysstat.te
@@ -47,6 +47,7 @@ dev_read_urand(sysstat_t)
 files_search_var(sysstat_t)
 files_read_etc_runtime_files(sysstat_t)
 files_search_all_mountpoints(sysstat_t)
+files_getattr_all_mountpoints(sysstat_t)
 
 fs_getattr_xattr_fs(sysstat_t)
 fs_list_inotifyfs(sysstat_t)


### PR DESCRIPTION
The sadc utility from sysstat that collects file systems statistics (-F
flag) will be denied to access /var/log/audit (getattr) if it is a
mountpoint

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>