### PR TITLE
Label programs in /usr/bin like /usr/sbin

### DIFF
--- a/policy/modules/services/hostapd.fc
+++ b/policy/modules/services/hostapd.fc
@@ -1,3 +1,5 @@
+/usr/bin/hostapd                --      gen_context(system_u:object_r:hostapd_exec_t,s0)
+
 /usr/sbin/hostapd               --      gen_context(system_u:object_r:hostapd_exec_t,s0)
 
 /var/run/hostapd(/.*)?          gen_context(system_u:object_r:hostapd_var_run_t,s0)

--- a/policy/modules/services/knot.fc
+++ b/policy/modules/services/knot.fc
@@ -4,6 +4,9 @@
 
 /run/knot(/.*)?			gen_context(system_u:object_r:knot_runtime_t,s0)
 
+/usr/bin/knotc		--	gen_context(system_u:object_r:knotc_exec_t,s0)
+/usr/bin/knotd		--	gen_context(system_u:object_r:knotd_exec_t,s0)
+
 /usr/sbin/knotc		--      gen_context(system_u:object_r:knotc_exec_t,s0)
 /usr/sbin/knotd		--	gen_context(system_u:object_r:knotd_exec_t,s0)
 

--- a/policy/modules/services/tpm2.fc
+++ b/policy/modules/services/tpm2.fc
@@ -1,3 +1,5 @@
+/usr/bin/tpm2-abrmd								--	gen_context(system_u:object_r:tpm2_abrmd_exec_t,s0)
+
 /usr/sbin/tpm2-abrmd								--	gen_context(system_u:object_r:tpm2_abrmd_exec_t,s0)
 
 /usr/lib/systemd/system/[^/]*tpm2-abrmd\.service	--	gen_context(system_u:object_r:tpm2_abrmd_unit_t,s0)


### PR DESCRIPTION
Some recent modifications added patterns in `.fc` files for programs in `/usr/sbin` without adding the patterns for `/usr/bin`. On Arch Linux, where `/usr/sbin` is a symlink to `/usr/bin`, such patterns are never matched.

Add the missing patterns.