### PR TITLE
java: remove unnecessary parentheses in pattern

### DIFF
--- a/policy/modules/apps/java.fc
+++ b/policy/modules/apps/java.fc
@@ -24,7 +24,7 @@ HOME_DIR/\.java(/.*)?	gen_context(system_u:object_r:java_home_t,s0)
 /usr/lib/eclipse/eclipse	--	gen_context(system_u:object_r:java_exec_t,s0)
 /usr/lib/icedtea[0-9]+/bin/.*	--	gen_context(system_u:object_r:java_exec_t,s0)
 /usr/lib/icedtea[0-9]+/jre/bin/.*	--	gen_context(system_u:object_r:java_exec_t,s0)
-/usr/lib/jvm/java(.*/)bin(/.*)?	--	gen_context(system_u:object_r:java_exec_t,s0)
+/usr/lib/jvm/java.*/bin(/.*)?	--	gen_context(system_u:object_r:java_exec_t,s0)
 /usr/lib/opera(/.*)?/opera	--	gen_context(system_u:object_r:java_exec_t,s0)
 /usr/lib/opera(/.*)?/works	--	gen_context(system_u:object_r:java_exec_t,s0)
 


### PR DESCRIPTION
`/usr/lib/jvm/java(.*/)bin(/.*)?` uses misleading parentheses around `.*/`. In some cases, a pattern with `(.*/)` is a misspelling to `(.*/)?`, but not here (`/usr/lib/jvm/javabin/` never exists).

Moreover, using `.*` here is right, as the pattern matches the content of subdirectories of `/usr/lib/jvm/` which names are prefixed by `java`. More precisely, the pattern matches for example:

- programs in `/usr/lib/jvm/java-10-openjdk/bin`
- programs in `/usr/lib/jvm/java-8-openjdk/jre/bin`

In the end, the pattern does not have any error, but the parentheses are misleading. Remove them.