### PR TITLE
systemd: introduce a new attribute for services using PrivateDevices=yes

### DIFF
--- a/policy/modules/services/entropyd.te
+++ b/policy/modules/services/entropyd.te
@@ -64,6 +64,12 @@ miscfiles_read_localization(entropyd_t)
 userdom_dontaudit_use_unpriv_user_fds(entropyd_t)
 userdom_dontaudit_search_user_home_dirs(entropyd_t)
 
+ifdef(`init_systemd', `
+	optional_policy(`
+		systemd_PrivateDevices(entropyd_t)
+	')
+')
+
 tunable_policy(`entropyd_use_audio',`
 	dev_read_sound(entropyd_t)
 	dev_write_sound(entropyd_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -76,6 +76,24 @@ interface(`systemd_log_parse_environment',`
 	typeattribute $1 systemd_log_parse_env_type;
 ')
 
+######################################
+## <summary>
+##   Allow domain to be used as a systemd service with a unit
+##   that uses PrivateDevices=yes in section [Service].
+## </summary>
+## <param name="domain">
+##   <summary>
+##     Domain allowed access
+##   </summary>
+## </param>
+#
+interface(`systemd_PrivateDevices',`
+	# For services using PrivateDevices, systemd mounts a dedicated
+	# tmpfs filesystem for the /dev, which gets label tmpfs_t.
+	# Allow to traverse /dev and to read symlinks in /dev (for example /dev/log)
+	fs_read_tmpfs_symlinks($1)
+')
+
 #######################################
 ## <summary>
 ##  Allow domain to read udev hwdb file


### PR DESCRIPTION
When a service is configured with `PrivateDevices=yes`, its `/dev` directory has label `tmpfs_t`. This requires allowing more accesses in order for the service to use `/dev`.

This is related to https://github.com/SELinuxProject/refpolicy/pull/61