### PR TITLE
systemd-networkd: allow creating a generic netlink socket

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -642,6 +642,7 @@ systemd_log_parse_environment(systemd_modules_load_t)
 #
 
 allow systemd_networkd_t self:capability { chown dac_override fowner net_admin net_raw setgid setpcap setuid };
+allow systemd_networkd_t self:netlink_generic_socket create_socket_perms;
 allow systemd_networkd_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow systemd_networkd_t self:netlink_route_socket { create_socket_perms nlmsg_read nlmsg_write };
 allow systemd_networkd_t self:packet_socket create_socket_perms;


### PR DESCRIPTION
Since systemd 237 (commit https://github.com/systemd/systemd/commit/05d0c2e3cfb5aac8bc14b68a12a6c3ef3e88e3a3), `systemd-networkd` requires a generic netlink socket in order to start. Otherwise, it fails to start and systemd's journal contains:

    audit[19262]: AVC avc:  denied  { create } for  pid=19262
    comm="systemd-network" scontext=system_u:system_r:systemd_networkd_t
    tcontext=system_u:system_r:systemd_networkd_t
    tclass=netlink_generic_socket permissive=0

    audit[19262]: SYSCALL arch=c000003e syscall=41 success=no exit=-13
    a0=10 a1=80803 a2=10 a3=20 items=0 ppid=1 pid=19262 auid=4294967295
    uid=102 gid=103 euid=102 suid=102 fsuid=102 egid=103 sgid=103
    fsgid=103 tty=(none) ses=4294967295 comm="systemd-network"
    exe="/usr/lib/systemd/systemd-networkd"
    subj=system_u:system_r:systemd_networkd_t key=(null)

    audit: PROCTITLE proctitle="/lib/systemd/systemd-networkd"

    systemd-networkd[19262]: Could not create manager: Permission denied

For information, `syscall=41 a0=10 a1=80803 a2=10` means:

    socket(AF_NETLINK, SOCK_RAW|SOCK_CLOEXEC|SOCK_NONBLOCK, NETLINK_GENERIC);

... which matches the call to `sd_genl_socket_open(&m->genl);` in
https://github.com/systemd/systemd/blob/v243/src/network/networkd-manager.c#L1143