### PR TITLE
ssh: use dac_read_search instead of dac_override

### DIFF
--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -181,7 +181,7 @@ template(`ssh_server_template', `
 	type $1_var_run_t;
 	files_pid_file($1_var_run_t)
 
-	allow $1_t self:capability { chown dac_override fowner fsetid kill setgid setuid sys_chroot sys_nice sys_resource sys_tty_config };
+	allow $1_t self:capability { chown dac_read_search fowner fsetid kill setgid setuid sys_chroot sys_nice sys_resource sys_tty_config };
 	# net_admin is for SO_SNDBUFFORCE
 	dontaudit $1_t self:capability net_admin;
 	allow $1_t self:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
When creating a session for a new user, sshd performs a stat() call
somewhere:

    type=AVC msg=audit(1502951786.649:211): avc:  denied  {
    dac_read_search } for  pid=274 comm="sshd" capability=2
    scontext=system_u:system_r:sshd_t tcontext=system_u:system_r:sshd_t
    tclass=capability permissive=1

    type=SYSCALL msg=audit(1502951786.649:211): arch=c000003e syscall=4
    success=no exit=-2 a0=480e79b300 a1=7ffe0e09b080 a2=7ffe0e09b080
    a3=7fb2aa321b20 items=0 ppid=269 pid=274 auid=1000 uid=0 gid=0
    euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=1
    comm="sshd" exe="/usr/bin/sshd" subj=system_u:system_r:sshd_t
    key=(null)

    type=PROCTITLE msg=audit(1502951786.649:211):
    proctitle=737368643A2076616772616E74205B707269765D