### PR TITLE
genhomedircon.py: Fix top-level exception handling.

### DIFF
--- a/support/genhomedircon.py
+++ b/support/genhomedircon.py
@@ -486,9 +486,5 @@ try:
 	selconf=selinuxConfig(directory, setype, usepwd)
 	selconf.write()
 
-except getopt.error as error:
-	errorExit("Options Error " + error)
-except ValueError as error:
-	errorExit("ValueError " + error)
-except IndexError:
-	errorExit("IndexError")
+except Exception as error:
+	errorExit(error)


### PR DESCRIPTION
Fixes errors like this:
```
Traceback (most recent call last):
  File "support/genhomedircon.py", line 490, in <module>
    errorExit("Options Error " + error)
TypeError: Can't convert 'GetoptError' object to str implicitly
```