### PR TITLE
Fix find commands in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,9 +259,9 @@ user_default_contexts_names := $(addprefix $(contextpath)/users/,$(subst _defaul
 appfiles := $(addprefix $(appdir)/,default_contexts default_type initrc_context failsafe_context userhelper_context removable_context dbus_contexts sepgsql_contexts x_contexts customizable_types securetty_types lxc_contexts openrc_contexts virtual_domain_context virtual_image_context) $(contextpath)/files/media $(fcsubspath) $(user_default_contexts_names)
 net_contexts := $(builddir)net_contexts
 
-all_layers := $(shell find $(wildcard $(moddir)/*) -maxdepth 0 -type d)
+all_layers := $(shell find $(moddir)/* -maxdepth 0 -type d)
 ifdef LOCAL_ROOT
-all_layers += $(shell find $(wildcard $(local_moddir)/*) -maxdepth 0 -type d)
+all_layers += $(shell find $(local_moddir)/* -maxdepth 0 -type d)
 endif
 
 generated_te := $(basename $(foreach dir,$(all_layers),$(wildcard $(dir)/*.te.in)))

--- a/support/Makefile.devel
+++ b/support/Makefile.devel
@@ -88,11 +88,11 @@ M4PARAM += -D hide_broken_symptoms -D mls_num_sens=$(MLS_SENS) -D mls_num_cats=$
 # policy headers
 m4support = $(wildcard $(HEADERDIR)/support/*.spt)
 
-header_layers := $(filter-out $(HEADERDIR)/support,$(shell find $(wildcard $(HEADERDIR)/*) -maxdepth 0 -type d))
+header_layers := $(filter-out $(HEADERDIR)/support,$(shell find $(HEADERDIR)/* -maxdepth 0 -type d))
 header_xml := $(addsuffix .xml,$(header_layers))
 header_interfaces := $(foreach layer,$(header_layers),$(wildcard $(layer)/*.if))
 
-local_layers := $(filter-out CVS tmp $(docs),$(shell find $(wildcard *) -maxdepth 0 -type d))
+local_layers := $(filter-out CVS tmp $(docs),$(shell find * -maxdepth 0 -type d))
 local_xml := $(addprefix tmp/, $(addsuffix .xml,$(local_layers)))
 
 all_layer_names := $(sort $(notdir $(header_layers) $(local_layers)))


### PR DESCRIPTION
Without this fix, building a custom module in a directory that contains
a file with special characters in its name (e.g. '(') triggers a syntax
error:
```
$ cat >foo.te <<EOF
module foo 1.0;
require {
	class file entrypoint;
	type shell_exec_t;
	type vmtools_unconfined_t;
}
allow vmtools_unconfined_t shell_exec_t : file entrypoint;
EOF
$ touch "my broken (file)"
$ make -f /usr/share/selinux/devel/Makefile foo.pp
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `find anaconda-ks.cfg my broken (file) vncserver.strace systemd.strace rhel-server-7.6-x86_64-boot.iso rt_minimal.c vnc.cil foo.te rsyslog tmp virt-install.log evil_banner.sh livemedia.log program.log foo.if rhel7-minimal.ks TestZip.java TestZip.class foo.fc sudoloop foo.pp strace.log -maxdepth 0 -type d'
```
Link: https://bugzilla.redhat.com/show_bug.cgi?id=1692676
Reported-by: Renaud Métrich <rmetrich@redhat.com>
Suggested-by: Petr Lautrbach <plautrba@redhat.com>
Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>