### PR TITLE
Allow systemd-journald to read systemd unit symlinks

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -2790,6 +2790,24 @@ interface(`init_read_pid_pipes',`
 	read_fifo_files_pattern($1, init_var_run_t, init_var_run_t)
 ')
 
+######################################
+## <summary>
+##	read systemd unit symlinks (usually under /run/systemd/units/)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_read_runtime_symlinks',`
+	gen_require(`
+		type init_var_run_t;
+	')
+
+	read_lnk_files_pattern($1, init_var_run_t, init_var_run_t)
+')
+
 ########################################
 ## <summary>
 ##	Allow the specified domain to connect to daemon with a tcp socket

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -551,6 +551,7 @@ ifdef(`init_systemd',`
 	init_delete_pid_files(syslogd_t)
 	init_dgram_send(syslogd_t)
 	init_read_pid_pipes(syslogd_t)
+	init_read_runtime_symlinks(syslogd_t)
 	init_read_state(syslogd_t)
 
 	systemd_manage_journal_files(syslogd_t)


### PR DESCRIPTION
    type=AVC msg=audit(1546723651.696:2091): avc:  denied  { read } for
    pid=240 comm="systemd-journal" name="invocation:user@1000.service"
    dev="tmpfs" ino=17614 scontext=system_u:system_r:syslogd_t
    tcontext=system_u:object_r:init_var_run_t tclass=lnk_file
    permissive=0
    type=AVC msg=audit(1546723651.799:2092): avc:  denied  { read } for
    pid=240 comm="systemd-journal" name="invocation:dbus.service"
    dev="tmpfs" ino=12542 scontext=system_u:system_r:syslogd_t
    tcontext=system_u:object_r:init_var_run_t tclass=lnk_file
    permissive=0

``ls -lZ`` on these files gives:

    lrwxrwxrwx. 1 root root system_u:object_r:init_var_run_t 32
        /run/systemd/units/invocation:user@1000.service -> a12344e990e641d9a43065b2d1e115a7
    lrwxrwxrwx. 1 root root system_u:object_r:init_var_run_t 32
        /run/systemd/units/invocation:dbus.service -> 70bd8da4e0c14bf8b7fcadcd71d22214

cf. https://lore.kernel.org/selinux-refpolicy/78e0708d-d6ae-454a-418d-3276a593b996@ieee.org/