### PR TITLE
logging: Reduce the scope of systemd-journald accesses

### DIFF
--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -640,8 +640,11 @@ interface(`logging_send_syslog_msg',`
 	term_dontaudit_read_console($1)
 
 	ifdef(`init_systemd',`
-		# Allow systemd-journald to check whether the process died
-		allow syslogd_t $1:process signull;
+		# Allow systemd-journald to read the state of its clients and to check whether they died
+		allow syslogd_t $1:process {getattr signull};
+		allow syslogd_t $1:dir search_dir_perms;
+		allow syslogd_t $1:file read_file_perms;
+		allow syslogd_t $1:lnk_file read_lnk_file_perms;
 	')
 ')
 

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -485,8 +485,6 @@ dev_read_urand(syslogd_t)
 dev_rw_kmsg(syslogd_t)
 
 domain_use_interactive_fds(syslogd_t)
-# Allow access to /proc/ information for journald
-domain_read_all_domains_state(syslogd_t)
 
 files_read_etc_files(syslogd_t)
 files_read_usr_files(syslogd_t)
@@ -540,9 +538,6 @@ ifdef(`init_systemd',`
 	dev_read_kmsg(syslogd_t)
 	dev_read_urand(syslogd_t)
 	dev_write_kmsg(syslogd_t)
-
-	domain_getattr_all_domains(syslogd_t)
-	domain_read_all_domains_state(syslogd_t)
 
 	init_create_runtime_dirs(syslogd_t)
 	init_daemon_pid_file(syslogd_var_run_t, dir, "syslogd")


### PR DESCRIPTION
`systemd-journald` only requests the states of processes that are sending messages to logs. Make the policy more restrictive in this regard.