### PR TITLE
chromium: remove distro-specific ifdef

### DIFF
--- a/policy/modules/apps/chromium.fc
+++ b/policy/modules/apps/chromium.fc
@@ -19,14 +19,11 @@
 /opt/google/chrome-unstable/nacl_helper_bootstrap	--	gen_context(system_u:object_r:chromium_naclhelper_exec_t,s0)
 /opt/google/chrome-unstable/libudev\.so\.0			gen_context(system_u:object_r:lib_t,s0)
 
-ifdef(`distro_debian',`
 /usr/lib/chromium/chromium				--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /usr/lib/chromium/chrome-sandbox			--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
-', `
 /usr/lib/chromium-browser/chrome			--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /usr/lib/chromium-browser/chrome_sandbox		--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
 /usr/lib/chromium-browser/chrome-sandbox		--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
-')
 /usr/lib/chromium-browser/chromium-launcher\.sh		--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /usr/lib/chromium-browser/nacl_helper_bootstrap		--	gen_context(system_u:object_r:chromium_naclhelper_exec_t,s0)
 


### PR DESCRIPTION
Arch Linux installs Chromium in `/usr/lib/chromium/` like Debian. Instead of adding a new ``ifdef(`distro_arch')`` block, remove the restriction in `chromium.fc`.