### PR TITLE
bugfix/123: allow xserver_t self:capability chown

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -632,8 +632,7 @@ allow xserver_t input_xevent_t:x_event send;
 # execheap needed until the X module loader is fixed.
 # NVIDIA Needs execstack
 
-allow xserver_t self:capability { dac_override fowner fsetid ipc_owner mknod net_bind_service setgid setuid sys_admin sys_nice sys_rawio sys_tty_config };
-dontaudit xserver_t self:capability chown;
+allow xserver_t self:capability { chown dac_override fowner fsetid ipc_owner mknod net_bind_service setgid setuid sys_admin sys_nice sys_rawio sys_tty_config };
 allow xserver_t self:capability2 wake_alarm;
 allow xserver_t self:process { fork transition signal_perms getsched setsched getsession getpgid setpgid getcap setcap share getattr noatsecure siginh rlimitinh dyntransition setkeycreate setsockcreate getrlimit };
 allow xserver_t self:fd use;


### PR DESCRIPTION
on Funtoo 1.4 when xdm is started by OpenRC it additionally wants to

type=AVC msg=audit(1571776002.581:399): avc: denied { chown } for pid=6225 comm="X" capability=0 scontext=system_u:system_r:xserver_t tcontext=system_u:system_r:xserver_t tclass=capability permissive=0
type=AVC msg=audit(1571776002.729:400): avc: denied { chown } for pid=6225 comm="X" capability=0 scontext=system_u:system_r:xserver_t tcontext=system_u:system_r:xserver_t tclass=capability permissive=0

this does not occur if this is run by root: /etc/init.d/xdm start

more info:
- https://bugs.funtoo.org/browse/FL-6779
- https://bugs.gentoo.org/698112