### PR TITLE
newrole: allow newrole to use setcap to drop capabilities

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -226,7 +226,7 @@ optional_policy(`
 
 allow newrole_t self:capability { dac_override fowner setgid setuid };
 dontaudit newrole_t self:capability net_admin;
-allow newrole_t self:process setexec;
+allow newrole_t self:process { setcap setexec };
 allow newrole_t self:fd use;
 allow newrole_t self:fifo_file rw_fifo_file_perms;
 allow newrole_t self:sock_file read_sock_file_perms;


### PR DESCRIPTION
Commit 61b72e0796d9 ("selinuxutil: adjustments") removed negative permission
matching for newrole_t:process. One of the removed permission was setcap which
is needed by newrole as it tries to drop capabilities:

    $ newrole -r sysadm_r
    Sorry, newrole failed to drop capabilities
    : Permission denied

    type=PROCTITLE msg=audit(09/06/2019 15:07:01.908:10821) : proctitle=newrole -r sysadm_r

    type=SYSCALL msg=audit(09/06/2019 15:07:01.908:10821) : arch=x86_64
    syscall=capset success=no exit=EACCES(Permission denied) a0=0x7fbe17d4cb6c
    a1=0x7fbe17d4cb74 a2=0x7fbe17d4d5d0 a3=0x0 items=0 ppid=4981 pid=7255
    auid=admin uid=admin gid=admin euid=admin
    suid=admin fsuid=admin egid=admin sgid=admin fsgid=admin tty=tty1 ses=6
    comm=newrole exe=/usr/bin/newrole subj=staff_u:staff_r:newrole_t:s0
    key=(null)

    type=AVC msg=audit(09/06/2019 15:07:01.908:10821) : avc:  denied  { setcap }
    for  pid=7255 comm=newrole scontext=staff_u:staff_r:newrole_t:s0
    tcontext=staff_u:staff_r:newrole_t:s0 tclass=process permissive=0

Signed-off-by: Petr Lautrbach <plautrba@redhat.com>