### PR TITLE
Misc system fixes.

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -84,7 +84,7 @@ genfscon proc /fs/openafs gen_context(system_u:object_r:proc_afs_t,s0)
 # kernel message interface
 type proc_kmsg_t, proc_type;
 genfscon proc /kmsg gen_context(system_u:object_r:proc_kmsg_t,mls_systemhigh)
-neverallow ~{ can_receive_kernel_messages kern_unconfined } proc_kmsg_t:file ~getattr;
+neverallow ~{ can_receive_kernel_messages kern_unconfined } proc_kmsg_t:file read;
 
 # /proc kcore: inaccessible
 type proc_kcore_t, proc_type;

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -987,8 +987,6 @@ ifdef(`init_systemd',`
 	# for logsave in strict configuration
 	fstools_write_log(initrc_t)
 
-	selinux_set_enforce_mode(initrc_t)
-
 	init_get_all_units_status(initrc_t)
 	init_manage_var_lib_files(initrc_t)
 	init_rw_stream_sockets(initrc_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -745,7 +745,6 @@ kernel_mounton_sysctl_dirs(systemd_nspawn_t)
 kernel_read_kernel_sysctls(systemd_nspawn_t)
 kernel_read_system_state(systemd_nspawn_t)
 kernel_remount_proc(systemd_nspawn_t)
-kernel_unconfined(systemd_nspawn_t)
 
 corecmd_exec_shell(systemd_nspawn_t)
 corecmd_search_bin(systemd_nspawn_t)

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -66,7 +66,6 @@ allow udev_t self:rawip_socket create_socket_perms;
 # for systemd-udevd to rename interfaces
 allow udev_t self:netlink_route_socket nlmsg_write;
 
-allow udev_t udev_exec_t:file write;
 can_exec(udev_t, udev_exec_t)
 
 allow udev_t udev_helper_exec_t:dir list_dir_perms;


### PR DESCRIPTION
Remove use of kernel_unconfined() by systemd_nspawn and udev write to its own executable.