### PR TITLE
ntp: allow systemd-timesyncd to read network status

### DIFF
--- a/policy/modules/services/ntp.te
+++ b/policy/modules/services/ntp.te
@@ -156,6 +156,8 @@ ifdef(`init_systemd',`
 
 	# for /run/systemd/netif/links
 	systemd_list_networkd_runtime(ntpd_t)
+	# for /run/systemd/netif/state
+	systemd_read_networkd_runtime(ntpd_t)
 
 	optional_policy(`
 		chronyd_enabledisable(ntpd_t)


### PR DESCRIPTION
`systemd-timesyncd` uses `network_is_online()` [1], which calls `sd_network_get_operational_state()` [2], which reads `/run/systemd/netif/state` [3]:
```C
    r = parse_env_file(NULL, "/run/systemd/netif/state", "OPER_STATE", &s);
```
On a Debian virtual machine created with Vagrant, `/run/systemd/netif/state` contains:
```sh
# This is private data. Do not parse.
OPER_STATE=routable
DNS=192.168.121.1 172.28.128.1
```
`systemd-timesyncd`'s access produces the following logs:

    type=AVC msg=audit(1567359197.660:323): avc:  denied  { read } for
    pid=230 comm="systemd-timesyn" name="state" dev="tmpfs" ino=24564
    scontext=system_u:system_r:ntpd_t
    tcontext=system_u:object_r:systemd_networkd_var_run_t tclass=file
    permissive=1

    type=AVC msg=audit(1567359197.660:324): avc:  denied  { open } for
    pid=230 comm="systemd-timesyn" path="/run/systemd/netif/state"
    dev="tmpfs" ino=24564 scontext=system_u:system_r:ntpd_t
    tcontext=system_u:object_r:systemd_networkd_var_run_t tclass=file
    permissive=1

    type=AVC msg=audit(1567359197.660:325): avc:  denied  { getattr }
    for  pid=230 comm="systemd-timesyn" path="/run/systemd/netif/state"
    dev="tmpfs" ino=24564 scontext=system_u:system_r:ntpd_t
    tcontext=system_u:object_r:systemd_networkd_var_run_t tclass=file
    permissive=1

Allow these accesses.

[1] https://github.com/systemd/systemd/blob/v242/src/timesync/timesyncd.c#L158
[2] https://github.com/systemd/systemd/blob/v242/src/libsystemd/sd-network/network-util.c#L13
[3] https://github.com/systemd/systemd/blob/v242/src/libsystemd/sd-network/sd-network.c#L27