### PR TITLE
Allow logrotate to execute fail2ban-client

### DIFF
--- a/policy/modules/admin/logrotate.te
+++ b/policy/modules/admin/logrotate.te
@@ -193,6 +193,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	fail2ban_domtrans_client(logrotate_t)
 	fail2ban_stream_connect(logrotate_t)
 ')
 


### PR DESCRIPTION
fail2ban logrotate configuration runs "fail2ban-client flushlogs" after
rotating the logs