### PR TITLE
libraries: fix some misspellings in patterns

### DIFF
--- a/policy/modules/system/libraries.fc
+++ b/policy/modules/system/libraries.fc
@@ -69,7 +69,7 @@ ifdef(`distro_gentoo',`
 
 ifdef(`distro_redhat',`
 /opt/Adobe.*/libcurl\.so 		-- 	gen_context(system_u:object_r:textrel_shlib_t,s0)
-/opt/Adobe(/.*?)/nppdf\.so 		-- 	gen_context(system_u:object_r:textrel_shlib_t,s0)
+/opt/Adobe(/.*)?/nppdf\.so 		-- 	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /opt/Adobe/Reader[0-9]?/Reader/intellinux/plug_ins/.*\.api -- gen_context(system_u:object_r:textrel_shlib_t,s0)
 /opt/Adobe/Reader[0-9]?/Reader/intellinux/SPPlugins/.*\.ap[il] -- gen_context(system_u:object_r:lib_t,s0)
 /opt/cisco-vpnclient/lib/libvpnapi\.so	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
@@ -78,7 +78,6 @@ ifdef(`distro_redhat',`
 /opt/ibm/java.*/jre/.+\.jar		--	gen_context(system_u:object_r:lib_t,s0)
 /opt/ibm/java.*/jre/.+\.so(\.[^/]*)*	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /opt/ibm/java.*/jre/bin/.+\.so(\.[^/]*)* --	gen_context(system_u:object_r:textrel_shlib_t,s0)
-/opt/netbeans(.*/)?jdk.*/linux/.+\.so(\.[^/]*)* -- gen_context(system_u:object_r:textrel_shlib_t,s0)
 ')
 
 #
@@ -259,7 +258,7 @@ HOME_DIR/\.mozilla/plugins/nprhapengine\.so.* --	gen_context(system_u:object_r:t
 /usr/lib/(.*/)?jre.*/.*\.so(\.[^/]*)*	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 
 /usr/(local/)?Adobe/(.*/)?intellinux/nppdf\.so -- gen_context(system_u:object_r:textrel_shlib_t,s0)
-/usr/(local/)?Adobe/(.*/)?intellinux/sidecars/* -- gen_context(system_u:object_r:textrel_shlib_t,s0)
+/usr/(local/)?Adobe/(.*/)?intellinux/sidecars/.+ -- gen_context(system_u:object_r:textrel_shlib_t,s0)
 
 /usr/(local/)?acroread/(.*/)?intellinux/nppdf\.so -- gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/(local/)?Adobe/(.*/)?lib/[^/]*\.so(\.[^/]*)* -- gen_context(system_u:object_r:textrel_shlib_t,s0)
@@ -272,7 +271,7 @@ HOME_DIR/\.mozilla/plugins/nprhapengine\.so.* --	gen_context(system_u:object_r:t
 
 /usr/(.*/)?intellinux/SPPlugins/ADMPlugin\.apl -- gen_context(system_u:object_r:textrel_shlib_t,s0)
 
-/usr/lib/acroread/(.*/)?sidecars/*	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
+/usr/lib/acroread/(.*/)?sidecars/.+	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/lib/acroread/(.*/)?nppdf\.so	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/lib/acroread/(.*/)?lib/[^/]*\.so(\.[^/]*)* -- gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/lib/acroread/.+\.api		--	gen_context(system_u:object_r:textrel_shlib_t,s0)


### PR DESCRIPTION
In libraries.fc:

- `(/.*?)` is very likely a misspelling for `(/.*)?`
- `sidecars/*` with `--` as file type is very likely a misspelling for `sidecars/.+`, in order to match files that are shared libraries.
- `/opt/netbeans(.*/)?jdk` matches `/opt/netbeansjdk`, which is buggy.

In Apache NetBeans 11.1 downloaded from https://netbeans.apache.org/download/nb111/nb111.html, there are files such as `profiler/lib/deployed/jdk16/linux-amd64/libprofilerinterface.so`.
Several websites document installing NetBeans in directories such as `/opt/netbeans-11.1/`, so the installed `.so` files are probably installed in `/opt/netbeans-11.1/profiler/lib/deployed/jdk16/linux-amd64/libprofilerinterface.so`.
There is thus an issue with the current pattern:

    /opt/netbeans(.*/)?jdk.*/linux/.+\.so(\.[^/]*)*

This pattern requires `/linux/` in the path, not `/linux-amd64/`.

As this pattern was introduced in 2007 by commit 02d968c58148 ("trunk: several fc updates from dan."), consider it as outdated and remove it.

If the `.so` files in `/opt/netbeans/` really need a label such as `textrel_shlib_t`, a file pattern will need to be written with less issues than the one which is removed.