### PR TITLE
authlogin: allow callers of getpwent() to get dynamic users

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -433,6 +433,11 @@ tunable_policy(`authlogin_nsswitch_use_ldap',`
 	sysnet_use_ldap(nsswitch_domain)
 ')
 
+ifdef(`init_systemd',`
+	# nss-systemd calls GetDynamicUsers() exposed by systemd over D-Bus
+	init_dbus_chat(nsswitch_domain)
+')
+
 optional_policy(`
 	tunable_policy(`authlogin_nsswitch_use_ldap',`
 		ldap_stream_connect(nsswitch_domain)


### PR DESCRIPTION
On a system with systemd as init, nss-systemd module makes D-Bus calls to systemd.

cf. https://lore.kernel.org/selinux-refpolicy/87lg3y8ckd.fsf@gmail.com/T/