### PR TITLE
Allow systemd-journald to use kill(pid, 0) on every process

### DIFF
--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -638,6 +638,11 @@ interface(`logging_send_syslog_msg',`
 	# will write to the console.
 	term_write_console($1)
 	term_dontaudit_read_console($1)
+
+	ifdef(`init_systemd',`
+		# Allow systemd-journald to check whether the process died
+		allow syslogd_t $1:process signull;
+	')
 ')
 
 ########################################


### PR DESCRIPTION
Since systemd 241, systemd-journald is using `kill(pid, 0)` in order to find dead processes and reduce its cache. The relevant commit is https://github.com/systemd/systemd/commit/91714a7f427a6c9c5c3be8b3819fee45050028f3 ("journald: periodically drop cache for all dead PIDs"). This commit added a call to `pid_is_unwaited(c->pid)`, which is a function implemented in https://github.com/systemd/systemd/blob/v241/src/basic/process-util.c#L936 :
```c
    bool pid_is_unwaited(pid_t pid) {
        /* Checks whether a PID is still valid at all, including a zombie */
        if (pid < 0)
                return false;
        if (pid <= 1) /* If we or PID 1 would be dead and have been waited for, this code would not be running */
                return true;
        if (pid == getpid_cached())
                return true;
        if (kill(pid, 0) >= 0)
                return true;
        return errno != ESRCH;
    }
```
This new code triggers the following AVC denials:

    type=AVC msg=audit(1550911933.606:332): avc:  denied  { signull }
    for  pid=224 comm="systemd-journal"
    scontext=system_u:system_r:syslogd_t
    tcontext=system_u:system_r:auditd_t tclass=process permissive=1

    type=AVC msg=audit(1550911933.606:333): avc:  denied  { signull }
    for  pid=224 comm="systemd-journal"
    scontext=system_u:system_r:syslogd_t
    tcontext=system_u:system_r:dhcpc_t tclass=process permissive=1

    type=AVC msg=audit(1550911933.606:334): avc:  denied  { signull }
    for  pid=224 comm="systemd-journal"
    scontext=system_u:system_r:syslogd_t
    tcontext=system_u:system_r:sshd_t tclass=process permissive=1