### PR TITLE
libraries: match a digit in Adobe Reader directories

### DIFF
--- a/policy/modules/system/libraries.fc
+++ b/policy/modules/system/libraries.fc
@@ -70,8 +70,8 @@ ifdef(`distro_gentoo',`
 ifdef(`distro_redhat',`
 /opt/Adobe.*/libcurl\.so 		-- 	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /opt/Adobe(/.*?)/nppdf\.so 		-- 	gen_context(system_u:object_r:textrel_shlib_t,s0)
-/opt/Adobe/Reader.?/Reader/intellinux/plug_ins/.*\.api -- gen_context(system_u:object_r:textrel_shlib_t,s0)
-/opt/Adobe/Reader.?/Reader/intellinux/SPPlugins/.*\.ap[il] -- gen_context(system_u:object_r:lib_t,s0)
+/opt/Adobe/Reader[0-9]?/Reader/intellinux/plug_ins/.*\.api -- gen_context(system_u:object_r:textrel_shlib_t,s0)
+/opt/Adobe/Reader[0-9]?/Reader/intellinux/SPPlugins/.*\.ap[il] -- gen_context(system_u:object_r:lib_t,s0)
 /opt/cisco-vpnclient/lib/libvpnapi\.so	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /opt/cx.*/lib/wine/.+\.so		--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /opt/f-secure/fspms/libexec/librapi\.so(\.[^/]*)* -- gen_context(system_u:object_r:textrel_shlib_t,s0)


### PR DESCRIPTION
Patterns using this have a small issue:

    /opt/Adobe/Reader.?/Reader/intellinux

The issue is that the dot can also match a slash. A bettern pattern would be:

    /opt/Adobe/Reader[^/]?/Reader/intellinux

In this specific case, the intent is to match digits (like `/opt/Adobe/Reader9`). Use `[0-9]` for this.