### PR TITLE
filesystem: allow following symlinks with fs_rw_cgroup_files()

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -881,6 +881,7 @@ interface(`fs_rw_cgroup_files',`
 	')
 
 	rw_files_pattern($1, cgroup_t, cgroup_t)
+	read_lnk_files_pattern($1, cgroup_t, cgroup_t)
 	dev_search_sysfs($1)
 ')
 


### PR DESCRIPTION
`fs_read_cgroup_files()` grants access to reading files and to following symlinks (with `read_lnk_files_pattern($1, cgroup_t, cgroup_t)`). `fs_rw_cgroup_files()` does not include such a rule, which is needed in order to transparently use symlinks such as `/sys/fs/cgroup/cpu`. This access is currently denied, for example to `systemd --user` daemon:

    type=AVC msg=audit(1569756917.537:242): avc:  denied  { getattr }
    for  pid=9710 comm="systemd" path="/sys/fs/cgroup/cpu" dev="tmpfs"
    ino=9683 scontext=sysadm_u:sysadm_r:sysadm_systemd_t
    tcontext=system_u:object_r:cgroup_t tclass=lnk_file permissive=0

    type=SYSCALL msg=audit(1569756917.537:242): arch=c000003e
    syscall=262 success=no exit=-13 a0=ffffff9c a1=7ffc605b1f70
    a2=7ffc605b1ea0 a3=100 items=0 ppid=1 pid=9710 auid=1000 uid=1000
    gid=1000 euid=1000 suid=1000 fsuid=1000 egid=1000 sgid=1000
    fsgid=1000 tty=(none) ses=10 comm="systemd"
    exe="/usr/lib/systemd/systemd"
    subj=sysadm_u:sysadm_r:sysadm_systemd_t key=(null)

    type=PROCTITLE msg=audit(1569756917.537:242):
    proctitle=2F6C69622F73797374656D642F73797374656D64002D2D75736572

On this system (Debian 10), `/sys/fs/cgroup/cpu` is a symlink to `/sys/fs/cgroup/cpu,cpuacct`.