### PR TITLE
Update systemd-update-done policy

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -1,3 +1,5 @@
+/etc/\.updated				--	gen_context(system_u:object_r:systemd_update_run_t,s0)
+
 /etc/udev/hwdb\.bin			--	gen_context(system_u:object_r:systemd_hwdb_t,s0)
 
 /run/log/journal(/.*)?				gen_context(system_u:object_r:systemd_journal_t,s0)
@@ -45,6 +47,8 @@
 /usr/lib/systemd/system/systemd-binfmt.*	--	gen_context(system_u:object_r:systemd_binfmt_unit_t,s0)
 /usr/lib/systemd/system/systemd-networkd.*		gen_context(system_u:object_r:systemd_networkd_unit_t,s0)
 /usr/lib/systemd/system/systemd-rfkill.*	--	gen_context(system_u:object_r:systemd_rfkill_unit_t,s0)
+
+/var/\.updated				--	gen_context(system_u:object_r:systemd_update_run_t,s0)
 
 /var/lib/systemd/backlight(/.*)?	gen_context(system_u:object_r:systemd_backlight_var_lib_t,s0)
 /var/lib/systemd/coredump(/.*)?	gen_context(system_u:object_r:systemd_coredump_var_lib_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1126,12 +1126,13 @@ optional_policy(`
 # Update Done local policy
 #
 
-allow systemd_update_done_t systemd_update_run_t:file manage_file_perms;
+allow systemd_update_done_t self:process setfscreate;
 
-dev_write_kmsg(systemd_update_done_t)
+allow systemd_update_done_t systemd_update_run_t:file manage_file_perms;
 
 files_etc_filetrans(systemd_update_done_t, systemd_update_run_t, file, ".updated")
 files_var_filetrans(systemd_update_done_t, systemd_update_run_t, file, ".updated")
 
-kernel_read_system_state(systemd_update_done_t)
+seutil_read_file_contexts(systemd_update_done_t)
 
+systemd_log_parse_environment(systemd_update_done_t)


### PR DESCRIPTION
systemd-update-done sends logs to journald like other services, as shown by the following AVC:

    type=AVC msg=audit(1550865504.453:76): avc:  denied  { sendto } for
    pid=277 comm="systemd-update-" path="/run/systemd/journal/socket"
    scontext=system_u:system_r:systemd_update_done_t
    tcontext=system_u:system_r:syslogd_t tclass=unix_dgram_socket
    permissive=1

    type=AVC msg=audit(1550865504.453:76): avc:  denied  { write } for
    pid=277 comm="systemd-update-" name="socket" dev="tmpfs" ino=10729
    scontext=system_u:system_r:systemd_update_done_t
    tcontext=system_u:object_r:devlog_t tclass=sock_file permissive=1

    type=AVC msg=audit(1550865504.453:76): avc:  denied  { connect } for
    pid=277 comm="systemd-update-"
    scontext=system_u:system_r:systemd_update_done_t
    tcontext=system_u:system_r:systemd_update_done_t
    tclass=unix_dgram_socket permissive=1

Moreover it creates `/etc/.updated` and `/var/.updated` using temporary files:

    type=AVC msg=audit(1550865504.463:83): avc:  denied  { setfscreate }
    for  pid=277 comm="systemd-update-"
    scontext=system_u:system_r:systemd_update_done_t
    tcontext=system_u:system_r:systemd_update_done_t tclass=process
    permissive=1

    type=AVC msg=audit(1550865504.463:84): avc:  denied  { read write
    open } for  pid=277 comm="systemd-update-"
    path="/etc/.#.updatedTz6oE9" dev="vda1" ino=806171
    scontext=system_u:system_r:systemd_update_done_t
    tcontext=system_u:object_r:etc_t tclass=file permissive=1

    type=AVC msg=audit(1550865504.463:84): avc:  denied  { create } for
    pid=277 comm="systemd-update-" name=".#.updatedTz6oE9"
    scontext=system_u:system_r:systemd_update_done_t
    tcontext=system_u:object_r:etc_t tclass=file permissive=1

    [...]

    type=AVC msg=audit(1550865504.463:87): avc:  denied  { unlink } for
    pid=277 comm="systemd-update-" name=".updated" dev="vda1" ino=793017
    scontext=system_u:system_r:systemd_update_done_t
    tcontext=system_u:object_r:etc_t tclass=file permissive=1

    type=AVC msg=audit(1550865504.463:87): avc:  denied  { rename } for
    pid=277 comm="systemd-update-" name=".#.updatedTz6oE9" dev="vda1"
    ino=806171 scontext=system_u:system_r:systemd_update_done_t
    tcontext=system_u:object_r:etc_t tclass=file permissive=1