### PR TITLE
Fix SyntaxError

### DIFF
--- a/support/sedoctool.py
+++ b/support/sedoctool.py
@@ -266,7 +266,7 @@ def format_html_desc(node):
 	desc_buf = ''
 	for desc in node.childNodes:
 		if desc.nodeName == "#text":
-			if desc.data is not '':
+			if desc.data != '':
 				if desc.parentNode.nodeName != "p":
 					desc_buf += "<p>" + desc.data + "</p>"
 				else:


### PR DESCRIPTION
This fixes the following error while building on Arch Linus with python version 3.8.0:

```
Updating policy/booleans.conf and policy/modules.conf
python3 -t -t -E -W error support/sedoctool.py -b policy/booleans.conf -m policy/modules.conf -x doc/policy.xml
  File "support/sedoctool.py", line 269
    if desc.data is not '':
       ^
SyntaxError: "is not" with a literal. Did you mean "!="?
make: *** [Makefile:405: conf.intermediate] Error 1
==> ERROR: A failure occurred in prepare().
    Aborting...
```