### PR TITLE
apt: allow transition from apt_t to dpkg_t with NNP

### DIFF
--- a/policy/modules/admin/apt.te
+++ b/policy/modules/admin/apt.te
@@ -148,7 +148,7 @@ optional_policy(`
 
 optional_policy(`
 	dpkg_read_db(apt_t)
-	dpkg_domtrans(apt_t)
+	dpkg_nnp_domtrans(apt_t)
 	dpkg_lock_db(apt_t)
 ')
 


### PR DESCRIPTION
On a Debian 10 virtual machine, when running `apt-get update`, the following messages are logged to `audit.log`, several times:

    type=AVC msg=audit(1567717969.162:1639): avc:  denied  {
    nnp_transition } for  pid=5538 comm="apt-config"
    scontext=sysadm_u:sysadm_r:apt_t tcontext=sysadm_u:sysadm_r:dpkg_t
    tclass=process2 permissive=0

    type=SELINUX_ERR msg=audit(1567717969.162:1639):
    op=security_bounded_transition seresult=denied
    oldcontext=sysadm_u:sysadm_r:apt_t
    newcontext=sysadm_u:sysadm_r:dpkg_t

    type=SYSCALL msg=audit(1567717969.162:1639): arch=c000003e
    syscall=59 success=yes exit=0 a0=55ebb33d7780 a1=55ebb33ed610
    a2=7ffedd210980 a3=0 items=0 ppid=5537 pid=5538 auid=1000 uid=100
    gid=65534 euid=100 suid=100 fsuid=100 egid=65534 sgid=65534
    fsgid=65534 tty=(none) ses=45 comm="dpkg" exe="/usr/bin/dpkg"
    subj=sysadm_u:sysadm_r:apt_t key=(null)

    type=PROCTITLE msg=audit(1567717969.162:1639):
    proctitle=2F7573722F62696E2F64706B67002D2D7072696E742D666F726569676E2D61726368697465637475726573

According to `strace`, this occurs when sub-commands like `apt-config shell MASTER_KEYRING APT::Key::MasterKeyring` execute `/usr/bin/dpkg --print-foreign-architectures`.