### PR TITLE
apt: allow preventing shutdown by calling a systemd-logind D-Bus method

### DIFF
--- a/policy/modules/admin/apt.te
+++ b/policy/modules/admin/apt.te
@@ -142,6 +142,10 @@ optional_policy(`
 	')
 
 	optional_policy(`
+		systemd_dbus_chat_logind(apt_t)
+	')
+
+	optional_policy(`
 		unconfined_dbus_send(apt_t)
 	')
 ')


### PR DESCRIPTION
Since `apt` 1.8.1 (more precisely since commit https://salsa.debian.org/apt-team/apt/commit/60cc44d160af02c49614653c97bfa3e4e5c9601d), `apt` calls D-Bus method `Inhibit` of interface `org.freedesktop.login1.Manager` in order to prevent a shutdown from happening while installing software.

The call from `apt` to `systemd-logind` was already allowed through `unconfined_dbus_send(apt_t)`, but not the reply, which triggered the following audit log:

    type=USER_AVC msg=audit(1567780304.196:651): pid=287 uid=105
    auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t
    msg='avc:  denied  { send_msg } for msgtype=method_return
    dest=:1.137 spid=290 tpid=29557
    scontext=system_u:system_r:systemd_logind_t
    tcontext=sysadm_u:sysadm_r:apt_t tclass=dbus permissive=0
    exe="/usr/bin/dbus-daemon" sauid=105 hostname=? addr=? terminal=?'