### PR TITLE
monit: use s0 instead of s9

### DIFF
--- a/policy/modules/services/monit.fc
+++ b/policy/modules/services/monit.fc
@@ -1,4 +1,4 @@
-/etc/rc\.d/init\.d/monit	--	gen_context(system_u:object_r:monit_initrc_exec_t,s9)
+/etc/rc\.d/init\.d/monit	--	gen_context(system_u:object_r:monit_initrc_exec_t,s0)
 
 /etc/monit(/.*)?			gen_context(system_u:object_r:monit_conf_t,s0)
 


### PR DESCRIPTION
This seems to be a misspelling, and there is no reason which would explain why monit's init script would be labeled with a different sensitivity while the main binary uses `s0`.