### PR TITLE
init: Revise conditions in init_startstop_service().

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1728,28 +1728,29 @@ interface(`init_startstop_service',`
 		role system_r;
 	')
 
-	ifndef(`direct_sysadm_daemon',`
-		ifdef(`distro_gentoo',`
-			# for OpenRC
-			seutil_labeled_init_script_run_runinit($1, $2, $4)
-		',`
-			# rules for sysvinit / upstart
-			init_labeled_script_domtrans($1, $4)
-			domain_system_change_exemption($1)
-			role_transition $2 $4 system_r;
-			allow $2 system_r;
-		')
+	# sysvinit/upstart systems will need to use run_init
+	# if not using direct_sysadm_daemon.
+	ifdef(`direct_sysadm_daemon',`
+		init_labeled_script_domtrans($1, $4)
+		domain_system_change_exemption($1)
+		role_transition $2 $4 system_r;
+		allow $2 system_r;
+	')
 
-		ifdef(`init_systemd',`
-			# This ifelse condition is temporary, until
-			# all callers are updated to provide unit files.
-			ifelse(`$5',`',`',`
-				gen_require(`
-					class service { start status stop };
-				')
+	ifdef(`distro_gentoo',`
+		# for OpenRC
+		seutil_labeled_init_script_run_runinit($1, $2, $4)
+	')
 
-				allow $1 $5:service { start status stop };
+	ifdef(`init_systemd',`
+		# This ifelse condition is temporary, until
+		# all callers are updated to provide unit files.
+		ifelse(`$5',`',`',`
+			gen_require(`
+				class service { start status stop };
 			')
+
+			allow $1 $5:service { start status stop };
 		')
 	')
 ')


### PR DESCRIPTION
The role transition for directly executing an init script should only
happen if direct_sysadm_daemon is enabled and only on non-systemd
systems.

@perfinion 
@bigon 
@fishilico 
@bachradsusi