### PR TITLE
drbd: fix pattern for /usr/lib/ocf/resource.d/linbit/drbd

### DIFF
--- a/policy/modules/services/drbd.fc
+++ b/policy/modules/services/drbd.fc
@@ -3,7 +3,7 @@
 /usr/bin/drbdadm	--	gen_context(system_u:object_r:drbd_exec_t,s0)
 /usr/bin/drbdsetup	--	gen_context(system_u:object_r:drbd_exec_t,s0)
 
-/usr/lib/ocf/resource.\d/linbit/drbd	--	gen_context(system_u:object_r:drbd_exec_t,s0)
+/usr/lib/ocf/resource\.d/linbit/drbd	--	gen_context(system_u:object_r:drbd_exec_t,s0)
 
 /usr/sbin/drbdadm	--	gen_context(system_u:object_r:drbd_exec_t,s0)
 /usr/sbin/drbdsetup	--	gen_context(system_u:object_r:drbd_exec_t,s0)


### PR DESCRIPTION
In order to match `/usr/lib/ocf/resource.d/linbit/drbd`, the dot needs to be escaped, not the `d`.