### PR TITLE
Allow systemd_modules_load_t to module_request and map modules_object…

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -624,11 +624,13 @@ optional_policy(`
 #
 
 kernel_load_module(systemd_modules_load_t)
+kernel_request_load_module(systemd_modules_load_t)
 
 files_read_etc_files(systemd_modules_load_t)
 
 modutils_read_module_config(systemd_modules_load_t)
 modutils_read_module_deps(systemd_modules_load_t)
+modutils_read_module_objects(systemd_modules_load_t)
 
 systemd_log_parse_environment(systemd_modules_load_t)
 


### PR DESCRIPTION
…_t files

[   10.685610] audit: type=1400 audit(1563706740.429:3): avc:  denied  { map } for  pid=394 comm="systemd-modules" path="/usr/lib/modules/4.19.0-5-amd64/kernel/drivers/parport/parport.ko" dev="dm-0" ino=795927 scontext=system_u:system_r:systemd_modules_load_t:s0 tcontext=system_u:object_r:modules_object_t:s0 tclass=file permissive=1
[   10.695021] audit: type=1400 audit(1563706740.437:5): avc:  denied  { module_request } for  pid=394 comm="systemd-modules" kmod="parport_lowlevel" scontext=system_u:system_r:systemd_modules_load_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=1