### PR TITLE
authlogin: label utempter correctly on Debian

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -15,7 +15,7 @@
 
 /usr/kerberos/sbin/login\.krb5 -- gen_context(system_u:object_r:login_exec_t,s0)
 
-/usr/lib/utempter/utempter --	gen_context(system_u:object_r:utempter_exec_t,s0)
+/usr/lib/([^/]+/)?utempter/utempter --	gen_context(system_u:object_r:utempter_exec_t,s0)
 
 /usr/sbin/pam_console_apply	--	gen_context(system_u:object_r:pam_console_exec_t,s0)
 /usr/sbin/pam_timestamp_check	--	gen_context(system_u:object_r:pam_exec_t,s0)


### PR DESCRIPTION
When starting `tmux` on Debian, the following audit log appears:

    type=AVC msg=audit(1567781766.314:820): avc:  denied  {
    execute_no_trans } for  pid=6686 comm=746D75783A20736572766572
    path="/usr/lib/x86_64-linux-gnu/utempter/utempter" dev="vda1"
    ino=545302 scontext=sysadm_u:sysadm_r:sysadm_screen_t
    tcontext=system_u:object_r:lib_t tclass=file permissive=0

`/usr/lib/x86_64-linux-gnu/utempter/utempter` is indeed labeled as `system_u:object_r:lib_t`, which is wrong.