### PR TITLE
irc: add WeeChat policy

### DIFF
--- a/policy/modules/apps/irc.fc
+++ b/policy/modules/apps/irc.fc
@@ -1,5 +1,6 @@
 HOME_DIR/\.ircmotd	--	gen_context(system_u:object_r:irc_home_t,s0)
 HOME_DIR/\.irssi(/.*)?	gen_context(system_u:object_r:irc_home_t,s0)
+HOME_DIR/\.weechat(/.*)?	gen_context(system_u:object_r:irc_home_t,s0)
 HOME_DIR/irclogs(/.*)?	gen_context(system_u:object_r:irc_log_home_t,s0)
 
 /etc/irssi\.conf	--	gen_context(system_u:object_r:irc_conf_t,s0)
@@ -8,3 +9,4 @@ HOME_DIR/irclogs(/.*)?	gen_context(system_u:object_r:irc_log_home_t,s0)
 /usr/bin/ircII	--	gen_context(system_u:object_r:irc_exec_t,s0)
 /usr/bin/irssi	--	gen_context(system_u:object_r:irc_exec_t,s0)
 /usr/bin/tinyirc	--	gen_context(system_u:object_r:irc_exec_t,s0)
+/usr/bin/weechat	--	gen_context(system_u:object_r:irc_exec_t,s0)

--- a/policy/modules/apps/irc.te
+++ b/policy/modules/apps/irc.te
@@ -44,8 +44,9 @@ userdom_user_tmp_file(irc_tmp_t)
 # Local policy
 #
 
-allow irc_t self:process { signal sigkill };
+allow irc_t self:process { getsched signal sigkill };
 allow irc_t self:fifo_file rw_fifo_file_perms;
+allow irc_t self:unix_dgram_socket create_socket_perms;
 allow irc_t self:unix_stream_socket { accept listen };
 
 allow irc_t irc_conf_t:file read_file_perms;
@@ -54,10 +55,12 @@ can_exec(irc_t, irc_exec_t)
 corecmd_search_bin(irc_t)
 
 manage_dirs_pattern(irc_t, irc_home_t, irc_home_t)
+manage_fifo_files_pattern(irc_t, irc_home_t, irc_home_t)
 manage_files_pattern(irc_t, irc_home_t, irc_home_t)
 manage_lnk_files_pattern(irc_t, irc_home_t, irc_home_t)
 userdom_user_home_dir_filetrans(irc_t, irc_home_t, dir, ".irssi")
 userdom_user_home_dir_filetrans(irc_t, irc_home_t, file, ".ircmotd")
+userdom_user_home_dir_filetrans(irc_t, irc_home_t, dir, ".weechat")
 
 manage_dirs_pattern(irc_t, irc_log_home_t, irc_log_home_t)
 create_files_pattern(irc_t, irc_log_home_t, irc_log_home_t)
@@ -71,6 +74,8 @@ manage_fifo_files_pattern(irc_t, irc_tmp_t, irc_tmp_t)
 manage_sock_files_pattern(irc_t, irc_tmp_t, irc_tmp_t)
 files_tmp_filetrans(irc_t, irc_tmp_t, { file dir lnk_file sock_file fifo_file })
 
+# For /proc/sys/crypto/fips_enabled
+kernel_read_crypto_sysctls(irc_t)
 kernel_read_system_state(irc_t)
 
 corenet_all_recvfrom_unlabeled(irc_t)


### PR DESCRIPTION
WeeChat is an extensible IRC client: https://weechat.org/

* Label WeeChat program and configuration files like other IRC clients
* Allow WeeChat to create a pipe in `~/.weechat/weechat_fifo`
* Allow WeeChat to read `/proc/sys/crypto/fips_enabled`
* Allow WeeChat to use a Unix datagram socket with its forked children
* Allow other accesses