### PR TITLE
Label service binaries in /usr/bin like /usr/sbin

### DIFF
--- a/policy/modules/services/cgmanager.fc
+++ b/policy/modules/services/cgmanager.fc
@@ -4,6 +4,9 @@
 /run/cgmanager.pid					gen_context(system_u:object_r:cgmanager_run_t,s0)
 /run/cgmanager/fs(/.*)?					<<none>>
 
+/usr/bin/cgmanager				--	gen_context(system_u:object_r:cgmanager_exec_t,s0)
+/usr/bin/cgproxy				--	gen_context(system_u:object_r:cgmanager_exec_t,s0)
+
 /usr/libexec/cgmanager/cgm-release-agent	--	gen_context(system_u:object_r:cgmanager_exec_t,s0)
 
 /usr/sbin/cgmanager				--	gen_context(system_u:object_r:cgmanager_exec_t,s0)

--- a/policy/modules/services/gssproxy.fc
+++ b/policy/modules/services/gssproxy.fc
@@ -1,3 +1,5 @@
+/usr/bin/gssproxy				--	gen_context(system_u:object_r:gssproxy_exec_t,s0)
+
 /usr/lib/systemd/system/gssproxy.service	--	gen_context(system_u:object_r:gssproxy_unit_t,s0)
 
 /usr/sbin/gssproxy				--	gen_context(system_u:object_r:gssproxy_exec_t,s0)


### PR DESCRIPTION
For some services, the program responsible for the service has a file context which is defined only when it is installed in `/usr/sbin`. This does not work on Arch Linux, where every program is in `/usr/bin` (`/usr/sbin` is a symlink to `/usr/bin`).

Add relevant file contexts for `/usr/bin/$PROG` when `/usr/sbin/$PROG` exists.