### PR TITLE
entropyd: make haveged service work on Debian

### DIFF
--- a/policy/modules/services/entropyd.fc
+++ b/policy/modules/services/entropyd.fc
@@ -1,5 +1,7 @@
 /etc/rc\.d/init\.d/((audio-entropyd)|(haveged))	--	gen_context(system_u:object_r:entropyd_initrc_exec_t,s0)
 
+/usr/lib/systemd/system/haveged.*\.service	--	gen_context(system_u:object_r:entropyd_unit_t,s0)
+
 /usr/bin/audio-entropyd	--	gen_context(system_u:object_r:entropyd_exec_t,s0)
 /usr/bin/haveged	--	gen_context(system_u:object_r:entropyd_exec_t,s0)
 

--- a/policy/modules/services/entropyd.te
+++ b/policy/modules/services/entropyd.te
@@ -21,6 +21,9 @@ init_daemon_domain(entropyd_t, entropyd_exec_t)
 type entropyd_initrc_exec_t;
 init_script_file(entropyd_initrc_exec_t)
 
+type entropyd_unit_t;
+init_unit_file(entropyd_unit_t)
+
 type entropyd_var_run_t;
 files_pid_file(entropyd_var_run_t)
 
@@ -50,6 +53,7 @@ files_read_usr_files(entropyd_t)
 
 fs_getattr_all_fs(entropyd_t)
 fs_search_auto_mountpoints(entropyd_t)
+fs_search_tmpfs(entropyd_t)
 
 domain_use_interactive_fds(entropyd_t)
 


### PR DESCRIPTION
On Debian, haveged fails to start with "haveged: Couldn't open random device: Permission denied". strace shows:

    openat(AT_FDCWD, "/dev/random", O_RDWR) = -1 EACCES (Permission denied)

audit.log has:

    type=AVC msg=audit(1566048720.132:1338): avc:  denied  { search }
    for  pid=20235 comm="haveged" name="/" dev="tmpfs" ino=76666
    scontext=system_u:system_r:entropyd_t
    tcontext=system_u:object_r:tmpfs_t tclass=dir permissive=0

With systemd, /dev is a temporary filesystem (tmpfs_t), so haveged needs the search permission to it in order to open /dev/random.

While at it, add a file context of haveged's systemd unit file.