### PR TITLE
entropyd: allow haveged to create a Unix socket to received commands

### DIFF
--- a/policy/modules/services/entropyd.te
+++ b/policy/modules/services/entropyd.te
@@ -32,6 +32,7 @@ files_pid_file(entropyd_var_run_t)
 allow entropyd_t self:capability { dac_override ipc_lock sys_admin };
 dontaudit entropyd_t self:capability sys_tty_config;
 allow entropyd_t self:process signal_perms;
+allow entropyd_t self:unix_stream_socket create_stream_socket_perms;
 
 manage_files_pattern(entropyd_t, entropyd_var_run_t, entropyd_var_run_t)
 files_pid_filetrans(entropyd_t, entropyd_var_run_t, file)


### PR DESCRIPTION
haveged listens to commands using a Unix socket (at path `"\0/sys/entropy/haveged"` according to https://github.com/jirka-h/haveged/blob/1.9.4/src/havegecmd.h#L34).
The implementation of this server is available on https://github.com/jirka-h/haveged/blob/1.9.4/src/havegecmd.c .

This fixes the following denial:

    type=AVC msg=audit(1551002989.396:27): avc:  denied  { listen } for
    pid=262 comm="haveged"
    path=002F7379732F656E74726F70792F68617665676564
    scontext=system_u:system_r:entropyd_t
    tcontext=system_u:system_r:entropyd_t tclass=unix_stream_socket
    permissive=1