### PR TITLE
portage: really make consoletype module optional

### DIFF
--- a/policy/modules/admin/portage.te
+++ b/policy/modules/admin/portage.te
@@ -130,14 +130,16 @@ miscfiles_read_localization(gcc_config_t)
 
 userdom_use_user_terminals(gcc_config_t)
 
-consoletype_exec(gcc_config_t)
-
 ifdef(`distro_gentoo',`
 	init_exec_rc(gcc_config_t)
 ')
 
 tunable_policy(`portage_use_nfs',`
 	fs_read_nfs_files(gcc_config_t)
+')
+
+optional_policy(`
+	consoletype_exec(gcc_config_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
All callers of `consoletype_exec()` put it in an `optional_policy()` block but `portage`. This makes `consoletype` module mandatory when module `portage` is loaded, even when `consoletype` is not installed.

Fix this issue by introducing an `optional_policy()` block.