### PR TITLE
dbus: allow systemd services to watch the DBUS system socket

### DIFF
--- a/policy/modules/services/dbus.if
+++ b/policy/modules/services/dbus.if
@@ -438,6 +438,34 @@ interface(`dbus_spec_session_domain',`
 
 ########################################
 ## <summary>
+##	Watch the creation of the Unix socket
+##	of the DBUS system bus and its parent
+##	directories with inotify.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dbus_watch_system_bus',`
+	gen_require(`
+		type system_dbusd_runtime_t;
+	')
+
+	files_list_pids($1)
+
+	# Do not use list_dirs_pattern() and read_sock_files_pattern(), as
+	# inotify_add_watch() only needs the read permission.
+
+	# For /run/dbus
+	allow $1 system_dbusd_runtime_t:dir {search_dir_perms read};
+	# For /run/dbus/system_bus_socket
+	allow $1 system_dbusd_runtime_t:sock_file read;
+')
+
+########################################
+## <summary>
 ##	Acquire service on the DBUS system bus.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/ntp.te
+++ b/policy/modules/services/ntp.te
@@ -141,6 +141,7 @@ ifdef(`init_systemd',`
 
 	dbus_system_bus_client(ntpd_t)
 	dbus_connect_system_bus(ntpd_t)
+	dbus_watch_system_bus(ntpd_t)
 	init_dbus_chat(ntpd_t)
 	init_get_system_status(ntpd_t)
 	init_list_unit_dirs(ntpd_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -699,6 +699,7 @@ systemd_log_parse_environment(systemd_networkd_t)
 optional_policy(`
 	dbus_system_bus_client(systemd_networkd_t)
 	dbus_connect_system_bus(systemd_networkd_t)
+	dbus_watch_system_bus(systemd_networkd_t)
 
 	systemd_dbus_chat_hostnamed(systemd_networkd_t)
 ')
@@ -993,6 +994,7 @@ systemd_read_networkd_runtime(systemd_resolved_t)
 optional_policy(`
 	dbus_connect_system_bus(systemd_resolved_t)
 	dbus_system_bus_client(systemd_resolved_t)
+	dbus_watch_system_bus(systemd_resolved_t)
 ')
 
 #########################################


### PR DESCRIPTION
Since systemd 243 (commit https://github.com/systemd/systemd/commit/8a5cd31e5fa0b1313a196b902e4b3c4603e7dfdf), several systemd's services use `inotify_add_watch()` if connecting to the DBUS system socket failed, in order to wait for the socket to appear.

On Debian 10, this produces logs such as:

    type=AVC msg=audit(1570213116.564:18): avc:  denied  { read } for
    pid=255 comm="systemd-resolve" name="system_bus_socket" dev="tmpfs"
    ino=13104 scontext=system_u:system_r:systemd_resolved_t
    tcontext=system_u:object_r:system_dbusd_runtime_t tclass=sock_file
    permissive=1

    type=SYSCALL msg=audit(1570213116.564:18): arch=c000003e syscall=254
    success=yes exit=4 a0=f a1=55d645b99960 a2=2000d84 a3=1 items=0
    ppid=1 pid=255 auid=4294967295 uid=103 gid=104 euid=103 suid=103
    fsuid=103 egid=104 sgid=104 fsgid=104 tty=(none) ses=4294967295
    comm="systemd-resolve" exe="/usr/lib/systemd/systemd-resolved"
    subj=system_u:system_r:systemd_resolved_t key=(null)

    type=PROCTITLE msg=audit(1570213116.564:18):
    proctitle="/lib/systemd/systemd-resolved"

(syscall 254 on x86-64 is `inotify_add_watch()` and mode `a2=2000d84` means `IN_DELETE_SELF|IN_MOVE_SELF|IN_ATTRIB|IN_CREATE|IN_MOVED_TO|IN_DONT_FOLLOW`).

As this does not extend to all DBUS users, but only to those which are using `libsystemd-shared-243.so`, introduce a new interface to allow this access instead of adding more statements to `dbus_system_bus_client()`.