### PR TITLE
selinuxutil: allow restorecond to read symlinks

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -372,6 +372,7 @@ selinux_compute_user_contexts(restorecond_t)
 
 files_relabel_non_auth_files(restorecond_t )
 files_read_non_auth_files(restorecond_t)
+files_read_non_auth_symlinks(restorecond_t)
 auth_use_nsswitch(restorecond_t)
 
 logging_send_syslog_msg(restorecond_t)


### PR DESCRIPTION
As restorecond dereferences symlinks when it encounters them in user home directories, allow this access.