### PR TITLE
Resolvconf

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -85,6 +85,8 @@ ifdef(`distro_redhat',`
 
 /etc/rc\.d/init\.d/functions	--	gen_context(system_u:object_r:bin_t,s0)
 
+/etc/resolvconf/update\.d/.*	--	gen_context(system_u:object_r:bin_t,s0)
+
 /etc/security/namespace\.init	--	gen_context(system_u:object_r:bin_t,s0)
 
 /etc/sysconfig/crond		--	gen_context(system_u:object_r:bin_t,s0)

--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -216,6 +216,7 @@ ifdef(`distro_gentoo',`
 /usr/lib/portage/bin(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/pm-utils(/.*)?			gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/readahead(/.*)?		gen_context(system_u:object_r:bin_t,s0)
+/usr/lib/resolvconf/.*	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/rpm/rpmd		-- 	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/rpm/rpmk		-- 	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/rpm/rpmq		-- 	gen_context(system_u:object_r:bin_t,s0)

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -917,6 +917,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	resolvconf_run(sysadm_t, sysadm_r)
+')
+
+optional_policy(`
 	rgmanager_admin(sysadm_t, sysadm_r)
 ')
 

--- a/policy/modules/services/networkmanager.te
+++ b/policy/modules/services/networkmanager.te
@@ -340,6 +340,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	resolvconf_domtrans(NetworkManager_t)
+')
+
+optional_policy(`
 	rpm_exec(NetworkManager_t)
 	rpm_read_db(NetworkManager_t)
 	rpm_dontaudit_manage_db(NetworkManager_t)

--- a/policy/modules/services/ppp.te
+++ b/policy/modules/services/ppp.te
@@ -210,6 +210,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	resolvconf_domtrans(pppd_t)
+')
+
+optional_policy(`
 	seutil_sigchld_newrole(pppd_t)
 ')
 

--- a/policy/modules/services/resolvconf.fc
+++ b/policy/modules/services/resolvconf.fc
@@ -1,5 +1,3 @@
 /etc/resolvconf/update\.d/.*	--	gen_context(system_u:object_r:resolvconf_exec_t,s0)
 
-/usr/lib/resolvconf/.*	gen_context(system_u:object_r:resolvconf_exec_t,s0)
-
 /usr/sbin/resolvconf	--	gen_context(system_u:object_r:resolvconf_exec_t,s0)

--- a/policy/modules/services/resolvconf.fc
+++ b/policy/modules/services/resolvconf.fc
@@ -1,5 +1,3 @@
-/etc/resolvconf/update\.d/.*	--	gen_context(system_u:object_r:resolvconf_exec_t,s0)
-
 /run/resolvconf	-d	gen_context(system_u:object_r:resolvconf_runtime_t,s0)
 /run/resolvconf/.*	gen_context(system_u:object_r:resolvconf_runtime_t,s0)
 

--- a/policy/modules/services/resolvconf.fc
+++ b/policy/modules/services/resolvconf.fc
@@ -1,0 +1,5 @@
+/etc/resolvconf/update\.d/.*	--	gen_context(system_u:object_r:resolvconf_exec_t,s0)
+
+/usr/lib/resolvconf/.*	gen_context(system_u:object_r:resolvconf_exec_t,s0)
+
+/usr/sbin/resolvconf	--	gen_context(system_u:object_r:resolvconf_exec_t,s0)

--- a/policy/modules/services/resolvconf.fc
+++ b/policy/modules/services/resolvconf.fc
@@ -1,3 +1,6 @@
 /etc/resolvconf/update\.d/.*	--	gen_context(system_u:object_r:resolvconf_exec_t,s0)
 
+/run/resolvconf	-d	gen_context(system_u:object_r:resolvconf_runtime_t,s0)
+/run/resolvconf/.*	gen_context(system_u:object_r:resolvconf_runtime_t,s0)
+
 /usr/sbin/resolvconf	--	gen_context(system_u:object_r:resolvconf_exec_t,s0)

--- a/policy/modules/services/resolvconf.if
+++ b/policy/modules/services/resolvconf.if
@@ -1,0 +1,47 @@
+## <summary>Framework for manageing resolver configurations</summary>
+
+########################################
+## <summary>
+##  Execute resolvconf in the resolvconf domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`resolvconf_domtrans',`
+	gen_require(`
+		type resolvconf_t, resolvconf_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, resolvconf_exec_t, resolvconf_t)
+')
+
+########################################
+## <summary>
+##	Execute resolvconf in the resolvconf
+##	domain, and allow the specified
+##	role the resolvconf domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`resolvconf_run', `
+	gen_require(`
+		attribute_role resolvconf_roles;
+	')
+
+	resolvconf_domtrans($1)
+	roleattribute $2 resolvconf_roles;
+')

--- a/policy/modules/services/resolvconf.if
+++ b/policy/modules/services/resolvconf.if
@@ -45,3 +45,22 @@ interface(`resolvconf_run', `
 	resolvconf_domtrans($1)
 	roleattribute $2 resolvconf_roles;
 ')
+
+#######################################
+## <summary>
+##  Read resolvconf runtime files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`resolvconf_read_runtime', `
+	gen_require(`
+		type resolvconf_runtime_t;
+	')
+
+	files_search_pids($1)
+	read_files_pattern($1, resolvconf_runtime_t, resolvconf_runtime_t)
+')

--- a/policy/modules/services/resolvconf.te
+++ b/policy/modules/services/resolvconf.te
@@ -4,7 +4,6 @@ policy_module(resolvconf, 1.0)
 #
 # Declarations
 #
-
 attribute_role resolvconf_roles;
 
 type resolvconf_t;
@@ -16,21 +15,20 @@ role resolvconf_roles types resolvconf_t;
 #
 # Local policy
 #
+allow resolvconf_t self:fifo_file rw_fifo_file_perms;
+allow resolvconf_t self:process signal;
+allow resolvconf_t net_conf_t:dir { create rmdir };
+allow resolvconf_t resolvconf_exec_t:file exec_file_perms;
+
 corecmd_exec_bin(resolvconf_t)
 corecmd_exec_shell(resolvconf_t)
 
-## shell script permissions
 files_read_etc_files(resolvconf_t)
-miscfiles_read_localization(resolvconf_t)
-allow resolvconf_t self:fifo_file rw_fifo_file_perms;
-allow resolvconf_t self:process signal;
 
-## special permissions
 sysnet_manage_config(resolvconf_t)
-allow resolvconf_t net_conf_t:dir { create rmdir };
+
+miscfiles_read_localization(resolvconf_t)
 
 # /run/resolvconf
 files_pid_filetrans(resolvconf_t, net_conf_t, dir, "resolvconf")
 init_daemon_pid_file(net_conf_t, dir, "resolvconf")
-
-allow resolvconf_t resolvconf_exec_t:file exec_file_perms;

--- a/policy/modules/services/resolvconf.te
+++ b/policy/modules/services/resolvconf.te
@@ -17,7 +17,6 @@ role resolvconf_roles types resolvconf_t;
 #
 allow resolvconf_t self:fifo_file rw_fifo_file_perms;
 allow resolvconf_t self:process signal;
-allow resolvconf_t net_conf_t:dir { create rmdir };
 allow resolvconf_t resolvconf_exec_t:file exec_file_perms;
 
 corecmd_exec_bin(resolvconf_t)
@@ -25,6 +24,8 @@ corecmd_exec_shell(resolvconf_t)
 
 files_read_etc_files(resolvconf_t)
 
+sysnet_create_config_dirs(resolvconf_t)
+sysnet_delete_config_dirs(resolvconf_t)
 sysnet_manage_config(resolvconf_t)
 
 miscfiles_read_localization(resolvconf_t)

--- a/policy/modules/services/resolvconf.te
+++ b/policy/modules/services/resolvconf.te
@@ -1,0 +1,36 @@
+policy_module(resolvconf, 1.0)
+
+########################################
+#
+# Declarations
+#
+
+attribute_role resolvconf_roles;
+
+type resolvconf_t;
+type resolvconf_exec_t;
+init_system_domain(resolvconf_t, resolvconf_exec_t)
+role resolvconf_roles types resolvconf_t;
+
+########################################
+#
+# Local policy
+#
+corecmd_exec_bin(resolvconf_t)
+corecmd_exec_shell(resolvconf_t)
+
+## shell script permissions
+files_read_etc_files(resolvconf_t)
+miscfiles_read_localization(resolvconf_t)
+allow resolvconf_t self:fifo_file rw_fifo_file_perms;
+allow resolvconf_t self:process signal;
+
+## special permissions
+sysnet_manage_config(resolvconf_t)
+allow resolvconf_t net_conf_t:dir { create rmdir };
+
+# /run/resolvconf
+files_pid_filetrans(resolvconf_t, net_conf_t, dir, "resolvconf")
+init_daemon_pid_file(net_conf_t, dir, "resolvconf")
+
+allow resolvconf_t resolvconf_exec_t:file exec_file_perms;

--- a/policy/modules/services/resolvconf.te
+++ b/policy/modules/services/resolvconf.te
@@ -11,6 +11,9 @@ type resolvconf_exec_t;
 init_system_domain(resolvconf_t, resolvconf_exec_t)
 role resolvconf_roles types resolvconf_t;
 
+type resolvconf_runtime_t;
+files_pid_file(resolvconf_runtime_t)
+
 ########################################
 #
 # Local policy
@@ -19,16 +22,16 @@ allow resolvconf_t self:fifo_file rw_fifo_file_perms;
 allow resolvconf_t self:process signal;
 allow resolvconf_t resolvconf_exec_t:file exec_file_perms;
 
+manage_dirs_pattern(resolvconf_t, resolvconf_runtime_t, resolvconf_runtime_t)
+manage_files_pattern(resolvconf_t, resolvconf_runtime_t, resolvconf_runtime_t)
+files_pid_filetrans(resolvconf_t, resolvconf_runtime_t, dir, "resolvconf")
+
 corecmd_exec_bin(resolvconf_t)
 corecmd_exec_shell(resolvconf_t)
 
 files_read_etc_files(resolvconf_t)
 
-sysnet_create_config_dirs(resolvconf_t)
-sysnet_delete_config_dirs(resolvconf_t)
 sysnet_manage_config(resolvconf_t)
 
 miscfiles_read_localization(resolvconf_t)
 
-# /run/resolvconf
-sysnet_pid_filetrans_config(resolvconf_t, dir, "resolvconf")

--- a/policy/modules/services/resolvconf.te
+++ b/policy/modules/services/resolvconf.te
@@ -31,5 +31,4 @@ sysnet_manage_config(resolvconf_t)
 miscfiles_read_localization(resolvconf_t)
 
 # /run/resolvconf
-files_pid_filetrans(resolvconf_t, net_conf_t, dir, "resolvconf")
-init_daemon_pid_file(net_conf_t, dir, "resolvconf")
+sysnet_pid_filetrans_config(resolvconf_t, dir, "resolvconf")

--- a/policy/modules/system/sysnetwork.fc
+++ b/policy/modules/system/sysnetwork.fc
@@ -81,8 +81,6 @@ ifdef(`distro_redhat',`
 
 /run/dhclient.*	--	gen_context(system_u:object_r:dhcpc_runtime_t,s0)
 /run/dhcpcd(/.*)?		gen_context(system_u:object_r:dhcpc_runtime_t,s0)
-/run/resolvconf	-d	gen_context(system_u:object_r:net_conf_t,s0)
-/run/resolvconf/.*	gen_context(system_u:object_r:net_conf_t,s0)
 
 ifdef(`distro_gentoo',`
 /var/lib/dhcpc(/.*)?		gen_context(system_u:object_r:dhcpc_state_t,s0)

--- a/policy/modules/system/sysnetwork.fc
+++ b/policy/modules/system/sysnetwork.fc
@@ -81,6 +81,8 @@ ifdef(`distro_redhat',`
 
 /run/dhclient.*	--	gen_context(system_u:object_r:dhcpc_runtime_t,s0)
 /run/dhcpcd(/.*)?		gen_context(system_u:object_r:dhcpc_runtime_t,s0)
+/run/resolvconf	-d	gen_context(system_u:object_r:net_conf_t,s0)
+/run/resolvconf/.*	gen_context(system_u:object_r:net_conf_t,s0)
 
 ifdef(`distro_gentoo',`
 /var/lib/dhcpc(/.*)?		gen_context(system_u:object_r:dhcpc_state_t,s0)
@@ -88,6 +90,5 @@ ifdef(`distro_gentoo',`
 
 ifdef(`distro_debian',`
 /run/network(/.*)?	gen_context(system_u:object_r:net_conf_t,s0)
-/run/resolvconf/.* --	gen_context(system_u:object_r:net_conf_t,s0)
 ')
 

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -465,6 +465,44 @@ interface(`sysnet_etc_filetrans_config',`
 
 #######################################
 ## <summary>
+##  Create network config directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_create_config_dirs', `
+	gen_require(`
+		type net_conf_t;
+	')
+
+	files_search_etc($1)
+	allow $1 net_conf_t:dir create_dir_perms;
+')
+
+#######################################
+## <summary>
+##  Delete network config directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_delete_config_dirs', `
+	gen_require(`
+		type net_conf_t;
+	')
+
+	files_search_etc($1)
+	allow $1 net_conf_t:dir delete_dir_perms;
+')
+
+#######################################
+## <summary>
 ##	Create, read, write, and delete network config files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -362,6 +362,10 @@ interface(`sysnet_read_config',`
 	ifdef(`init_systemd',`
 		systemd_read_resolved_runtime($1)
 	')
+
+	optional_policy(`
+		resolvconf_read_runtime($1)
+	')
 ')
 
 #######################################
@@ -461,44 +465,6 @@ interface(`sysnet_etc_filetrans_config',`
 	')
 
 	files_etc_filetrans($1, net_conf_t, file, $2)
-')
-
-#######################################
-## <summary>
-##  Create network config directories.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`sysnet_create_config_dirs', `
-	gen_require(`
-		type net_conf_t;
-	')
-
-	files_search_etc($1)
-	allow $1 net_conf_t:dir create_dir_perms;
-')
-
-#######################################
-## <summary>
-##  Delete network config directories.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`sysnet_delete_config_dirs', `
-	gen_require(`
-		type net_conf_t;
-	')
-
-	files_search_etc($1)
-	allow $1 net_conf_t:dir delete_dir_perms;
 ')
 
 #######################################
@@ -707,42 +673,6 @@ interface(`sysnet_search_dhcp_state',`
 
 	files_search_var_lib($1)
 	allow $1 dhcp_state_t:dir search_dir_perms;
-')
-
-########################################
-## <summary>
-##  Create an object in the pid directory
-##  with an automatic type transition to the
-##  network config type.
-## </summary>
-## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
-## </param>
-## <param name="private type">
-##  <summary>
-##  The type of the object to be created
-##  </summary>
-## </param>
-## <param name="object">
-##  <summary>
-##  The object class of the object being created.
-##  </summary>
-## </param>
-## <param name="name" optional="true">
-##  <summary>
-##  The name of the object being created.
-##  </summary>
-## </param>
-#
-interface(`sysnet_pid_filetrans_config', `
-	gen_require(`
-		type net_conf_t;
-	')
-
-	files_pid_filetrans($1, net_conf_t, $2, $3, $4)
-	init_daemon_pid_file(net_conf_t, $2, $3)
 ')
 
 ########################################

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -711,6 +711,42 @@ interface(`sysnet_search_dhcp_state',`
 
 ########################################
 ## <summary>
+##  Create an object in the pid directory
+##  with an automatic type transition to the
+##  network config type.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+## <param name="private type">
+##  <summary>
+##  The type of the object to be created
+##  </summary>
+## </param>
+## <param name="object">
+##  <summary>
+##  The object class of the object being created.
+##  </summary>
+## </param>
+## <param name="name" optional="true">
+##  <summary>
+##  The name of the object being created.
+##  </summary>
+## </param>
+#
+interface(`sysnet_pid_filetrans_config', `
+	gen_require(`
+		type net_conf_t;
+	')
+
+	files_pid_filetrans($1, net_conf_t, $2, $3, $4)
+	init_daemon_pid_file(net_conf_t, $2, $3)
+')
+
+########################################
+## <summary>
 ##	Create DHCP state data.
 ## </summary>
 ## <desc>

--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -244,6 +244,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	resolvconf_domtrans(dhcpc_t);
+')
+
+optional_policy(`
 	samba_manage_config(dhcpc_t)
 ')
 


### PR DESCRIPTION
Policy for https://roy.marples.name/projects/openresolv (and https://tracker.debian.org/pkg/resolvconf)

**TODO:**
- [ ] test on a debian minimal install using resolvconf
- [ ] test on a debian minimal install using openresolv

Note: This policy currently does not allow any plugins (e.g. the dnsmasq plugin that is delivered with openresolv) or service restarting.