### PR TITLE
selinuxutil: restorecond is buggy when it dereferencies symlinks

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -372,7 +372,7 @@ selinux_compute_user_contexts(restorecond_t)
 
 files_relabel_non_auth_files(restorecond_t )
 files_read_non_auth_files(restorecond_t)
-files_read_non_auth_symlinks(restorecond_t)
+files_dontaudit_read_all_symlinks(restorecond_t)
 auth_use_nsswitch(restorecond_t)
 
 logging_send_syslog_msg(restorecond_t)


### PR DESCRIPTION
restorecond uses libselinux's selinux_restorecon() to relabel files, which dereferences symlinks in a useless call to statfs(). This produces AVC denials which are noisy.

Fixes: https://github.com/SELinuxProject/refpolicy/pull/22