### PR TITLE
dbus: allow using dynamic UID

### DIFF
--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -158,6 +158,10 @@ ifdef(`init_systemd', `
 	# gdm3 causes system_dbusd_t to want this access
 	dev_rw_dri(system_dbusd_t)
 	dev_rw_input_dev(system_dbusd_t)
+
+	# for /run/systemd/dynamic-uid/
+	init_list_pids(system_dbusd_t)
+	init_read_runtime_symlinks(system_dbusd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
When using a systemd service with dynamic UID, dbus-daemon reads symlinks in `/run/systemd/dynamic-uid/`:

    type=SYSCALL msg=audit(1547313774.993:373): arch=c000003e
    syscall=257 success=yes exit=12 a0=ffffff9c a1=7f7ccdc6ec72 a2=90800
    a3=0 items=0 ppid=1 pid=282 auid=4294967295 uid=81 gid=81 euid=81
    suid=81 fsuid=81 egid=81 sgid=81 fsgid=81 tty=(none) ses=4294967295
    comm="dbus-daemon" exe="/usr/bin/dbus-daemon"
    subj=system_u:system_r:system_dbusd_t key=(null)

    type=AVC msg=audit(1547313774.993:373): avc:  denied  { read } for
    pid=282 comm="dbus-daemon" name="dynamic-uid" dev="tmpfs" ino=12688
    scontext=system_u:system_r:system_dbusd_t
    tcontext=system_u:object_r:init_var_run_t tclass=dir permissive=1

    type=SYSCALL msg=audit(1547313774.993:374): arch=c000003e
    syscall=267 success=yes exit=7 a0=ffffff9c a1=7ffe25cf0800
    a2=558ac0043b00 a3=1000 items=0 ppid=1 pid=282 auid=4294967295
    uid=81 gid=81 euid=81 suid=81 fsuid=81 egid=81 sgid=81 fsgid=81
    tty=(none) ses=4294967295 comm="dbus-daemon"
    exe="/usr/bin/dbus-daemon" subj=system_u:system_r:system_dbusd_t
    key=(null)

    type=AVC msg=audit(1547313774.993:374): avc:  denied  { read } for
    pid=282 comm="dbus-daemon" name="direct:65306" dev="tmpfs" ino=12690
    scontext=system_u:system_r:system_dbusd_t
    tcontext=system_u:object_r:init_var_run_t tclass=lnk_file
    permissive=1

This directory looks like this, on Arch Linux with systemd 240:

    # ls -alZ /run/systemd/dynamic-uid
    drwxr-xr-x.  2 root root system_u:object_r:init_var_run_t 100 2019-01-12 15:53 ./
    drwxr-xr-x. 17 root root system_u:object_r:init_var_run_t 420 2019-01-12 15:53 ../
    -rw-------.  1 root root system_u:object_r:init_var_run_t   8 2019-01-12 15:53 65306
    lrwxrwxrwx.  1 root root system_u:object_r:init_var_run_t   7 2019-01-12 15:53 direct:65306 -> haveged
    lrwxrwxrwx.  1 root root system_u:object_r:init_var_run_t   5 2019-01-12 15:53 direct:haveged -> 65306