### PR TITLE
systemd: allow systemd --user to receive messages from netlink_kobject_uevent_socket

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1155,7 +1155,7 @@ dontaudit systemd_user_session_type self:capability dac_override;
 allow systemd_user_session_type self:process setfscreate;
 allow systemd_user_session_type self:udp_socket create_socket_perms;
 allow systemd_user_session_type self:unix_stream_socket create_stream_socket_perms;
-allow systemd_user_session_type self:netlink_kobject_uevent_socket { bind create getattr setopt };
+allow systemd_user_session_type self:netlink_kobject_uevent_socket { bind create getattr read setopt };
 
 allow systemd_user_session_type systemd_user_runtime_t:dir manage_dir_perms;
 allow systemd_user_session_type systemd_user_runtime_t:sock_file { create write };


### PR DESCRIPTION
When bringing up a Wireguard interface with `wg-quick up wg0` from a `sysadm_u:sysadm_r:sysadm_t` session, `systemd --user` spams the logs with this event repeated between 100 and 200 times per second:

    type=AVC msg=audit(1567798007.591:138076): avc:  denied  { read }
    for  pid=711 comm="systemd"
    scontext=sysadm_u:sysadm_r:sysadm_systemd_t
    tcontext=sysadm_u:sysadm_r:sysadm_systemd_t
    tclass=netlink_kobject_uevent_socket permissive=0