### PR TITLE
bitlbee: allow using GetDynamicUser on Debian

### DIFF
--- a/policy/modules/services/bitlbee.te
+++ b/policy/modules/services/bitlbee.te
@@ -120,6 +120,17 @@ logging_send_syslog_msg(bitlbee_t)
 
 miscfiles_read_localization(bitlbee_t)
 
+ifdef(`init_systemd', `
+	# For /run/systemd/dynamic-uid/
+	init_list_pids(bitlbee_t)
+
+	optional_policy(`
+		dbus_system_bus_client(bitlbee_t)
+		# For GetDynamicUser() of org.freedesktop.systemd1.Manager
+		init_dbus_chat(bitlbee_t)
+	')
+')
+
 optional_policy(`
 	tcpd_wrapped_domain(bitlbee_t, bitlbee_exec_t)
 ')


### PR DESCRIPTION
On Debian 10, starting bitlbee daemon leads to:

    type=AVC msg=audit(1567941717.044:14204): avc:  denied  { search }
    for  pid=5704 comm="bitlbee" name="dbus" dev="tmpfs" ino=13798
    scontext=system_u:system_r:bitlbee_t
    tcontext=system_u:object_r:system_dbusd_var_run_t tclass=dir
    permissive=0

    type=AVC msg=audit(1567941717.044:14205): avc:  denied  { read } for
    pid=5704 comm="bitlbee" name="direct:64707" dev="tmpfs" ino=16529
    scontext=system_u:system_r:bitlbee_t
    tcontext=system_u:object_r:init_var_run_t tclass=lnk_file
    permissive=0

    type=AVC msg=audit(1567941756.020:14208): avc:  denied  { search }
    for  pid=6363 comm="bitlbee" name="dbus" dev="tmpfs" ino=13798
    scontext=system_u:system_r:bitlbee_t
    tcontext=system_u:object_r:system_dbusd_var_run_t tclass=dir
    permissive=0

    type=AVC msg=audit(1567941756.020:14209): avc:  denied  { read } for
    pid=6363 comm="bitlbee" name="direct:64707" dev="tmpfs" ino=16529
    scontext=system_u:system_r:bitlbee_t
    tcontext=system_u:object_r:init_var_run_t tclass=lnk_file
    permissive=0

    type=USER_AVC msg=audit(1567941770.492:14215): pid=432 uid=106
    auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t
    msg='avc:  denied  { send_msg } for msgtype=method_call
    interface=org.freedesktop.systemd1.Manager member=GetDynamicUsers
    dest=org.freedesktop.systemd1 spid=6694 tpid=1
    scontext=system_u:system_r:bitlbee_t
    tcontext=system_u:system_r:init_t tclass=dbus permissive=0
    exe="/usr/bin/dbus-daemon" sauid=106 hostname=? addr=? terminal=?'

All these denials are related to getting dynamic users through a D-Bus call to `GetDynamicUsers()` of interface `org.freedesktop.systemd1.Manager`.