### PR TITLE
Bug fixes for Iscsi

### DIFF
--- a/policy/modules/system/iscsi.te
+++ b/policy/modules/system/iscsi.te
@@ -40,6 +40,7 @@ allow iscsid_t self:fifo_file rw_fifo_file_perms;
 allow iscsid_t self:unix_stream_socket { accept connectto listen };
 allow iscsid_t self:sem create_sem_perms;
 allow iscsid_t self:shm create_shm_perms;
+allow iscsid_t self:netlink_iscsi_socket create_socket_perms;
 allow iscsid_t self:netlink_socket create_socket_perms;
 allow iscsid_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow iscsid_t self:netlink_route_socket nlmsg_write;


### PR DESCRIPTION
For the 2nd patch, I'm not sure if it's better to allow libvirt to connect to the socket or to add a domain for iscsiadm and allow the transition to that domain

Edit: I removed the 2nd patch, this was not enough, it's probably better to go for a private type for iscsiadm as it's requires more permissions (capability, creation of a lock file in /run/lock,...)