### PR TITLE
systemd: allow systemd-modules-load.service to read sysfs

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -626,6 +626,8 @@ optional_policy(`
 kernel_load_module(systemd_modules_load_t)
 kernel_request_load_module(systemd_modules_load_t)
 
+dev_read_sysfs(systemd_modules_load_t)
+
 files_read_etc_files(systemd_modules_load_t)
 
 modutils_read_module_config(systemd_modules_load_t)


### PR DESCRIPTION
`systemd-modules-load.service` needs to read file `/sys/module/${MODULE}/initstate` for each `${MODULE}` defined in `/etc/modules-load.d/`. These files are labeled `sysfs_t`.

This fixes:

    type=AVC msg=audit(1567804818.331:138713): avc:  denied  { read }
    for  pid=31153 comm="systemd-modules" name="initstate" dev="sysfs"
    ino=14778 scontext=system_u:system_r:systemd_modules_load_t
    tcontext=system_u:object_r:sysfs_t tclass=file permissive=0