### PR TITLE
Allow Debian to generate a dynamic motd when users log in

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -97,6 +97,8 @@ ifdef(`distro_redhat',`
 /etc/sysconfig/network-scripts/net.*	gen_context(system_u:object_r:bin_t,s0)
 /etc/sysconfig/network-scripts/init.*	gen_context(system_u:object_r:bin_t,s0)
 
+/etc/update-motd\.d(/.*)?		gen_context(system_u:object_r:bin_t,s0)
+
 /etc/vmware-tools(/.*)?			gen_context(system_u:object_r:bin_t,s0)
 
 /etc/X11/xdm/GiveConsole	--	gen_context(system_u:object_r:bin_t,s0)

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -276,6 +276,7 @@ corenet_sendrecv_xserver_server_packets(sshd_t)
 
 ifdef(`distro_debian',`
 	allow sshd_t self:process { getcap setcap };
+	auth_use_pam_motd_dynamic(sshd_t)
 ')
 
 ifdef(`init_systemd',`

--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -43,6 +43,9 @@ ifdef(`distro_suse', `
 
 /run/console(/.*)?	 	gen_context(system_u:object_r:pam_var_console_t,s0)
 /run/faillock(/.*)?		gen_context(system_u:object_r:faillog_t,s0)
+/run/motd		--	gen_context(system_u:object_r:pam_motd_runtime_t,s0)
+/run/motd\.dynamic	--	gen_context(system_u:object_r:pam_motd_runtime_t,s0)
+/run/motd\.dynamic\.new	--	gen_context(system_u:object_r:pam_motd_runtime_t,s0)
 /run/pam_mount(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
 /run/pam_ssh(/.*)?		gen_context(system_u:object_r:var_auth_t,s0)
 /run/sepermit(/.*)? 	gen_context(system_u:object_r:pam_var_run_t,s0)

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -100,6 +100,32 @@ interface(`auth_use_pam_systemd',`
 
 ########################################
 ## <summary>
+##	Use the pam module motd with dynamic support during authentication.
+##	This module comes from Ubuntu (https://bugs.launchpad.net/ubuntu/+source/pam/+bug/399071)
+##	and was added to Debian (https://sources.debian.org/src/pam/1.3.1-5/debian/patches-applied/update-motd/)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_use_pam_motd_dynamic',`
+	gen_require(`
+		type pam_motd_runtime_t;
+	')
+
+	# Allow pam_motd to run /usr/bin/env and /usr/bin/dash to generate
+	# /run/motd.dynamic from motd.dynamic.new.
+	corecmd_exec_bin($1)
+	corecmd_exec_shell($1)
+
+	allow $1 pam_motd_runtime_t:file manage_file_perms;
+	files_pid_filetrans($1, pam_motd_runtime_t, file, "motd.dynamic.new")
+')
+
+########################################
+## <summary>
 ##	Make the specified domain used for a login program.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -49,6 +49,9 @@ role system_r types pam_t;
 type pam_exec_t;
 domain_entry_file(pam_t, pam_exec_t)
 
+type pam_motd_runtime_t;
+files_pid_file(pam_motd_runtime_t)
+
 type pam_tmp_t;
 files_tmp_file(pam_tmp_t)
 

--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -69,8 +69,6 @@ ifdef(`distro_redhat',`
 ifdef(`distro_debian',`
 /run/hotkey-setup	--	gen_context(system_u:object_r:initrc_var_run_t,s0)
 /run/kdm/.*		--	gen_context(system_u:object_r:initrc_var_run_t,s0)
-/run/motd		--	gen_context(system_u:object_r:initrc_var_run_t,s0)
-/run/motd\.dynamic	--	gen_context(system_u:object_r:initrc_var_run_t,s0)
 /etc/network/if-pre-up\.d/.* --	gen_context(system_u:object_r:initrc_exec_t,s0)
 /etc/network/if-up\.d/.* --	gen_context(system_u:object_r:initrc_exec_t,s0)
 /etc/network/if-down\.d/.* --	gen_context(system_u:object_r:initrc_exec_t,s0)

--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -144,6 +144,10 @@ ifdef(`init_systemd',`
 	systemd_manage_logind_pid_pipes(local_login_t)
 ')
 
+ifdef(`distro_debian',`
+	auth_use_pam_motd_dynamic(local_login_t)
+')
+
 ifdef(`distro_ubuntu',`
 	optional_policy(`
 		unconfined_domain(local_login_t)


### PR DESCRIPTION
Debian's PAM configuration uses a patched `pam_motd` module that runs files in `/etc/update-motd.d/` in order to generate a dynamic Message Of The Day (MOTD). By default, there is only one script:

    $ cat /etc/update-motd.d/10-uname
    #!/bin/sh
    uname -snrvm

According to https://wiki.debian.org/motd, the script is executed through `run-parts`:
```C
if (!system("/usr/bin/env -i PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
    run-parts --lsbsysinit /etc/update-motd.d > /run/motd.dynamic.new"))
        rename("/run/motd.dynamic.new", "/run/motd.dynamic");
```

This requires allowing `pam_motd` users to execute `bin_t` commands (`/usr/bin/env`) and shells (`/bin/sh`), and to manage `/run/motd.dynamic*` files.

Allow relevant accesses for Debian-based systems.

In order for this to fully works, `unconfined_shell_domtrans(sshd_t)` and `unconfined_shell_domtrans(remote_login_t)` need to be removed from the policy. A patch has been sent related to this on https://lore.kernel.org/selinux-refpolicy/20190831172713.140005-1-dac.override@gmail.com/