### PR TITLE
gpg: allow gpg-agent to read crypto.fips_enabled sysctl

### DIFF
--- a/policy/modules/apps/gpg.te
+++ b/policy/modules/apps/gpg.te
@@ -247,6 +247,7 @@ domtrans_pattern(gpg_agent_t, gpg_pinentry_exec_t, gpg_pinentry_t)
 
 kernel_dontaudit_search_sysctl(gpg_agent_t)
 kernel_read_core_if(gpg_agent_t)
+kernel_read_crypto_sysctls(gpg_agent_t)
 kernel_read_system_state(gpg_agent_t)
 
 auth_use_nsswitch(gpg_agent_t)


### PR DESCRIPTION
On Debian 10, when gpg-agent starts, it reads  `crypto.fips_enabled`:

    type=AVC msg=audit(1569958604.280:42): avc:  denied  { open } for
    pid=329 comm="gpg-agent" path="/proc/sys/crypto/fips_enabled"
    dev="proc" ino=14687 scontext=sysadm_u:sysadm_r:gpg_agent_t
    tcontext=system_u:object_r:sysctl_crypto_t tclass=file permissive=1

    type=AVC msg=audit(1569958604.280:42): avc:  denied  { read } for
    pid=329 comm="gpg-agent" name="fips_enabled" dev="proc" ino=14687
    scontext=sysadm_u:sysadm_r:gpg_agent_t
    tcontext=system_u:object_r:sysctl_crypto_t tclass=file permissive=1