### PR TITLE
Upgrade Vagrant VM to Fedora 30 and add a Debian 10 VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,41 +6,46 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure("2") do |config|
-  # build a Fedora 24 VM
-  config.vm.box = "bento/fedora-24"
-  # assign a nice hostname
-  config.vm.hostname = "selinux-devel"
-  # give it a private internal IP address
-  config.vm.network "private_network", type: "dhcp"
+  # build a Fedora 30 VM
+  config.vm.define "fedora" do |fedora|
+    fedora.vm.box = "fedora/30-cloud-base"
+    # assign a nice hostname
+    fedora.vm.hostname = "selinux-fedora-devel"
+    # give it a private internal IP address
+    fedora.vm.network "private_network", type: "dhcp"
 
-  config.vm.provider "virtualbox" do |vb|
-    # Customize the amount of memory on the VM:
-    vb.memory = "1024"
+    # Customize the amount of memory on the VM
+    fedora.vm.provider "virtualbox" do |vb|
+      vb.memory = 1024
+    end
+    fedora.vm.provider "libvirt" do |lv|
+      lv.memory = 1024
+    end
+
+    # Enable provisioning with a shell script. Additional provisioners such as
+    # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+    # documentation for more information about their specific syntax and use.
+    fedora.vm.provision "shell", run: "once", inline: <<-SHELL
+      # get the man pages
+      echo "Upgrading DNF and installing man pages..."
+      dnf install -q -y man-pages >/dev/null
+      dnf upgrade -q -y dnf >/dev/null
+
+      # install a few packages to make this machine ready to go out of the box
+      echo "Installing SELinux dev dependencies..."
+      dnf install -q -y \
+        bash-completion \
+        man-pages \
+        vim \
+        make \
+        kernel-devel \
+        selinux-policy-devel \
+        libselinux-python3 \
+        >/dev/null
+
+      # we set to permissive to allow loading and working with reference policy as opposed to fedora's fork
+      echo "Setting SELinux to Permissive Mode..."
+      setenforce 0
+    SHELL
   end
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  config.vm.provision "shell", run: "once", inline: <<-SHELL
-    # get the man pages
-    echo "Upgrading DNF and installing man pages..."
-    dnf install -q -y man-pages >/dev/null
-    dnf upgrade -q -y dnf >/dev/null
-
-    # install a few packages to make this machine ready to go out of the box
-    echo "Installing SELinux dev dependencies..."
-    dnf install -q -y \
-      bash-completion \
-      man-pages \
-      vim \
-      make \
-      kernel-devel \
-      selinux-policy-devel \
-      libselinux-python3 \
-      >/dev/null
-
-    # we set to permissive to allow loading and working with reference policy as opposed to fedora's fork
-    echo "Setting SELinux to Permissive Mode..."
-    setenforce 0
-  SHELL
 end


### PR DESCRIPTION
When debugging issues on Debian's policy, it is useful to have a minimal Debian install in a virtual machine. Vagrant provides a straightforward way of configuring such a virtual machine, using base images and provisioning scripts.

There were already a `Vagrantfile` in the repository with Fedora 24. This PR updates it to Fedora 30 and adds a machine for Debian.

For you information, I have been using a VM to help packaging SELinux tools and test refpolicy on Arch Linux for 3.5 years. My configuration of this machine is available on https://github.com/archlinuxhardened/selinux/tree/master/_vagrant.