### PR TITLE
travis: force the use of python3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Derived from Nicolas Iooss: https://github.com/fishilico/selinux-refpolicy-patched/blob/travis-upstream/.travis.yml
 
-language: generic
+language: python
+python: 3.5
 
 matrix:
   fast_finish: true
@@ -49,7 +50,7 @@ before_install:
   - bison -V
   - flex -V
   - swig -version
-  - python -V
+  - python3 -V
 
 install:
   - SELINUX_USERSPACE_VERSION=master


### PR DESCRIPTION
python3.5 is the oldest available one on bionic (though refpolicy requires only 3.4)

Also print the python3 (not 2) version during build