### PR TITLE
Add policy for stubby DNS resolver

### DIFF
--- a/policy/modules/kernel/corenetwork.te.in
+++ b/policy/modules/kernel/corenetwork.te.in
@@ -121,7 +121,7 @@ network_port(dhcpc, udp,68,s0, tcp,68,s0, udp,546,s0, tcp, 546,s0, udp,5546,s0, 
 network_port(dhcpd, udp,67,s0, udp,547,s0, tcp, 547,s0, udp,548,s0, tcp, 548,s0, tcp,647,s0, udp,647,s0, tcp,847,s0, udp,847,s0, tcp,7911,s0)
 network_port(dict, tcp,2628,s0)
 network_port(distccd, tcp,3632,s0)
-network_port(dns, tcp,53,s0, udp,53,s0)
+network_port(dns, tcp,53,s0, udp,53,s0, tcp,853,s0)
 network_port(dropbox, tcp,17500,s0, udp,17500,s0)
 network_port(efs, tcp,520,s0)
 network_port(embrace_dp_c, tcp,3198,s0, udp,3198,s0)

--- a/policy/modules/services/stubby.fc
+++ b/policy/modules/services/stubby.fc
@@ -1,0 +1,5 @@
+/etc/stubby(/.*)?				--	gen_context(system_u:object_r:stubby_etc_t,s0)
+
+/usr/bin/stubby					--	gen_context(system_u:object_r:stubby_exec_t,s0)
+
+/usr/lib/systemd/system/stubby.*\.service	--	gen_context(system_u:object_r:stubby_unit_t,s0)

--- a/policy/modules/services/stubby.if
+++ b/policy/modules/services/stubby.if
@@ -1,0 +1,1 @@
+## <summary>DNS Privacy stub resolver.</summary>

--- a/policy/modules/services/stubby.te
+++ b/policy/modules/services/stubby.te
@@ -1,0 +1,51 @@
+policy_module(stubby, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type stubby_t;
+type stubby_exec_t;
+init_daemon_domain(stubby_t, stubby_exec_t)
+
+type stubby_etc_t;
+files_config_file(stubby_etc_t)
+
+type stubby_unit_t;
+init_unit_file(stubby_unit_t)
+
+########################################
+#
+# Local policy
+#
+
+allow stubby_t self:tcp_socket create_stream_socket_perms;
+allow stubby_t self:udp_socket create_stream_socket_perms;
+
+read_files_pattern(stubby_t, stubby_etc_t, stubby_etc_t)
+
+corenet_tcp_bind_dns_port(stubby_t)
+corenet_tcp_bind_generic_node(stubby_t)
+corenet_udp_bind_dns_port(stubby_t)
+corenet_udp_bind_generic_node(stubby_t)
+
+# DNS-over-TLS uses TCP port 853
+corenet_tcp_connect_dns_port(stubby_t)
+# DNS-over-HTTPS uses TCP port 443
+corenet_tcp_connect_http_port(stubby_t)
+
+# for /etc/trusted-key.key
+files_read_etc_files(stubby_t)
+
+miscfiles_read_generic_certs(stubby_t)
+miscfiles_read_localization(stubby_t)
+
+sysnet_read_config(stubby_t)
+
+ifdef(`init_systemd',`
+	# stubby systemd service uses DynamicUser=yes, which makes it call
+	# LookupDynamicUserByUID in order to get its own user name.
+	init_dbus_chat(stubby_t)
+	dbus_system_bus_client(stubby_t)
+')


### PR DESCRIPTION
Stubby is a DNS resolver that encrypts DNS queries and transmits them to
a resolver in a TLS channel. It therefore requires less permissions than
a traditionnal DNS resolver such as named or unbound (provided by module
"bind").

DNS-over-TLS uses TCP port 853, which does not seem to conflict with
existing ports.

cf. https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby

This program is packaged for Arch Linux, Debian, etc.