### PR TITLE
files: reduce the scope of the pattern matching /usr/include

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -197,7 +197,8 @@ HOME_ROOT/lost\+found/.*	<<none>>
 
 /usr/etc(/.*)?			gen_context(system_u:object_r:etc_t,s0)
 
-/usr/inclu.e(/.*)?		gen_context(system_u:object_r:usr_t,s0)
+# Avoid calling m4's include by using en empty string
+/usr/include`'(/.*)?		gen_context(system_u:object_r:usr_t,s0)
 
 /usr/local/\.journal		<<none>>
 


### PR DESCRIPTION
The pattern that matches /usr/include uses a dot, in order probably to avoid calling m4's function `include()`. This also matches other paths such as `/usr/inclu/e`. Such a side-effect can be avoided by using a more restrictive pattern such as `/usr/includ[e](/.*)?`.

Mailing-list discussion: https://lore.kernel.org/selinux-refpolicy/CAJfZ7=krh_TaCBQzFxLM394Sc5-82ZO0DdcfvWON-RXu-wqBVw@mail.gmail.com/t/#u