### PR TITLE
Allow sudo to transmit SIGWINCH

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -69,6 +69,9 @@ template(`sudo_role_template',`
 
 	allow $1_sudo_t $3:key search;
 
+	# Transmit SIGWINCH to children
+	allow $1_sudo_t $3:process signal;
+
 	# Enter this derived domain from the user domain
 	domtrans_pattern($3, sudo_exec_t, $1_sudo_t)
 

--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -52,7 +52,7 @@ template(`sudo_role_template',`
 	#
 
 	# Use capabilities.
-	allow $1_sudo_t self:capability { chown dac_override fowner setgid setuid sys_nice sys_resource };
+	allow $1_sudo_t self:capability { chown dac_override fowner kill setgid setuid sys_nice sys_resource };
 	allow $1_sudo_t self:process { signal_perms getsched setsched getsession getpgid setpgid getcap setcap share getattr getrlimit rlimitinh siginh transition setsockcreate dyntransition noatsecure setkeycreate };
 	allow $1_sudo_t self:process { setexec setrlimit };
 	allow $1_sudo_t self:fd use;


### PR DESCRIPTION
When resizing the X11 window of a terminal running `sudo` on a remote Debian 10 system (through `ssh`), `sudo` receives signal `SIGWINCH` and forwards it to its children.

Here are two commits in order to allow such forwarding in two cases:

* when `sudo` is used to gain `root` privileges from another user (which is associated with `sysadm_u`)
* and when `sudo` is used by `root` to get a shell as an unprivileged user.