### PR TITLE
sysadm: allow resolving dynamic users

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -71,6 +71,12 @@ ifndef(`enable_mls',`
 	logging_run_auditctl(sysadm_t, sysadm_r)
 ')
 
+ifdef(`init_systemd',`
+	# Allow sysadm to resolve the username of dynamic users by calling
+	# LookupDynamicUserByUID on org.freedesktop.systemd1.
+	init_dbus_chat(sysadm_t)
+')
+
 tunable_policy(`allow_ptrace',`
 	domain_ptrace_all_domains(sysadm_t)
 ')


### PR DESCRIPTION
On a virtual machine using haveged daemon, running ``ps`` from a ``sysadm_t`` user leads to the following output:

    $ ps -eH -o label,user,pid,cmd
    ...
    system_u:system_r:init_t        root         1 /sbin/init
    system_u:system_r:syslogd_t     root       223   /usr/lib/systemd/systemd-journald
    system_u:system_r:lvm_t         root       234   /usr/bin/lvmetad -f
    system_u:system_r:udev_t        root       236   /usr/lib/systemd/systemd-udevd
    system_u:system_r:entropyd_t    65306      266   /usr/bin/haveged --Foreground --verbose=1

User 65306 is a dynamic user attributed by systemd:

    $ cat /var/run/systemd/dynamic-uid/65306
    haveged

Running ``ps`` leads to the following log:

    type=USER_AVC msg=audit(1549830356.959:1056): pid=278 uid=81
    auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t
    msg='avc:  denied  { send_msg } for msgtype=method_call
    interface=org.freedesktop.systemd1.Manager
    member=LookupDynamicUserByUID dest=org.freedesktop.systemd1
    spid=12038 tpid=1 scontext=sysadm_u:sysadm_r:sysadm_t
    tcontext=system_u:system_r:init_t tclass=dbus permissive=0
    exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'

Allow ``sysadm_t`` to resolve dynamic users when systemd is used.

After this, ``ps`` works fine:

    system_u:system_r:entropyd_t    haveged    266   /usr/bin/haveged --Foreground --verbose=1