### PR TITLE
Remove unescaped single dot from the policy

### DIFF
--- a/policy/modules/admin/portage.fc
+++ b/policy/modules/admin/portage.fc
@@ -26,7 +26,7 @@
 /var/db/pkg(/.*)?	gen_context(system_u:object_r:portage_db_t,s0)
 /var/cache/edb(/.*)?	gen_context(system_u:object_r:portage_cache_t,s0)
 /var/log/emerge\.log.*	--	gen_context(system_u:object_r:portage_log_t,s0)
-/var/log/emerge-fetch.log	--	gen_context(system_u:object_r:portage_log_t,s0)
+/var/log/emerge-fetch\.log	--	gen_context(system_u:object_r:portage_log_t,s0)
 /var/log/portage(/.*)?	gen_context(system_u:object_r:portage_log_t,s0)
 /var/lib/layman(/.*)?	gen_context(system_u:object_r:portage_ebuild_t,s0)
 /var/lib/portage(/.*)?	gen_context(system_u:object_r:portage_cache_t,s0)

--- a/policy/modules/admin/rpm.fc
+++ b/policy/modules/admin/rpm.fc
@@ -24,7 +24,7 @@
 /usr/lib/systemd/system/[^/]*yum-makecache.*	--	gen_context(system_u:object_r:rpm_unit_t,s0)
 
 /usr/libexec/packagekitd	--	gen_context(system_u:object_r:rpm_exec_t,s0)
-/usr/libexec/yumDBUSBackend.py	--	gen_context(system_u:object_r:rpm_exec_t,s0)
+/usr/libexec/yumDBUSBackend\.py	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 
 /usr/sbin/bcfg2	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/sbin/pirut	--	gen_context(system_u:object_r:rpm_exec_t,s0)

--- a/policy/modules/apps/chromium.fc
+++ b/policy/modules/apps/chromium.fc
@@ -3,21 +3,21 @@
 /opt/google/chrome/chrome-sandbox			--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
 /opt/google/chrome/google-chrome			--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /opt/google/chrome/nacl_.*				--	gen_context(system_u:object_r:chromium_naclhelper_exec_t,s0)
-/opt/google/chrome/libudev.so.0					gen_context(system_u:object_r:lib_t,s0)
+/opt/google/chrome/libudev\.so\.0				gen_context(system_u:object_r:lib_t,s0)
 
 /opt/google/chrome-beta/chrome				--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /opt/google/chrome-beta/chrome_sandbox			--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
 /opt/google/chrome-beta/chrome-sandbox			--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
 /opt/google/chrome-beta/google-chrome			--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /opt/google/chrome-beta/nacl_helper_bootstrap		--	gen_context(system_u:object_r:chromium_naclhelper_exec_t,s0)
-/opt/google/chrome-beta/libudev.so.0				gen_context(system_u:object_r:lib_t,s0)
+/opt/google/chrome-beta/libudev\.so\.0				gen_context(system_u:object_r:lib_t,s0)
 
 /opt/google/chrome-unstable/chrome			--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /opt/google/chrome-unstable/chrome_sandbox		--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
 /opt/google/chrome-unstable/chrome-sandbox		--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
 /opt/google/chrome-unstable/google-chrome		--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /opt/google/chrome-unstable/nacl_helper_bootstrap	--	gen_context(system_u:object_r:chromium_naclhelper_exec_t,s0)
-/opt/google/chrome-unstable/libudev.so.0			gen_context(system_u:object_r:lib_t,s0)
+/opt/google/chrome-unstable/libudev\.so\.0			gen_context(system_u:object_r:lib_t,s0)
 
 ifdef(`distro_debian',`
 /usr/lib/chromium/chromium				--	gen_context(system_u:object_r:chromium_exec_t,s0)

--- a/policy/modules/apps/mozilla.fc
+++ b/policy/modules/apps/mozilla.fc
@@ -37,6 +37,6 @@ HOME_DIR/zimbrauserdata(/.*)?	gen_context(system_u:object_r:mozilla_plugin_home_
 /usr/lib/mozilla/plugins-wrapped(/.*)?	gen_context(system_u:object_r:mozilla_plugin_rw_t,s0)
 /usr/lib/netscape/base-4/wrapper	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
 /usr/lib/netscape/.+/communicator/communicator-smotif\.real	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
-/usr/lib/nspluginwrapper/npviewer.bin	--	gen_context(system_u:object_r:mozilla_plugin_exec_t,s0)
+/usr/lib/nspluginwrapper/npviewer\.bin	--	gen_context(system_u:object_r:mozilla_plugin_exec_t,s0)
 /usr/lib/nspluginwrapper/plugin-config	--	gen_context(system_u:object_r:mozilla_plugin_config_exec_t,s0)
 /usr/lib/xulrunner[^/]*/plugin-container	--	gen_context(system_u:object_r:mozilla_plugin_exec_t,s0)

--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -37,10 +37,10 @@ ifdef(`distro_redhat',`
 /etc/ConsoleKit/run-seat\.d(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /etc/ConsoleKit/run-session\.d(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 
-/etc/cron.daily(/.*)?			gen_context(system_u:object_r:bin_t,s0)
-/etc/cron.hourly(/.*)?			gen_context(system_u:object_r:bin_t,s0)
-/etc/cron.weekly(/.*)?			gen_context(system_u:object_r:bin_t,s0)
-/etc/cron.monthly(/.*)?			gen_context(system_u:object_r:bin_t,s0)
+/etc/cron\.daily(/.*)?			gen_context(system_u:object_r:bin_t,s0)
+/etc/cron\.hourly(/.*)?			gen_context(system_u:object_r:bin_t,s0)
+/etc/cron\.weekly(/.*)?			gen_context(system_u:object_r:bin_t,s0)
+/etc/cron\.monthly(/.*)?			gen_context(system_u:object_r:bin_t,s0)
 
 /etc/dhcp/dhclient\.d(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 
@@ -58,7 +58,7 @@ ifdef(`distro_redhat',`
 /etc/mcelog/.*\.local		--	gen_context(system_u:object_r:bin_t,s0)
 
 ifdef(`distro_redhat',`
-/etc/mcelog/mcelog.setup	--	gen_context(system_u:object_r:bin_t,s0)
+/etc/mcelog/mcelog\.setup	--	gen_context(system_u:object_r:bin_t,s0)
 /etc/mcelog/triggers(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 ')
 
@@ -79,13 +79,13 @@ ifdef(`distro_redhat',`
 /etc/ppp/ipv6-up\..*		--	gen_context(system_u:object_r:bin_t,s0)
 /etc/ppp/ipv6-down\..*		--	gen_context(system_u:object_r:bin_t,s0)
 
-/etc/profile.d(/.*)?			gen_context(system_u:object_r:bin_t,s0)
+/etc/profile\.d(/.*)?			gen_context(system_u:object_r:bin_t,s0)
 
 /etc/racoon/scripts(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 
 /etc/rc\.d/init\.d/functions	--	gen_context(system_u:object_r:bin_t,s0)
 
-/etc/security/namespace.init	--	gen_context(system_u:object_r:bin_t,s0)
+/etc/security/namespace\.init	--	gen_context(system_u:object_r:bin_t,s0)
 
 /etc/sysconfig/crond		--	gen_context(system_u:object_r:bin_t,s0)
 /etc/sysconfig/init		--	gen_context(system_u:object_r:bin_t,s0)
@@ -178,8 +178,8 @@ ifdef(`distro_gentoo',`
 /usr/lib/wicd/monitor\.py 	-- 	gen_context(system_u:object_r:bin_t, s0)
 /usr/lib/apt/methods.+		--	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/ConsoleKit/.*		--	gen_context(system_u:object_r:bin_t,s0)
-/usr/lib/ConsoleKit/run-seat.d(/.*)?	gen_context(system_u:object_r:bin_t,s0)
-/usr/lib/ConsoleKit/run-session.d(/.*)?	gen_context(system_u:object_r:bin_t,s0)
+/usr/lib/ConsoleKit/run-seat\.d(/.*)?	gen_context(system_u:object_r:bin_t,s0)
+/usr/lib/ConsoleKit/run-session\.d(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/ConsoleKit/scripts(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/courier(/.*)?			gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/crda/setregdomain	--	gen_context(system_u:object_r:bin_t,s0)
@@ -203,7 +203,7 @@ ifdef(`distro_gentoo',`
 /usr/lib/mailman/mail(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/mediawiki/math/texvc.*		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/misc/sftp-server	--	gen_context(system_u:object_r:bin_t,s0)
-/usr/lib/mon/alert.d(/.*)?		gen_context(system_u:object_r:bin_t,s0)
+/usr/lib/mon/alert\.d(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/nagios/plugins(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/netsaint/plugins(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/NetworkManager/nm-.*	--	gen_context(system_u:object_r:bin_t,s0)
@@ -286,8 +286,8 @@ ifdef(`distro_gentoo',`
 
 /usr/share/mdadm/checkarray	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/(.*/)?bin(/.*)?		gen_context(system_u:object_r:bin_t,s0)
-/usr/share/ajaxterm/ajaxterm.py.* --	gen_context(system_u:object_r:bin_t,s0)
-/usr/share/ajaxterm/qweb.py.* --	gen_context(system_u:object_r:bin_t,s0)
+/usr/share/ajaxterm/ajaxterm\.py.* --	gen_context(system_u:object_r:bin_t,s0)
+/usr/share/ajaxterm/qweb\.py.* --	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/apr(-\d)?/build/[^/]+\.sh --	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/apr(-\d)?/build/libtool --	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/build-1/[^/]+\.sh --		gen_context(system_u:object_r:bin_t,s0)
@@ -314,13 +314,13 @@ ifdef(`distro_gentoo',`
 /usr/share/libalpm/scripts(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/mc/extfs/.*		--	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/Modules/init(/.*)?		gen_context(system_u:object_r:bin_t,s0)
-/usr/share/org.gnome.Weather/org\.gnome\.Weather\.Application	--	gen_context(system_u:object_r:bin_t,s0)
-/usr/share/org.gnome.Weather/org\.gnome\.Weather\.BackgroundService	--	gen_context(system_u:object_r:bin_t,s0)
+/usr/share/org\.gnome\.Weather/org\.gnome\.Weather\.Application	--	gen_context(system_u:object_r:bin_t,s0)
+/usr/share/org\.gnome\.Weather/org\.gnome\.Weather\.BackgroundService	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/printconf/util/print\.py --	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/PackageKit/pk-upgrade-distro\.sh -- 	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/PackageKit/helpers(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/reportbug/handle_bugscript -- gen_context(system_u:object_r:bin_t,s0)
-/usr/share/sandbox/sandboxX.sh	--	gen_context(system_u:object_r:bin_t,s0)
+/usr/share/sandbox/sandboxX\.sh	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/sectool/.*\.py	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/selinux/devel/policygentool -- gen_context(system_u:object_r:bin_t,s0)
 /usr/share/smartmontools/.*	--	gen_context(system_u:object_r:bin_t,s0)

--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -72,7 +72,7 @@ ifdef(`distro_suse',`
 /etc/sysconfig/iptables\.save -- gen_context(system_u:object_r:etc_runtime_t,s0)
 /etc/sysconfig/firstboot --	gen_context(system_u:object_r:etc_runtime_t,s0)
 
-/etc/zfs/zpool.cache	--	gen_context(system_u:object_r:etc_runtime_t,s0)
+/etc/zfs/zpool\.cache	--	gen_context(system_u:object_r:etc_runtime_t,s0)
 
 ifdef(`distro_gentoo', `
 /etc/profile\.env	--	gen_context(system_u:object_r:etc_runtime_t,s0)

--- a/policy/modules/services/apache.fc
+++ b/policy/modules/services/apache.fc
@@ -139,7 +139,7 @@ ifdef(`distro_suse',`
 /var/lib/pootle/po(/.*)?					gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)
 /var/lib/rt3/data/RT-Shredder(/.*)?				gen_context(system_u:object_r:httpd_var_lib_t,s0)
 /var/lib/squirrelmail/prefs(/.*)?				gen_context(system_u:object_r:httpd_squirrelmail_t,s0)
-/var/lib/stickshift/.httpd.d(/.*)?				gen_context(system_u:object_r:httpd_config_t,s0)
+/var/lib/stickshift/\.httpd\.d(/.*)?				gen_context(system_u:object_r:httpd_config_t,s0)
 /var/lib/svn(/.*)?						gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)
 /var/lib/trac(/.*)?						gen_context(system_u:object_r:httpd_sys_content_t,s0)
 /var/lib/wordpress(/.*)?					gen_context(system_u:object_r:httpd_var_lib_t,s0)

--- a/policy/modules/services/boinc.fc
+++ b/policy/modules/services/boinc.fc
@@ -1,4 +1,4 @@
-/etc/boinc-client/global_prefs_override.xml -- gen_context(system_u:object_r:boinc_var_lib_t,s0)
+/etc/boinc-client/global_prefs_override\.xml -- gen_context(system_u:object_r:boinc_var_lib_t,s0)
 /etc/rc\.d/init\.d/boinc-client	--	gen_context(system_u:object_r:boinc_initrc_exec_t,s0)
 
 /usr/bin/boinc		--	gen_context(system_u:object_r:boinc_exec_t,s0)

--- a/policy/modules/services/cgmanager.fc
+++ b/policy/modules/services/cgmanager.fc
@@ -1,7 +1,7 @@
 /sys/fs/cgroup/cgmanager(/.*)?				gen_context(system_u:object_r:cgmanager_cgroup_t,s0)
 
 /run/cgmanager(/.*)?					gen_context(system_u:object_r:cgmanager_run_t,s0)
-/run/cgmanager.pid					gen_context(system_u:object_r:cgmanager_run_t,s0)
+/run/cgmanager\.pid					gen_context(system_u:object_r:cgmanager_run_t,s0)
 /run/cgmanager/fs(/.*)?					<<none>>
 
 /usr/bin/cgmanager				--	gen_context(system_u:object_r:cgmanager_exec_t,s0)

--- a/policy/modules/services/dirmngr.fc
+++ b/policy/modules/services/dirmngr.fc
@@ -15,4 +15,4 @@ HOME_DIR/\.gnupg/crls\.d(/.+)?		gen_context(system_u:object_r:dirmngr_home_t,s0)
 
 /run/dirmngr(/.*)?	gen_context(system_u:object_r:dirmngr_var_run_t,s0)
 
-/run/user/%{USERID}/gnupg/S.dirmngr	-s	gen_context(system_u:object_r:dirmngr_tmp_t,s0)
+/run/user/%{USERID}/gnupg/S\.dirmngr	-s	gen_context(system_u:object_r:dirmngr_tmp_t,s0)

--- a/policy/modules/services/dovecot.fc
+++ b/policy/modules/services/dovecot.fc
@@ -31,7 +31,7 @@
 /usr/libexec/dovecot/dovecot-auth	--	gen_context(system_u:object_r:dovecot_auth_exec_t,s0)
 
 /run/dovecot(-login)?(/.*)?	gen_context(system_u:object_r:dovecot_var_run_t,s0)
-/run/dovecot/login/ssl-parameters.dat	--	gen_context(system_u:object_r:dovecot_var_lib_t,s0)
+/run/dovecot/login/ssl-parameters\.dat	--	gen_context(system_u:object_r:dovecot_var_lib_t,s0)
 
 /var/lib/dovecot(/.*)?	gen_context(system_u:object_r:dovecot_var_lib_t,s0)
 

--- a/policy/modules/services/gssproxy.fc
+++ b/policy/modules/services/gssproxy.fc
@@ -1,6 +1,6 @@
 /usr/bin/gssproxy				--	gen_context(system_u:object_r:gssproxy_exec_t,s0)
 
-/usr/lib/systemd/system/gssproxy.service	--	gen_context(system_u:object_r:gssproxy_unit_t,s0)
+/usr/lib/systemd/system/gssproxy\.service	--	gen_context(system_u:object_r:gssproxy_unit_t,s0)
 
 /usr/sbin/gssproxy				--	gen_context(system_u:object_r:gssproxy_exec_t,s0)
 

--- a/policy/modules/services/hostapd.fc
+++ b/policy/modules/services/hostapd.fc
@@ -4,4 +4,4 @@
 
 /etc/hostapd(/.*)?          gen_context(system_u:object_r:hostapd_conf_t,s0)
 
-/run/hostapd.pid                --      gen_context(system_u:object_r:hostapd_var_run_t,s0)
+/run/hostapd\.pid                --      gen_context(system_u:object_r:hostapd_var_run_t,s0)

--- a/policy/modules/services/mon.fc
+++ b/policy/modules/services/mon.fc
@@ -2,10 +2,10 @@
 
 /usr/bin/mon		--	gen_context(system_u:object_r:mon_exec_t,s0)
 
-/usr/lib/mon/mon.d/.*			--	gen_context(system_u:object_r:mon_net_test_exec_t,s0)
-/usr/lib/mon/mon-local.d/.*		--	gen_context(system_u:object_r:mon_local_test_exec_t,s0)
-/usr/lib/mon-contrib/mon.d/.*		--	gen_context(system_u:object_r:mon_net_test_exec_t,s0)
-/usr/lib/mon-contrib/mon-local.d/.*	--	gen_context(system_u:object_r:mon_local_test_exec_t,s0)
+/usr/lib/mon/mon\.d/.*			--	gen_context(system_u:object_r:mon_net_test_exec_t,s0)
+/usr/lib/mon/mon-local\.d/.*		--	gen_context(system_u:object_r:mon_local_test_exec_t,s0)
+/usr/lib/mon-contrib/mon\.d/.*		--	gen_context(system_u:object_r:mon_net_test_exec_t,s0)
+/usr/lib/mon-contrib/mon-local\.d/.*	--	gen_context(system_u:object_r:mon_local_test_exec_t,s0)
 
 /usr/sbin/mon		--	gen_context(system_u:object_r:mon_exec_t,s0)
 

--- a/policy/modules/services/nx.fc
+++ b/policy/modules/services/nx.fc
@@ -10,4 +10,4 @@
 /usr/NX/home/nx/\.ssh(/.*)?	gen_context(system_u:object_r:nx_server_home_ssh_t,s0)
 
 /var/lib/nxserver(/.*)?	gen_context(system_u:object_r:nx_server_var_lib_t,s0)
-/var/lib/nxserver/home/.ssh(/.*)?	gen_context(system_u:object_r:nx_server_home_ssh_t,s0)
+/var/lib/nxserver/home/\.ssh(/.*)?	gen_context(system_u:object_r:nx_server_home_ssh_t,s0)

--- a/policy/modules/services/pkcs.fc
+++ b/policy/modules/services/pkcs.fc
@@ -2,7 +2,7 @@
 
 /usr/bin/pkcsslotd	--	gen_context(system_u:object_r:pkcs_slotd_exec_t,s0)
 
-/usr/lib/systemd/system/pkcsslotd.service  gen_context(system_u:object_r:pkcs_slotd_unit_t,s0)
+/usr/lib/systemd/system/pkcsslotd\.service  gen_context(system_u:object_r:pkcs_slotd_unit_t,s0)
 
 /usr/sbin/pkcsslotd	--	gen_context(system_u:object_r:pkcs_slotd_exec_t,s0)
 

--- a/policy/modules/services/policykit.fc
+++ b/policy/modules/services/policykit.fc
@@ -18,7 +18,7 @@
 /usr/libexec/polkit-1/polkit-agent-helper-1	--	gen_context(system_u:object_r:policykit_auth_exec_t,s0)
 /usr/libexec/polkit-1/polkitd.*	--	gen_context(system_u:object_r:policykit_exec_t,s0)
 
-/var/lib/misc/PolicyKit.reload	gen_context(system_u:object_r:policykit_reload_t,s0)
+/var/lib/misc/PolicyKit\.reload	gen_context(system_u:object_r:policykit_reload_t,s0)
 /var/lib/PolicyKit(/.*)?	gen_context(system_u:object_r:policykit_var_lib_t,s0)
 /var/lib/polkit-1(/.*)?	gen_context(system_u:object_r:policykit_var_lib_t,s0)
 /var/lib/PolicyKit-public(/.*)?	gen_context(system_u:object_r:policykit_var_lib_t,s0)

--- a/policy/modules/services/virt.fc
+++ b/policy/modules/services/virt.fc
@@ -64,4 +64,4 @@ HOME_DIR/VirtualMachines/isos(/.*)?	gen_context(system_u:object_r:virt_content_t
 /run/libvirt/virtlockd-sock	-s	gen_context(system_u:object_r:virtlockd_run_t,s0)
 /run/user/[^/]*/libguestfs(/.*)?	gen_context(system_u:object_r:virt_home_t,s0)
 /run/vdsm(/.*)?	gen_context(system_u:object_r:virt_var_run_t,s0)
-/run/virtlockd.pid	--	gen_context(system_u:object_r:virtlockd_run_t,s0)
+/run/virtlockd\.pid	--	gen_context(system_u:object_r:virtlockd_run_t,s0)

--- a/policy/modules/system/ipsec.fc
+++ b/policy/modules/system/ipsec.fc
@@ -16,7 +16,7 @@
 
 /etc/swanctl/(.*)?			gen_context(system_u:object_r:ipsec_key_file_t,s0)
 /etc/swanctl			-d	gen_context(system_u:object_r:ipsec_conf_file_t,s0)
-/etc/swanctl/swanctl.conf	--	gen_context(system_u:object_r:ipsec_conf_file_t,s0)
+/etc/swanctl/swanctl\.conf	--	gen_context(system_u:object_r:ipsec_conf_file_t,s0)
 
 /usr/bin/ipsec			-- 	gen_context(system_u:object_r:ipsec_mgmt_exec_t,s0)
 /usr/bin/racoon			--	gen_context(system_u:object_r:racoon_exec_t,s0)

--- a/policy/modules/system/libraries.fc
+++ b/policy/modules/system/libraries.fc
@@ -244,8 +244,6 @@ HOME_DIR/\.mozilla/plugins/nprhapengine\.so.* --	gen_context(system_u:object_r:t
 
 /usr/lib/libdvdcss\.so.*		--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 
-/usr/lib/python2\.4/site-packages/M2Crypto/__m2crypto\.so -- gen_context(system_u:object_r:textrel_shlib_t,s0)
-
 # vmware
 /usr/lib/vmware/lib(/.*)?/libgdk-x11-.*\.so.* -- gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/lib/vmware/lib(/.*)?/HConfig\.so	--	gen_context(system_u:object_r:textrel_shlib_t,s0)

--- a/policy/modules/system/libraries.fc
+++ b/policy/modules/system/libraries.fc
@@ -49,7 +49,7 @@ ifdef(`distro_redhat',`
 # despite the extensions, they are actually libs
 /opt/Acrobat[5-9]/Reader/intellinux/plugins/.*\.api -- gen_context(system_u:object_r:lib_t,s0)
 
-/opt/Komodo-Edit-5/lib/python/lib/python2.6/lib-dynload/.*\.so(\.[^/]*)* -- gen_context(system_u:object_r:textrel_shlib_t,s0)
+/opt/Komodo-Edit-5/lib/python/lib/python2\.6/lib-dynload/.*\.so(\.[^/]*)* -- gen_context(system_u:object_r:textrel_shlib_t,s0)
 
 ifdef(`distro_gentoo',`
 # despite the extensions, they are actually libs
@@ -171,8 +171,8 @@ ifdef(`distro_redhat',`
 # 	HelixPlayer, SDL, xorg-x11, xorg-x11-libs, Hermes, valgrind, openoffice.org-libs, httpd - php
 HOME_DIR/.*/plugins/nppdf\.so.* 	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/lib/allegro/(.*/)?alleg-vga\.so	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
-/usr/lib/firefox-[^/]*/extensions(/.*)?/libqfaservices.so -- gen_context(system_u:object_r:textrel_shlib_t,s0)
-/usr/lib/firefox-[^/]*/plugins/nppdf.so	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
+/usr/lib/firefox-[^/]*/extensions(/.*)?/libqfaservices\.so -- gen_context(system_u:object_r:textrel_shlib_t,s0)
+/usr/lib/firefox-[^/]*/plugins/nppdf\.so	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/lib/firefox/plugins/libractrl\.so	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/lib/libFLAC\.so.*			--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/lib/libfglrx_gamma\.so.* 		--	gen_context(system_u:object_r:textrel_shlib_t,s0)
@@ -233,7 +233,7 @@ HOME_DIR/.*/plugins/nppdf\.so.* 	--	gen_context(system_u:object_r:textrel_shlib_
 /usr/lib/codecs/drv[1-9c]\.so(\.[^/]*)* --	gen_context(system_u:object_r:textrel_shlib_t,s0)
 
 HOME_DIR/.*/plugins/nppdf\.so		--	gen_context(system_u:object_r:textrel_shlib_t,s0)
-HOME_DIR/.mozilla/plugins/nprhapengine\.so.* --	gen_context(system_u:object_r:textrel_shlib_t,s0)
+HOME_DIR/\.mozilla/plugins/nprhapengine\.so.* --	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/lib/.*/nprhapengine\.so.*		--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/local/(.*/)?nprhapengine\.so.*	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 
@@ -244,7 +244,7 @@ HOME_DIR/.mozilla/plugins/nprhapengine\.so.* --	gen_context(system_u:object_r:te
 
 /usr/lib/libdvdcss\.so.*		--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 
-/usr/lib/python2.4/site-packages/M2Crypto/__m2crypto\.so -- gen_context(system_u:object_r:textrel_shlib_t,s0)
+/usr/lib/python2\.4/site-packages/M2Crypto/__m2crypto\.so -- gen_context(system_u:object_r:textrel_shlib_t,s0)
 
 # vmware
 /usr/lib/vmware/lib(/.*)?/libgdk-x11-.*\.so.* -- gen_context(system_u:object_r:textrel_shlib_t,s0)

--- a/policy/modules/system/logging.fc
+++ b/policy/modules/system/logging.fc
@@ -39,10 +39,10 @@
 /usr/sbin/syslog-ng	--	gen_context(system_u:object_r:syslogd_exec_t,s0)
 /usr/sbin/syslogd	--	gen_context(system_u:object_r:syslogd_exec_t,s0)
 
-/var/lib/misc/syslog-ng.persist-? -- gen_context(system_u:object_r:syslogd_var_lib_t,s0)
+/var/lib/misc/syslog-ng\.persist-? -- gen_context(system_u:object_r:syslogd_var_lib_t,s0)
 /var/lib/syslog-ng(/.*)? 	gen_context(system_u:object_r:syslogd_var_lib_t,s0)
 /var/lib/r?syslog(/.*)?		gen_context(system_u:object_r:syslogd_var_lib_t,s0)
-/var/lib/syslog-ng.persist --	gen_context(system_u:object_r:syslogd_var_lib_t,s0)
+/var/lib/syslog-ng\.persist --	gen_context(system_u:object_r:syslogd_var_lib_t,s0)
 
 ifdef(`distro_suse', `
 /var/lib/stunnel/dev/log -s	gen_context(system_u:object_r:devlog_t,s0)
@@ -82,7 +82,7 @@ ifdef(`distro_redhat',`
 /run/metalog\.pid	--	gen_context(system_u:object_r:syslogd_var_run_t,s0)
 /run/rsyslogd\.pid	--	gen_context(system_u:object_r:syslogd_var_run_t,mls_systemhigh)
 /run/syslogd\.pid	--	gen_context(system_u:object_r:syslogd_var_run_t,mls_systemhigh)
-/run/syslog-ng.ctl	--	gen_context(system_u:object_r:syslogd_var_run_t,s0)
+/run/syslog-ng\.ctl	--	gen_context(system_u:object_r:syslogd_var_run_t,s0)
 /run/syslog-ng\.pid	--	gen_context(system_u:object_r:syslogd_var_run_t,mls_systemhigh)
 /run/syslog-ng(/.*)?	gen_context(system_u:object_r:syslogd_var_run_t,s0)
 /run/systemd/journal(/.*)?	gen_context(system_u:object_r:syslogd_var_run_t,mls_systemhigh)

--- a/policy/modules/system/miscfiles.fc
+++ b/policy/modules/system/miscfiles.fc
@@ -17,7 +17,7 @@ ifdef(`distro_gentoo',`
 /etc/timezone		--	gen_context(system_u:object_r:locale_t,s0)
 
 ifdef(`distro_debian',`
-/etc/locale.alias	--	gen_context(system_u:object_r:locale_t,s0)
+/etc/locale\.alias	--	gen_context(system_u:object_r:locale_t,s0)
 ')
 
 ifdef(`distro_redhat',`

--- a/policy/modules/system/modutils.fc
+++ b/policy/modules/system/modutils.fc
@@ -5,7 +5,7 @@
 ifdef(`distro_gentoo',`
 # gentoo init scripts still manage this file
 # even if devfs is off
-/etc/modprobe.devfs.*		--	gen_context(system_u:object_r:modules_conf_t,s0)
+/etc/modprobe\.devfs.*		--	gen_context(system_u:object_r:modules_conf_t,s0)
 ')
 
 ifdef(`init_systemd',`

--- a/policy/modules/system/udev.fc
+++ b/policy/modules/system/udev.fc
@@ -6,7 +6,7 @@
 
 /etc/hotplug\.d/default/udev.* -- gen_context(system_u:object_r:udev_helper_exec_t,s0)
 
-/etc/udev/rules.d(/.*)? gen_context(system_u:object_r:udev_rules_t,s0)
+/etc/udev/rules\.d(/.*)? gen_context(system_u:object_r:udev_rules_t,s0)
 /etc/udev/scripts/.+ --	gen_context(system_u:object_r:udev_helper_exec_t,s0)
 
 /usr/bin/udev		--	gen_context(system_u:object_r:udev_exec_t,s0)


### PR DESCRIPTION
In a pattern, a dot can match any character, including slash. It makes sense when it is combined with `?`, `+` or `*`, but makes little sense when left alone.

Most of the time, the label was for file containing dots, where the dot was not escaped. A few times, the dot was really intended to match any character. In such case, `[^/]` better suits the intent.