### PR TITLE
Add a policy module for WireGuard VPN

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1237,6 +1237,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	wireguard_admin(sysadm_t, sysadm_r)
+	wireguard_run(sysadm_t, sysadm_r)
+')
+
+optional_policy(`
 	wireshark_role(sysadm_r, sysadm_t)
 ')
 

--- a/policy/modules/services/wireguard.fc
+++ b/policy/modules/services/wireguard.fc
@@ -1,0 +1,8 @@
+/etc/wireguard(/.*)?		gen_context(system_u:object_r:wireguard_etc_t,s0)
+
+/run/wireguard(/.*)?		gen_context(system_u:object_r:wireguard_runtime_t,s0)
+
+/usr/bin/wg		--	gen_context(system_u:object_r:wireguard_exec_t,s0)
+/usr/bin/wg-quick	--	gen_context(system_u:object_r:wireguard_exec_t,s0)
+
+/usr/lib/systemd/system/wg-quick.*\.service	--	gen_context(system_u:object_r:wireguard_unit_t,s0)

--- a/policy/modules/services/wireguard.if
+++ b/policy/modules/services/wireguard.if
@@ -1,0 +1,77 @@
+## <summary>WireGuard VPN.</summary>
+
+########################################
+## <summary>
+##	Execute WireGuard in the wireguard domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`wireguard_domtrans',`
+	gen_require(`
+		type wireguard_t, wireguard_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, wireguard_exec_t, wireguard_t)
+')
+
+########################################
+## <summary>
+##	Execute WireGuard in the wireguard domain, and
+##	allow the specified role the wireguard domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`wireguard_run',`
+	gen_require(`
+		attribute_role wireguard_roles;
+	')
+
+	wireguard_domtrans($1)
+	roleattribute $2 wireguard_roles;
+')
+
+########################################
+## <summary>
+##	All of the rules required to
+##	administrate a WireGuard
+##	environment.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`wireguard_admin',`
+	gen_require(`
+		type wireguard_t, wireguard_etc_t, wireguard_initrc_exec_t, wireguard_unit_t;
+	')
+
+	admin_process_pattern($1, wireguard_t)
+
+	init_startstop_service($1, $2, wireguard_t, wireguard_initrc_exec_t, wireguard_unit_t)
+
+	files_search_etc($1)
+	admin_pattern($1, wireguard_etc_t)
+')

--- a/policy/modules/services/wireguard.te
+++ b/policy/modules/services/wireguard.te
@@ -1,0 +1,72 @@
+policy_module(wireguard, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+attribute_role wireguard_roles;
+roleattribute system_r wireguard_roles;
+
+type wireguard_t;
+type wireguard_exec_t;
+init_system_domain(wireguard_t, wireguard_exec_t)
+role wireguard_roles types wireguard_t;
+
+type wireguard_etc_t;
+files_config_file(wireguard_etc_t)
+
+type wireguard_initrc_exec_t;
+init_unit_file(wireguard_initrc_exec_t)
+
+type wireguard_runtime_t;
+files_pid_file(wireguard_runtime_t)
+
+type wireguard_unit_t;
+init_unit_file(wireguard_unit_t)
+
+type wireguard_tmp_t;
+files_tmp_file(wireguard_tmp_t)
+
+########################################
+#
+# Local policy
+#
+
+allow wireguard_t self:capability net_admin;
+allow wireguard_t self:process getsched;
+
+allow wireguard_t self:fifo_file rw_fifo_file_perms;
+allow wireguard_t self:netlink_generic_socket create_socket_perms;
+allow wireguard_t self:netlink_route_socket r_netlink_socket_perms;
+allow wireguard_t self:udp_socket create_socket_perms;
+allow wireguard_t self:unix_stream_socket create_socket_perms;
+
+manage_files_pattern(wireguard_t, wireguard_etc_t, wireguard_etc_t);
+files_read_etc_files(wireguard_t)
+
+manage_files_pattern(wireguard_t, wireguard_runtime_t, wireguard_runtime_t)
+files_pid_filetrans(wireguard_t, wireguard_runtime_t, dir)
+
+manage_dirs_pattern(wireguard_t, wireguard_tmp_t, wireguard_tmp_t)
+manage_files_pattern(wireguard_t, wireguard_tmp_t, wireguard_tmp_t)
+files_tmp_filetrans(wireguard_t, wireguard_tmp_t, file)
+
+# wg-quick can execute wg
+can_exec(wireguard_t, wireguard_exec_t)
+
+# wg-quick is a shell script
+corecmd_exec_bin(wireguard_t)
+corecmd_exec_shell(wireguard_t)
+
+domain_use_interactive_fds(wireguard_t)
+
+# wg-quick tries to read /proc/filesystem when running "stat" and "mv" commands
+kernel_dontaudit_read_system_state(wireguard_t)
+
+miscfiles_read_localization(wireguard_t)
+
+# wg-quick runs /usr/bin/ip to configure the network
+sysnet_run_ifconfig(wireguard_t, wireguard_roles)
+
+userdom_use_user_terminals(wireguard_t)


### PR DESCRIPTION
WireGuard is a fast, modern, secure VPN tunnel, according to https://www.wireguard.com/. In order to install it, the mostly documented way consists in building and installing an out-of-tree kernel module and using userland tools to configure this module (`wg` and `wg-quick`).

* WireGuard is like `ip`: the userland tool communicates with the kernel module through a netlink socket.

* WireGuard is like `iptables`: there is no daemon, but some distributions ship systemd units that restores a WireGuard configuration when started.

* WireGuard is like other services: its configuration files are in `/etc` and it can use `/run` and `/tmp`.

Create a new policy module which handles all of this.