### PR TITLE
systemd: allow more accesses to systemd --user

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1170,7 +1170,7 @@ systemd_log_parse_environment(systemd_update_done_t)
 
 allow systemd_user_session_type self:capability { dac_read_search sys_resource };
 dontaudit systemd_user_session_type self:capability dac_override;
-allow systemd_user_session_type self:process setfscreate;
+allow systemd_user_session_type self:process { setfscreate setsockcreate };
 allow systemd_user_session_type self:udp_socket create_socket_perms;
 allow systemd_user_session_type self:unix_stream_socket create_stream_socket_perms;
 allow systemd_user_session_type self:netlink_kobject_uevent_socket { bind create getattr read setopt };
@@ -1189,14 +1189,23 @@ files_read_etc_files(systemd_user_session_type)
 files_list_usr(systemd_user_session_type)
 
 fs_getattr_cgroup(systemd_user_session_type)
+fs_getattr_tmpfs(systemd_user_session_type)
 fs_rw_cgroup_files(systemd_user_session_type)
 fs_manage_cgroup_dirs(systemd_user_session_type)
 
+# for /run/systemd/notify
+init_dgram_send(systemd_user_session_type)
 init_signal(systemd_user_session_type)
+# for /run/systemd/notify
+init_write_runtime_socket(systemd_user_session_type)
 
+# for /proc/sys/fs/nr_open
+kernel_read_fs_sysctls(systemd_user_session_type)
 kernel_read_kernel_sysctls(systemd_user_session_type)
 
 mount_list_runtime(systemd_user_session_type)
+
+selinux_compute_create_context(systemd_user_session_type)
 
 storage_getattr_fixed_disk_dev(systemd_user_session_type)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1196,8 +1196,6 @@ fs_manage_cgroup_dirs(systemd_user_session_type)
 # for /run/systemd/notify
 init_dgram_send(systemd_user_session_type)
 init_signal(systemd_user_session_type)
-# for /run/systemd/notify
-init_write_runtime_socket(systemd_user_session_type)
 
 # for /proc/sys/fs/nr_open
 kernel_read_fs_sysctls(systemd_user_session_type)


### PR DESCRIPTION
`systemd --user` needs to:

* run `statfs()` on `/sys/fs/cgroup`, which is a `tmpfs` on Debian 10:

      type=AVC msg=audit(1568544950.691:309): avc:  denied  { getattr }
      for  pid=10128 comm="systemd" name="/" dev="tmpfs" ino=9656
      scontext=sysadm_u:sysadm_r:sysadm_systemd_t
      tcontext=system_u:object_r:tmpfs_t tclass=filesystem permissive=0

      type=SYSCALL msg=audit(1568544950.691:309): arch=c000003e
      syscall=137 success=no exit=-13 a0=7f96e8b23ddb a1=7ffefbffb410
      a2=7f96e7b3c2a0 a3=0 items=0 ppid=1 pid=10128 auid=1000 uid=1000
      gid=1000 euid=1000 suid=1000 fsuid=1000 egid=1000 sgid=1000
      fsgid=1000 tty=(none) ses=14 comm="systemd"
      exe="/usr/lib/systemd/systemd"
      subj=sysadm_u:sysadm_r:sysadm_systemd_t key=(null)

      type=PROCTITLE msg=audit(1568544950.691:309):
      proctitle=2F6C69622F73797374656D642F73797374656D64002D2D75736572

      # ls -Zdi /sys/fs/cgroup  # ino=9656 is /sys/fs/cgroup
      9656 system_u:object_r:cgroup_t /sys/fs/cgroup

      # findmnt /sys/fs/cgroup
      /sys/fs/cgroup tmpfs  tmpfs  ro,nosuid,nodev,noexec,seclabel,mode=755

* read `/proc/sys/fs/nr_open`:

      type=AVC msg=audit(1568545206.580:392): avc:  denied  { search } for
      pid=19003 comm="systemd" name="fs" dev="proc" ino=9699
      scontext=sysadm_u:sysadm_r:sysadm_systemd_t
      tcontext=system_u:object_r:sysctl_fs_t tclass=dir permissive=1

      type=AVC msg=audit(1568545206.580:392): avc:  denied  { read } for
      pid=19003 comm="systemd" name="nr_open" dev="proc" ino=14620
      scontext=sysadm_u:sysadm_r:sysadm_systemd_t
      tcontext=system_u:object_r:sysctl_fs_t tclass=file permissive=1

      type=AVC msg=audit(1568545206.580:392): avc:  denied  { open } for
      pid=19003 comm="systemd" path="/proc/sys/fs/nr_open" dev="proc"
      ino=14620 scontext=sysadm_u:sysadm_r:sysadm_systemd_t
      tcontext=system_u:object_r:sysctl_fs_t tclass=file permissive=1

      type=SYSCALL msg=audit(1568545206.580:392): arch=c000003e
      syscall=257 success=yes exit=4 a0=ffffff9c a1=7fe0d8a8665f a2=80000
      a3=0 items=0 ppid=1 pid=19003 auid=1000 uid=1000 gid=1000 euid=1000
      suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=(none)
      ses=16 comm="systemd" exe="/usr/lib/systemd/systemd"
      subj=sysadm_u:sysadm_r:sysadm_systemd_t key=(null)

      type=PROCTITLE msg=audit(1568545206.580:392):
      proctitle=2F6C69622F73797374656D642F73797374656D64002D2D75736572

* notify systemd like services (this was not allowed because `*_systemd_t` is not associated with attribute `daemon`):

      type=AVC msg=audit(1568545206.748:410): avc:  denied  { write } for
      pid=19003 comm="systemd" name="notify" dev="tmpfs" ino=9840
      scontext=sysadm_u:sysadm_r:sysadm_systemd_t
      tcontext=system_u:object_r:init_runtime_t tclass=sock_file
      permissive=1

      type=AVC msg=audit(1568545206.748:410): avc:  denied  { sendto } for
      pid=19003 comm="systemd" path="/run/systemd/notify"
      scontext=sysadm_u:sysadm_r:sysadm_systemd_t
      tcontext=system_u:system_r:init_t tclass=unix_dgram_socket
      permissive=1

      type=SERVICE_START msg=audit(1568545206.756:411): pid=1 uid=0
      auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t
      msg='unit=user@1000 comm="systemd" exe="/usr/lib/systemd/systemd"
      hostname=? addr=? terminal=? res=success'

      type=SYSCALL msg=audit(1568545206.748:410): arch=c000003e syscall=46
      success=yes exit=36 a0=1e a1=7ffe70f2abf0 a2=4000 a3=7ffe70f2ab84
      items=0 ppid=1 pid=19003 auid=1000 uid=1000 gid=1000 euid=1000
      suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=(none)
      ses=16 comm="systemd" exe="/usr/lib/systemd/systemd"
      subj=sysadm_u:sysadm_r:sysadm_systemd_t key=(null)

      type=PROCTITLE msg=audit(1568545206.748:410):
      proctitle=2F6C69622F73797374656D642F73797374656D64002D2D75736572

* use `/sys/fs/selinux/create` to help define its own `sockcreate` attribute:

      type=AVC msg=audit(1568545206.748:406): avc:  denied  { write } for
      pid=19003 comm="systemd" name="create" dev="selinuxfs" ino=7
      scontext=sysadm_u:sysadm_r:sysadm_systemd_t
      tcontext=system_u:object_r:security_t tclass=file permissive=1
      type=SYSCALL msg=audit(1568545206.748:406): arch=c000003e
      syscall=257 success=yes exit=12 a0=ffffff9c a1=7ffe70f29da0 a2=80002
      a3=0 items=0 ppid=1 pid=19003 auid=1000 uid=1000 gid=1000 euid=1000
      suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=(none)
      ses=16 comm="systemd" exe="/usr/lib/systemd/systemd"
      subj=sysadm_u:sysadm_r:sysadm_systemd_t key=(null)
      type=PROCTITLE msg=audit(1568545206.748:406):
      proctitle=2F6C69622F73797374656D642F73797374656D64002D2D75736572

      type=AVC msg=audit(1568545206.748:407): avc:  denied  {
      compute_create } for  pid=19003 comm="systemd"
      scontext=sysadm_u:sysadm_r:sysadm_systemd_t
      tcontext=system_u:object_r:security_t tclass=security permissive=1
      type=SYSCALL msg=audit(1568545206.748:407): arch=c000003e syscall=1
      success=yes exit=71 a0=c a1=5555d61eadb0 a2=47 a3=0 items=0 ppid=1
      pid=19003 auid=1000 uid=1000 gid=1000 euid=1000 suid=1000 fsuid=1000
      egid=1000 sgid=1000 fsgid=1000 tty=(none) ses=16 comm="systemd"
      exe="/usr/lib/systemd/systemd"
      subj=sysadm_u:sysadm_r:sysadm_systemd_t key=(null)
      type=PROCTITLE msg=audit(1568545206.748:407):
      proctitle=2F6C69622F73797374656D642F73797374656D64002D2D75736572

      type=AVC msg=audit(1568545206.748:408): avc:  denied  {
      setsockcreate } for  pid=19003 comm="systemd"
      scontext=sysadm_u:sysadm_r:sysadm_systemd_t
      tcontext=sysadm_u:sysadm_r:sysadm_systemd_t tclass=process
      permissive=1
      type=SYSCALL msg=audit(1568545206.748:408): arch=c000003e syscall=1
      success=yes exit=35 a0=c a1=5555d61e1320 a2=23 a3=3 items=0 ppid=1
      pid=19003 auid=1000 uid=1000 gid=1000 euid=1000 suid=1000 fsuid=1000
      egid=1000 sgid=1000 fsgid=1000 tty=(none) ses=16 comm="systemd"
      exe="/usr/lib/systemd/systemd"
      subj=sysadm_u:sysadm_r:sysadm_systemd_t key=(null)
      type=PROCTITLE msg=audit(1568545206.748:408):
      proctitle=2F6C69622F73797374656D642F73797374656D64002D2D75736572