### PR TITLE
Resolve issues with plymouth in enforcing

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -1941,6 +1941,24 @@ interface(`dev_setattr_dri_dev',`
 
 ########################################
 ## <summary>
+##	IOCTL the dri devices.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_ioctl_dri_dev',`
+	gen_require(`
+		type device_t, dri_device_t;
+	')
+
+	allow $1 dri_device_t:chr_file ioctl;
+')
+
+########################################
+## <summary>
 ##	Read and write the dri devices.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -397,9 +397,12 @@ optional_policy(`
 ')
 
 optional_policy(`
-	plymouthd_read_lib_files(kernel_t)
+	dev_ioctl_dri_dev(kernel_t)
+
+	plymouthd_delete_pid_files(kernel_t)
 	plymouthd_read_pid_files(kernel_t)
 	plymouthd_read_spool_files(kernel_t)
+	plymouthd_rw_lib_files(kernel_t)
 
 	term_use_ptmx(kernel_t)
 	term_use_unallocated_ttys(kernel_t)

--- a/policy/modules/services/plymouthd.if
+++ b/policy/modules/services/plymouthd.if
@@ -194,6 +194,25 @@ interface(`plymouthd_read_lib_files',`
 
 ########################################
 ## <summary>
+##	Read and write plymouthd lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`plymouthd_rw_lib_files',`
+	gen_require(`
+		type plymouthd_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	rw_files_pattern($1, plymouthd_var_lib_t, plymouthd_var_lib_t)
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete
 ##	plymouthd lib files.
 ## </summary>
@@ -230,6 +249,25 @@ interface(`plymouthd_read_pid_files',`
 	files_search_pids($1)
 	allow $1 plymouthd_var_run_t:dir search_dir_perms; 
 	allow $1 plymouthd_var_run_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Delete the plymouthd pid files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`plymouthd_delete_pid_files',`
+	gen_require(`
+		type plymouthd_var_run_t;
+	')
+
+	files_search_pids($1)
+	delete_files_pattern($1, plymouthd_var_run_t, plymouthd_var_run_t)
 ')
 
 ########################################

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -616,6 +616,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	plymouthd_domtrans_plymouth(xdm_t)
+')
+
+optional_policy(`
 	resmgr_stream_connect(xdm_t)
 ')
 


### PR DESCRIPTION
I made some changes to the policy to get plymouth working in enforcing.  I have noticed that since plymouthd is started very early during boot it is running as kernel_t.  Some of the permissions are for kernel_t even though they are for the plymouthd process.

This is rebased on top of recent changes.