### PR TITLE
cups: add a slash to match /opt/brother/Printers/

### DIFF
--- a/policy/modules/services/cups.fc
+++ b/policy/modules/services/cups.fc
@@ -18,7 +18,7 @@
 
 /etc/printcap.*	--	gen_context(system_u:object_r:cupsd_rw_etc_t,s0)
 
-/opt/brother/Printers(.*/)?inf(/.*)?	gen_context(system_u:object_r:cupsd_rw_etc_t,s0)
+/opt/brother/Printers/(.*/)?inf(/.*)?	gen_context(system_u:object_r:cupsd_rw_etc_t,s0)
 /opt/gutenprint/ppds(/.*)?	gen_context(system_u:object_r:cupsd_rw_etc_t,s0)
 
 /usr/bin/hp-[^/]+	--	gen_context(system_u:object_r:hplip_exec_t,s0)

--- a/policy/modules/services/cups.fc
+++ b/policy/modules/services/cups.fc
@@ -18,7 +18,7 @@
 
 /etc/printcap.*	--	gen_context(system_u:object_r:cupsd_rw_etc_t,s0)
 
-/opt/brother/Printers/(.*/)?inf(/.*)?	gen_context(system_u:object_r:cupsd_rw_etc_t,s0)
+/opt/brother/Printers/([^/]+/)?inf(/.*)?	gen_context(system_u:object_r:cupsd_rw_etc_t,s0)
 /opt/gutenprint/ppds(/.*)?	gen_context(system_u:object_r:cupsd_rw_etc_t,s0)
 
 /usr/bin/hp-[^/]+	--	gen_context(system_u:object_r:hplip_exec_t,s0)


### PR DESCRIPTION
The pattern `/opt/brother/Printers(.*/)?inf(/.*)?` matches the content of directories such as `/opt/brother/Printersinf/`, which seems buggy. On several systems, `/opt/brother/Printers/` is a directory that contains directories named as printer models.

Add a `/` before `(.*/)?` in order to make sure subdirectories of `/opt/brother/Printers` named `inf` are matched by the pattern.