### PR TITLE
fix Makefile for policy-module directories with same ending

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,7 +427,7 @@ endif
 
 $(layerxml): %.xml: $(tmpdir)/iftemplates $(all_metaxml) $(filter $(addprefix $(moddir)/, $(notdir $*))%, $(detected_mods)) $(subst .te,.if, $(filter $(addprefix $(moddir)/, $(notdir $*))%, $(detected_mods)))
 	@test -d $(tmpdir) || mkdir -p $(tmpdir)
-	$(verbose) cat $(filter %$(notdir $*)/$(metaxml), $(all_metaxml)) > $@
+	$(verbose) cat $(filter %/$(notdir $*)/$(metaxml), $(all_metaxml)) > $@
 	$(verbose) for i in $(basename $(filter $(addprefix $(moddir)/, $(notdir $*))%, $(detected_mods))); do $(genxml) -w -T $(tmpdir)/iftemplates -m $$i >> $@; done
 ifdef LOCAL_ROOT
 	$(verbose) for i in $(basename $(filter $(addprefix $(local_moddir)/, $(notdir $*))%, $(detected_mods))); do $(genxml) -w -T $(tmpdir)/iftemplates -m $$i >> $@; done


### PR DESCRIPTION
Currently policy module directories must have a same ending.
Reproduce with:

```
mv policy/modules/admin/ policy/modules/adminapps
make conf
```

Results in:

```
...
cat policy/modules/adminapps/metadata.xml policy/modules/apps/metadata.xml > tmp/apps.xml
...
doc/policy.xml:4332: element layer: validity error : Element layer content does not follow the DTD, expecting (summary , module+), got (summary summary module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module module )
Document doc/policy.xml does not validate against doc/policy.dtd
make: *** [Makefile:452: doc/policy.xml] Error 3
```

Add a leading slash to the filter pattern, to not match partial names