### PR TITLE
systemd: make the kernel spawn systemd-coredump with a context transition

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -309,6 +309,7 @@ allow systemd_coredump_t self:process { getcap setcap setfscreate };
 
 manage_files_pattern(systemd_coredump_t, systemd_coredump_var_lib_t, systemd_coredump_var_lib_t)
 
+kernel_domtrans_to(systemd_coredump_t, systemd_coredump_exec_t)
 kernel_read_kernel_sysctls(systemd_coredump_t)
 kernel_read_system_state(systemd_coredump_t)
 kernel_rw_pipes(systemd_coredump_t)


### PR DESCRIPTION
On Arch Linux, `/proc/sys/kernel/core_pattern` contains:

    |/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h

When a crash happens in a userspace application, this setting makes the kernel spawn `/usr/lib/systemd/systemd-coredump` from `kernel_t`:

    type=AVC msg=audit(1569910108.877:336): avc:  denied  { execute }
    for  pid=1087 comm="kworker/u2:3" name="systemd-coredump" dev="vda1"
    ino=406365 scontext=system_u:system_r:kernel_t
    tcontext=system_u:object_r:systemd_coredump_exec_t tclass=file
    permissive=1

Introduce a transition to `systemd_coredump_t` to handle this.