### PR TITLE
java: reduce the scope of the pattern in for java entry points

### DIFF
--- a/policy/modules/apps/java.fc
+++ b/policy/modules/apps/java.fc
@@ -5,7 +5,7 @@ HOME_DIR/\.java(/.*)?	gen_context(system_u:object_r:java_home_t,s0)
 /opt/local/matlab.*/bin.*/MATLAB.*	--	gen_context(system_u:object_r:java_exec_t,s0)
 /opt/matlab.*/bin.*/MATLAB.*	--	gen_context(system_u:object_r:java_exec_t,s0)
 
-/usr/(.*/)?bin/java[^-]*	--	gen_context(system_u:object_r:java_exec_t,s0)
+/usr/(.*/)?bin/java[^/-]*	--	gen_context(system_u:object_r:java_exec_t,s0)
 /usr/bin/fastjar	--	gen_context(system_u:object_r:java_exec_t,s0)
 /usr/bin/frysk	--	gen_context(system_u:object_r:java_exec_t,s0)
 /usr/bin/gappletviewer	--	gen_context(system_u:object_r:java_exec_t,s0)


### PR DESCRIPTION
The following pattern seems to match much more than intended:

    /usr/(.*/)?bin/java[^-]*

According to the commit which introduced it (https://github.com/TresysTechnology/refpolicy/commit/0190325c18c30d31145950c1eaf80d12fa6c9db3), the aim was to match `java1.4`, `java5`, `java6`, and not `java-config` nor `java-check-environment`. The issue is that the pattern also matches sub-directories such as:

    /usr/share/my-application/bin/java/myfile

Prevent this by adding `/` in the character blacklist of the pattern.