### PR TITLE
sudo: allow using use_pty flag

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -131,10 +131,12 @@ template(`sudo_role_template',`
 
 	userdom_spec_domtrans_all_users($1_sudo_t)
 	userdom_create_all_users_keys($1_sudo_t)
+	userdom_create_user_pty($1_sudo_t)
 	userdom_manage_user_home_content_files($1_sudo_t)
 	userdom_manage_user_home_content_symlinks($1_sudo_t)
 	userdom_manage_user_tmp_files($1_sudo_t)
 	userdom_manage_user_tmp_symlinks($1_sudo_t)
+	userdom_setattr_user_ptys($1_sudo_t)
 	userdom_use_user_terminals($1_sudo_t)
 	# for some PAM modules and for cwd
 	userdom_dontaudit_search_user_home_content($1_sudo_t)


### PR DESCRIPTION
When `/etc/sudoers` contains `Defaults use_pty`, `sudo` creates a new pseudo-pty when running a command. This is currently denied from a `sysadm_u` session:

    type=AVC msg=audit(1567807315.843:13300): avc:  denied  { read write
    } for  pid=5053 comm="sudo" name="ptmx" dev="devtmpfs" ino=1108
    scontext=sysadm_u:sysadm_r:sysadm_sudo_t
    tcontext=system_u:object_r:ptmx_t tclass=chr_file permissive=0

As it seems logical for the newly-created pty to be labeled `user_devpts_t`, use `userdom_create_user_pty()` to allow this.

Then, a new denial appears:

    type=AVC msg=audit(1567808670.441:13341): avc:  denied  { setattr }
    for  pid=30256 comm="sudo" name="9" dev="devpts" ino=12
    scontext=sysadm_u:sysadm_r:sysadm_sudo_t
    tcontext=sysadm_u:object_r:user_devpts_t tclass=chr_file
    permissive=0

    type=SYSCALL msg=audit(1567808670.441:13341): arch=c000003e
    syscall=92 success=no exit=-13 a0=563c5aac5f80 a1=0 a2=5
    a3=fffffffffffff874 items=0 ppid=20934 pid=30256 auid=1000 uid=0
    gid=1000 euid=0 suid=0 fsuid=0 egid=1000 sgid=1000 fsgid=1000
    tty=pts4 ses=687 comm="sudo" exe="/usr/bin/sudo"
    subj=sysadm_u:sysadm_r:sysadm_sudo_t key=(null)

On x86-64, syscall 92 is `chown()`. Allow this access with `userdom_setattr_user_ptys()`.