### PR TITLE
sysnet_dns_name_resolve interface update for musl libc.

### DIFF
--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -745,6 +745,7 @@ interface(`sysnet_dns_name_resolve',`
 	corenet_udp_sendrecv_dns_port($1)
 	corenet_tcp_connect_dns_port($1)
 	corenet_sendrecv_dns_client_packets($1)
+	corenet_udp_bind_generic_node($1)
 
 	sysnet_read_config($1)
 


### PR DESCRIPTION
Add corenet_udp_bind_generic_node for sysnet_dns_name_resolve interface because with musl libc it required for address resolution.