### PR TITLE
ulogd: fix pattern for /run/ulog directory

### DIFF
--- a/policy/modules/services/ulogd.fc
+++ b/policy/modules/services/ulogd.fc
@@ -2,7 +2,7 @@
 
 /etc/rc\.d/init\.d/ulogd	--	gen_context(system_u:object_r:ulogd_initrc_exec_t,s0)
 
-/run/ulog(/*)		gen_context(system_u:object_r:ulogd_runtime_t,s0)
+/run/ulog(/.*)?		gen_context(system_u:object_r:ulogd_runtime_t,s0)
 
 /usr/bin/ulogd	--	gen_context(system_u:object_r:ulogd_exec_t,s0)
 


### PR DESCRIPTION
The pattern only matched `/run/ulog`, not its content.