### PR TITLE
Remove a broad read-files rule for restorecond

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -371,7 +371,6 @@ selinux_compute_relabel_context(restorecond_t)
 selinux_compute_user_contexts(restorecond_t)
 
 files_relabel_non_auth_files(restorecond_t )
-files_read_non_auth_files(restorecond_t)
 files_dontaudit_read_all_symlinks(restorecond_t)
 auth_use_nsswitch(restorecond_t)
 

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -380,6 +380,7 @@ logging_send_syslog_msg(restorecond_t)
 miscfiles_read_localization(restorecond_t)
 
 seutil_libselinux_linked(restorecond_t)
+seutil_read_default_contexts(restorecond_t)
 
 ifdef(`distro_ubuntu',`
 	optional_policy(`


### PR DESCRIPTION
When the policy for restorecond was introduced, it contained a rule which allowed restorecond to read every file except `shadow_t` (cf. https://github.com/SELinuxProject/refpolicy/commit/724925579d2933ab642e0104b2fa7aaded9a7ceb#diff-301316a33cafb23299e43112dc2bf2deR439):

    auth_read_all_files_except_shadow(restorecond_t)

Since 2006, the policy changed quite a bit, but this access remained. However restorecond does not need to read every available file.

This is related to this comment: https://github.com/SELinuxProject/refpolicy/pull/22#issuecomment-454976379