### PR TITLE
ulogd: adjust policy for Debian

### DIFF
--- a/policy/modules/services/ulogd.te
+++ b/policy/modules/services/ulogd.te
@@ -36,6 +36,7 @@ logging_log_file(ulogd_var_log_t)
 # a rule allowing dac_read_search if you encounter this, but fix your system.
 allow ulogd_t self:capability { net_admin setgid setuid sys_nice };
 allow ulogd_t self:process setsched;
+allow ulogd_t self:fifo_file rw_fifo_file_perms;
 allow ulogd_t self:netlink_netfilter_socket create_socket_perms;
 allow ulogd_t self:netlink_nflog_socket create_socket_perms;
 allow ulogd_t self:netlink_socket create_socket_perms;
@@ -64,6 +65,17 @@ logging_send_syslog_msg(ulogd_t)
 miscfiles_read_localization(ulogd_t)
 
 sysnet_dns_name_resolve(ulogd_t)
+
+ifdef(`init_systemd', `
+	# For /run/systemd/dynamic-uid/
+	init_list_pids(ulogd_t)
+
+	optional_policy(`
+		dbus_system_bus_client(ulogd_t)
+		# For GetDynamicUser() of org.freedesktop.systemd1.Manager
+		init_dbus_chat(ulogd_t)
+	')
+')
 
 optional_policy(`
 	mysql_stream_connect(ulogd_t)


### PR DESCRIPTION
On a Debian 10 system, I saw denials for `ulogd` service:

It uses a pipe with itself:

    type=AVC msg=audit(1567874422.328:13744): avc:  denied  { write }
    for pid=11416 comm="ulogd" path="pipe:[29006]" dev="pipefs"
    ino=29006 scontext=system_u:system_r:ulogd_t
    tcontext=system_u:system_r:ulogd_t tclass=fifo_file permissive=0

It enumerates users in `/run/systemd/dynamic-uid/` when changing to the `ulog` user (which is not dynamic):

    type=AVC msg=audit(1567874512.576:13748): avc:  denied  { read } for
    pid=18290 comm="ulogd" name="dynamic-uid" dev="tmpfs" ino=16527
    scontext=system_u:system_r:ulogd_t
    tcontext=system_u:object_r:init_var_run_t tclass=dir permissive=0

It connects to the system D-Bus socket in order to call `GetDynamicUser`:

    type=AVC msg=audit(1567875114.147:13761): avc:  denied  { write }
    for  pid=28135 comm="ulogd" name="system_bus_socket" dev="tmpfs"
    ino=13799 scontext=system_u:system_r:ulogd_t
    tcontext=system_u:object_r:system_dbusd_var_run_t tclass=sock_file
    permissive=1

    type=AVC msg=audit(1567875114.147:13761): avc:  denied  { connectto
    } for  pid=28135 comm="ulogd" path="/run/dbus/system_bus_socket"
    scontext=system_u:system_r:ulogd_t
    tcontext=system_u:system_r:system_dbusd_t tclass=unix_stream_socket
    permissive=1

    type=USER_AVC msg=audit(1567875276.683:13776): pid=432 uid=106
    auid=4294967295 ses=4294967295 subj=system_u:system_r:system_db
    usd_t msg='avc:  denied  { send_msg } for msgtype=method_call
    interface=org.freedesktop.systemd1.Manager member=GetDynamicUsers
    dest=org.freedesktop.systemd1 spid=30953 tpid=1
    scontext=system_u:system_r:ulogd_t tcontext=system_u:system_r:init_t
    tclass=dbus permissive=1  exe="/usr/bin/dbus-daemon" sauid=106
    hostname=? addr=? terminal=?'