### PR TITLE
unconfined: Fix systemd --user rule.

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -672,12 +672,7 @@ interface(`init_domtrans',`
 ## </desc>
 ## <param name="domain">
 ##	<summary>
-##	Domain allowed to transition.
-##	</summary>
-## </param>
-## <param name="domain">
-##	<summary>
-##	New domain.
+##	The type to be used as a systemd --user domain.
 ##	</summary>
 ## </param>
 #

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -62,7 +62,7 @@ ifdef(`init_systemd',`
 	# for systemd-analyze
 	init_service_status(unconfined_t)
 	# for systemd --user:
-	init_pgm_entrypoint(unconfined_t)
+	init_pgm_spec_user_daemon_domain(unconfined_t)
 
 	optional_policy(`
 		systemd_dbus_chat_resolved(unconfined_t)


### PR DESCRIPTION
Use the full init_pgm_spec_user_daemon_domain() to ensure correct
permissions.

Signed-off-by: Chris PeBenito <chpebeni@linux.microsoft.com>