### PR TITLE
Qt library version 5 requires unprivileged users to write xserver_tmp_t

### DIFF
--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -148,6 +148,9 @@ interface(`xserver_role',`
 	allow $2 xserver_t:shm rw_shm_perms;
 	allow $2 xserver_tmpfs_t:file rw_file_perms;
 
+	# XCB Event Queue: used by the Qt library for example
+	allow $2 xserver_tmp_t:file rw_file_perms;
+
 	allow $2 iceauth_home_t:file manage_file_perms;
 	allow $2 iceauth_home_t:file { relabelfrom relabelto };
 


### PR DESCRIPTION
The Qt library version 5 requires to write xserver_tmp_t files upon starting up applications (tested on version 5.12.1).
---
 policy/modules/services/xserver.if |    1 +
 1 file changed, 1 insertion(+)