### PR TITLE
init: rename *_pid_* interfaces to use "runtime"

### DIFF
--- a/policy/modules/admin/logrotate.te
+++ b/policy/modules/admin/logrotate.te
@@ -188,7 +188,7 @@ optional_policy(`
 
 optional_policy(`
 	dbus_system_bus_client(logrotate_t)
-	init_write_pid_socket(logrotate_t)
+	init_write_runtime_socket(logrotate_t)
 ')
 
 optional_policy(`

--- a/policy/modules/apps/userhelper.te
+++ b/policy/modules/apps/userhelper.te
@@ -149,7 +149,7 @@ auth_search_pam_console_data(userhelper_type)
 
 init_use_fds(userhelper_type)
 init_manage_utmp(userhelper_type)
-init_pid_filetrans_utmp(userhelper_type)
+init_runtime_filetrans_utmp(userhelper_type)
 
 logging_send_syslog_msg(userhelper_type)
 

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -2691,6 +2691,22 @@ interface(`init_relabel_utmp',`
 ## </param>
 #
 interface(`init_pid_filetrans_utmp',`
+	refpolicywarn(`$0($*) has been deprecated, please use init_runtime_filetrans_utmp() instead.')
+	init_runtime_filetrans_utmp($1)
+')
+
+########################################
+## <summary>
+##	Create files in /var/run with the
+##	utmp file type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_runtime_filetrans_utmp',`
 	gen_require(`
 		type initrc_var_run_t;
 	')
@@ -2709,6 +2725,21 @@ interface(`init_pid_filetrans_utmp',`
 ## </param>
 #
 interface(`init_create_pid_dirs',`
+	refpolicywarn(`$0($*) has been deprecated, please use init_create_runtime_dirs() instead.')
+	init_create_runtime_dirs($1)
+')
+
+#######################################
+## <summary>
+##	Create a directory in the /run/systemd directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_create_runtime_dirs',`
 	gen_require(`
 		type init_var_run_t;
 	')
@@ -2728,6 +2759,21 @@ interface(`init_create_pid_dirs',`
 ## </param>
 #
 interface(`init_rename_pid_files',`
+	refpolicywarn(`$0($*) has been deprecated, please use init_rename_runtime_files() instead.')
+	init_rename_runtime_files($1)
+')
+
+########################################
+## <summary>
+##      Rename init_var_run_t files
+## </summary>
+## <param name="domain">
+##      <summary>
+##      domain
+##      </summary>
+## </param>
+#
+interface(`init_rename_runtime_files',`
 	gen_require(`
 		type init_var_run_t;
 	')
@@ -2737,7 +2783,7 @@ interface(`init_rename_pid_files',`
 
 ########################################
 ## <summary>
-##      Rename and de init_var_run_t files
+##      Delete init_var_run_t files
 ## </summary>
 ## <param name="domain">
 ##      <summary>
@@ -2746,6 +2792,21 @@ interface(`init_rename_pid_files',`
 ## </param>
 #
 interface(`init_delete_pid_files',`
+	refpolicywarn(`$0($*) has been deprecated, please use init_delete_runtime_files() instead.')
+	init_delete_runtime_files($1)
+')
+
+########################################
+## <summary>
+##      Delete init_var_run_t files
+## </summary>
+## <param name="domain">
+##      <summary>
+##      domain
+##      </summary>
+## </param>
+#
+interface(`init_delete_runtime_files',`
 	gen_require(`
 		type init_var_run_t;
 	')
@@ -2765,6 +2826,22 @@ interface(`init_delete_pid_files',`
 ## </param>
 #
 interface(`init_write_pid_socket',`
+	refpolicywarn(`$0($*) has been deprecated, please use init_write_runtime_socket() instead.')
+	init_write_runtime_socket($1)
+')
+
+#######################################
+## <summary>
+##  Allow the specified domain to write to
+##  init sock file.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`init_write_runtime_socket',`
 	gen_require(`
 		type init_var_run_t;
 	')
@@ -2783,6 +2860,21 @@ interface(`init_write_pid_socket',`
 ## </param>
 #
 interface(`init_read_pid_pipes',`
+	refpolicywarn(`$0($*) has been deprecated, please use init_read_runtime_pipes() instead.')
+	init_read_runtime_pipes($1)
+')
+
+########################################
+## <summary>
+##	Read init unnamed pipes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_read_runtime_pipes',`
 	gen_require(`
 		type init_var_run_t;
 	')

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1372,7 +1372,7 @@ ifdef(`init_systemd',`
 	fs_search_cgroup_dirs(daemon)
 
 	# need write to /var/run/systemd/notify
-	init_write_pid_socket(daemon)
+	init_write_runtime_socket(daemon)
 ')
 
 tunable_policy(`init_daemons_use_tty',`

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -544,13 +544,13 @@ ifdef(`init_systemd',`
 	domain_getattr_all_domains(syslogd_t)
 	domain_read_all_domains_state(syslogd_t)
 
-	init_create_pid_dirs(syslogd_t)
+	init_create_runtime_dirs(syslogd_t)
 	init_daemon_pid_file(syslogd_var_run_t, dir, "syslogd")
 	init_getattr(syslogd_t)
-	init_rename_pid_files(syslogd_t)
-	init_delete_pid_files(syslogd_t)
+	init_rename_runtime_files(syslogd_t)
+	init_delete_runtime_files(syslogd_t)
 	init_dgram_send(syslogd_t)
-	init_read_pid_pipes(syslogd_t)
+	init_read_runtime_pipes(syslogd_t)
 	init_read_runtime_symlinks(syslogd_t)
 	init_read_state(syslogd_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -305,7 +305,7 @@ selinux_getattr_fs(systemd_coredump_t)
 init_list_var_lib_dirs(systemd_coredump_t)
 init_read_state(systemd_coredump_t)
 init_search_pids(systemd_coredump_t)
-init_write_pid_socket(systemd_coredump_t)
+init_write_runtime_socket(systemd_coredump_t)
 
 logging_send_syslog_msg(systemd_coredump_t)
 
@@ -752,7 +752,7 @@ init_getrlimit(systemd_nspawn_t)
 init_kill_scripts(systemd_nspawn_t)
 init_read_state(systemd_nspawn_t)
 init_search_run(systemd_nspawn_t)
-init_write_pid_socket(systemd_nspawn_t)
+init_write_runtime_socket(systemd_nspawn_t)
 init_spec_domtrans_script(systemd_nspawn_t)
 
 miscfiles_manage_localization(systemd_nspawn_t)
@@ -847,8 +847,8 @@ term_read_console(systemd_passwd_agent_t)
 
 auth_use_nsswitch(systemd_passwd_agent_t)
 
-init_create_pid_dirs(systemd_passwd_agent_t)
-init_read_pid_pipes(systemd_passwd_agent_t)
+init_create_runtime_dirs(systemd_passwd_agent_t)
+init_read_runtime_pipes(systemd_passwd_agent_t)
 init_read_state(systemd_passwd_agent_t)
 init_read_utmp(systemd_passwd_agent_t)
 init_stream_connect(systemd_passwd_agent_t)


### PR DESCRIPTION
The name of these interfaces is clearer that way.

This comes from a suggestion from https://lore.kernel.org/selinux-refpolicy/dedf3ce8-4e9f-2313-6799-bbc9dc3a8124@ieee.org/