### PR TITLE
systemd: allow detecting Windows Subsystem for Linux

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -245,6 +245,8 @@ files_search_var_lib(systemd_backlight_t)
 # Binfmt local policy
 #
 
+kernel_read_kernel_sysctls(systemd_binfmt_t)
+
 systemd_log_parse_environment(systemd_binfmt_t)
 
 # Allow to read /etc/binfmt.d/ files
@@ -256,6 +258,8 @@ fs_register_binary_executable_type(systemd_binfmt_t)
 #
 # GPT auto generator local policy
 #
+
+kernel_read_kernel_sysctls(systemd_gpt_generator_t)
 
 dev_read_sysfs(systemd_gpt_generator_t)
 files_list_usr(systemd_gpt_generator_t)
@@ -366,6 +370,8 @@ optional_policy(`
 #
 # hw local policy
 #
+
+kernel_read_kernel_sysctls(systemd_hw_t)
 
 allow systemd_hw_t systemd_hwdb_t:file { manage_file_perms relabelfrom relabelto };
 files_etc_filetrans(systemd_hw_t, systemd_hwdb_t, file)
@@ -624,6 +630,7 @@ optional_policy(`
 #
 
 kernel_load_module(systemd_modules_load_t)
+kernel_read_kernel_sysctls(systemd_modules_load_t)
 kernel_request_load_module(systemd_modules_load_t)
 
 dev_read_sysfs(systemd_modules_load_t)
@@ -930,6 +937,8 @@ manage_dirs_pattern(systemd_rfkill_t, systemd_rfkill_var_lib_t, systemd_rfkill_v
 manage_files_pattern(systemd_rfkill_t, systemd_rfkill_var_lib_t, systemd_rfkill_var_lib_t)
 init_var_lib_filetrans(systemd_rfkill_t, systemd_rfkill_var_lib_t, dir)
 
+kernel_read_kernel_sysctls(systemd_rfkill_t)
+
 dev_read_sysfs(systemd_rfkill_t)
 dev_rw_wireless(systemd_rfkill_t)
 
@@ -991,6 +1000,8 @@ allow systemd_sessions_t self:process setfscreate;
 
 allow systemd_sessions_t systemd_sessions_var_run_t:file manage_file_perms;
 files_pid_filetrans(systemd_sessions_t, systemd_sessions_var_run_t, file)
+
+kernel_read_kernel_sysctls(systemd_sessions_t)
 
 selinux_get_enforce_mode(systemd_sessions_t)
 selinux_get_fs_mount(systemd_sessions_t)
@@ -1142,6 +1153,8 @@ allow systemd_update_done_t systemd_update_run_t:file manage_file_perms;
 
 files_etc_filetrans(systemd_update_done_t, systemd_update_run_t, file)
 files_var_filetrans(systemd_update_done_t, systemd_update_run_t, file)
+
+kernel_read_kernel_sysctls(systemd_update_done_t)
 
 seutil_read_file_contexts(systemd_update_done_t)
 

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -406,6 +406,7 @@ files_read_usr_files(udevadm_t)
 init_list_pids(udevadm_t)
 init_read_state(udevadm_t)
 
+kernel_read_kernel_sysctls(udevadm_t)
 kernel_read_system_state(udevadm_t)
 
 seutil_read_file_contexts(udevadm_t)


### PR DESCRIPTION
Since systemd 242 (commit https://github.com/systemd/systemd/commit/6c8a2c679313f8283514923daf65f5e9d050d94c), systemd and its services read `/proc/sys/kernel/osrelease` in order to detect whether they are running in Microsoft's WSL (Windows Subsystem for Linux).

This leads to logs such as:

    type=AVC msg=audit(1568445663.990:10): avc:  denied  { read } for
    pid=401 comm="systemd-modules" name="osrelease" dev="proc" ino=13319
    scontext=system_u:system_r:systemd_modules_load_t
    tcontext=system_u:object_r:sysctl_kernel_t tclass=file permissive=1

    type=AVC msg=audit(1568445663.990:10): avc:  denied  { open } for
    pid=401 comm="systemd-modules" path="/proc/sys/kernel/osrelease"
    dev="proc" ino=13319
    scontext=system_u:system_r:systemd_modules_load_t
    tcontext=system_u:object_r:sysctl_kernel_t tclass=file permissive=1

    type=AVC msg=audit(1568445663.990:11): avc:  denied  { getattr } for
    pid=401 comm="systemd-modules" path="/proc/sys/kernel/osrelease"
    dev="proc" ino=13319
    scontext=system_u:system_r:systemd_modules_load_t
    tcontext=system_u:object_r:sysctl_kernel_t tclass=file permissive=1

Add `kernel_read_kernel_sysctls()` to services that read `/proc/sys/kernel/osrelease`. These services have been identified by running `grep osrelease < /var/log/audit/audit.log | audit2allow` on an Arch Linux test system.