### PR TITLE
modutils: make installing DKMS package work on Debian

### DIFF
--- a/policy/modules/system/modutils.te
+++ b/policy/modules/system/modutils.te
@@ -135,6 +135,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	apt_use_fds(kmod_t)
+	apt_use_ptys(kmod_t)
+')
+
+optional_policy(`
 	# for postinst of a new kernel package
 	dpkg_manage_script_tmp_files(kmod_t)
 	dpkg_map_script_tmp_files(kmod_t)

--- a/policy/modules/system/modutils.te
+++ b/policy/modules/system/modutils.te
@@ -90,6 +90,7 @@ domain_signal_all_domains(kmod_t)
 domain_use_interactive_fds(kmod_t)
 
 files_read_kernel_modules(kmod_t)
+files_read_kernel_symbol_table(kmod_t)
 files_read_etc_runtime_files(kmod_t)
 files_read_etc_files(kmod_t)
 files_read_usr_files(kmod_t)


### PR DESCRIPTION
When installing `wireguard-dkms` on Debian 10 (with refpolicy `master` in enforcing mode), `apt` encountered a fatal error when configuring WireGuard's kernel module, because it was not allowed to read `/boot/System.map-4.19.0-5-amd64`.

Moreover, `depmod` and `modprobe` were not allowed to use the pseudo-tty provided by `apt` when these commands are run when installing software.

Here are two commits that fix these issues.