### PR TITLE
.travis.yml: check the .fc files in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
   fast_finish: true
 
 env:
+  - LINT=true TYPE=standard
   - TYPE=standard DISTRO=redhat MONOLITHIC=y SYSTEMD=y WERROR=y
   - TYPE=standard DISTRO=redhat MONOLITHIC=n SYSTEMD=y WERROR=y
   - TYPE=standard DISTRO=debian MONOLITHIC=y SYSTEMD=y WERROR=y
@@ -89,6 +90,7 @@ install:
 script:
   - echo $TYPE $DISTRO $MONOLITHIC $SYSTEMD $WERROR
   - set -e
+  - if [ -n "$LINT" ] ; then ./testing/check_fc_files.py ; fi
   - make bare
   - make conf
   - make


### PR DESCRIPTION
Now that all issues reported by `testing/check_fc_files.py` have been fixed, call this script in Travis-CI in order to prevent common errors from being introduced in `.fc` files.

This follows https://github.com/SELinuxProject/refpolicy/pull/74.