### PR TITLE
gpg: label pacman gnupg directory

### DIFF
--- a/policy/modules/apps/gpg.fc
+++ b/policy/modules/apps/gpg.fc
@@ -3,6 +3,8 @@ HOME_DIR/\.gnupg/log-socket		-s	gen_context(system_u:object_r:gpg_agent_tmp_t,s0
 HOME_DIR/\.gnupg/S\.gpg-agent.*		-s	gen_context(system_u:object_r:gpg_agent_tmp_t,s0)
 HOME_DIR/\.gnupg/S\.scdaemon		-s	gen_context(system_u:object_r:gpg_agent_tmp_t,s0)
 
+/etc/pacman\.d/gnupg(/.+)?			gen_context(system_u:object_r:gpg_secret_t,s0)
+
 /usr/bin/gpg(2)?			--	gen_context(system_u:object_r:gpg_exec_t,s0)
 /usr/bin/gpgsm				--	gen_context(system_u:object_r:gpg_exec_t,s0)
 /usr/bin/gpg-agent			--	gen_context(system_u:object_r:gpg_agent_exec_t,s0)


### PR DESCRIPTION
On Arch Linux, pacman verifies the signature of packages using "gpg
--homedir /etc/pacman.d/gnupg/". When the gnupg directory is labeled
etc_t, the following record is logged in audit.log:

    type=AVC msg=audit(1546721190.943:704): avc:  denied  { write } for
    pid=8533 comm="gpg" name="trustdb.gpg" dev="vda1" ino=789644
    scontext=sysadm_u:sysadm_r:gpg_t tcontext=system_u:object_r:etc_t
    tclass=file permissive=0

    type=SYSCALL msg=audit(1546721190.943:704): arch=c000003e
    syscall=257 success=no exit=-13 a0=ffffff9c a1=56443a518ff0 a2=2
    a3=0 items=0 ppid=1 pid=8533 auid=1000 uid=0 gid=0 euid=0 suid=0
    fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=7 comm="gpg"
    exe="/usr/bin/gpg" subj=sysadm_u:sysadm_r:gpg_t key=(null)

    type=PROCTITLE msg=audit(1546721190.943:704): proctitle=677067002D2D
    6261746368002D2D6E6F2D736B2D636F6D6D656E7473002D2D6C632D6D6573736167
    65730043002D2D6C632D63747970650043002D2D686F6D65646972002F6574632F70
    61636D616E2E642F676E7570672F002D2D7374617475732D66640037002D2D6E6F2D
    747479002D2D636861727365740075746638002D

(the proctitle gives the exact gpg command line that pacman uses).

Define a context for /etc/pacman.d/gnupg/ in order to fix this access.