### PR TITLE
systemd-networkd: allow communicating with hostnamed

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -690,6 +690,8 @@ systemd_log_parse_environment(systemd_networkd_t)
 optional_policy(`
 	dbus_system_bus_client(systemd_networkd_t)
 	dbus_connect_system_bus(systemd_networkd_t)
+
+	systemd_dbus_chat_hostnamed(systemd_networkd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
When `systemd-netwokd` receives DHCP option 12 (hostname), it changes the hostname by calling method `SetHostname` from interface `org.freedesktop.hostname1` provided by `systemd-hostnamed`: https://github.com/systemd/systemd/blob/v243/src/network/networkd-manager.c#L1946

This access is currently denied and reported:

    type=USER_AVC msg=audit(1568403789.952:36): pid=288 uid=105
    auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t
    msg='avc:  denied  { send_msg } for msgtype=method_call
    interface=org.freedesktop.hostname1 member=SetHostname
    dest=org.freedesktop.hostname1 spid=233 tpid=317
    scontext=system_u:system_r:systemd_networkd_t
    tcontext=system_u:system_r:systemd_hostnamed_t tclass=dbus
    permissive=1  exe="/usr/bin/dbus-daemon" sauid=105 hostname=? addr=?
    terminal=?'