### PR TITLE
rpcbind: remove redundant file context for /run/rpc.statd.pid

### DIFF
--- a/policy/modules/services/rpcbind.fc
+++ b/policy/modules/services/rpcbind.fc
@@ -8,5 +8,4 @@
 
 /var/lib/rpcbind(/.*)?	gen_context(system_u:object_r:rpcbind_var_lib_t,s0)
 
-/run/rpc.statd\.pid	--	gen_context(system_u:object_r:rpcbind_var_run_t,s0)
 /run/rpcbind.*	gen_context(system_u:object_r:rpcbind_var_run_t,s0)


### PR DESCRIPTION
There are two patterns that define file contexts for `/run/rpc.statd.pid`:

* in `policy/modules/services/rpcbind.fc`:

      /run/rpc.statd\.pid	--	gen_context(system_u:object_r:rpcbind_var_run_t,s0)

* in `policy/modules/services/rpc.dc`:

      /run/rpc\.statd\.pid	--	gen_context(system_u:object_r:rpcd_var_run_t,s0)

They coexist even though their labels differ because the first one uses a unescaped dot. As it does not seem to exist other files matching the first pattern, remove it in order to only keep the second one.