### PR TITLE
selinuxutil: allow restorecond to try counting the number of files in cgroup fs

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -357,6 +357,7 @@ kernel_use_fds(restorecond_t)
 
 fs_dontaudit_list_nfs(restorecond_t)
 fs_getattr_all_xattr_fs(restorecond_t)
+fs_getattr_cgroup(restorecond_t)
 fs_getattr_pstore_dirs(restorecond_t)
 fs_getattr_tracefs(restorecond_t)
 fs_list_inotifyfs(restorecond_t)


### PR DESCRIPTION
When restorecond calls selinux_restorecon(), libselinux scans /proc/mounts in a function named exclude_non_seclabel_mounts with the following comment (https://github.com/SELinuxProject/selinux/blob/libselinux-2.8/libselinux/src/selinux_restorecon.c#L224-L230):

    /*
     * This is called once when selinux_restorecon() is first called.
     * Searches /proc/mounts for all file systems that do not support extended
     * attributes and adds them to the exclude directory table.  File systems
     * that support security labels have the seclabel option, return
     * approximate total file count.
     */

The "approximate total file count" is computed using statvfs(), which results in a system call to statfs().

The cgroup filesystem supports security label (/proc/mounts shows "seclabel") so restorecond uses statfs to try counting the number of its inodes. This result in the following denial:

    type=AVC msg=audit(1546727200.623:67): avc:  denied  { getattr } for
    pid=314 comm="restorecond" name="/" dev="cgroup" ino=1
    scontext=system_u:system_r:restorecond_t
    tcontext=system_u:object_r:cgroup_t tclass=filesystem permissive=0

    type=SYSCALL msg=audit(1546727200.623:67): arch=c000003e syscall=137
    success=no exit=-13 a0=556d2aeb4c37 a1=7fffa4a90a90 a2=556d2aeb4c55
    a3=7f043156a9f0 items=0 ppid=1 pid=314 auid=4294967295 uid=0 gid=0
    euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none)
    ses=4294967295 comm="restorecond" exe="/usr/bin/restorecond"
    subj=system_u:system_r:restorecond_t key=(null)

    type=PROCTITLE msg=audit(1546727200.623:67): proctitle="/usr/sbin/restorecond"

Allow this, like commit 5125b8eb2d58 ("last misc stuff") did for setfiles_t.