### PR TITLE
Add policy for console-setup on debian

### DIFF
--- a/policy/modules/apps/loadkeys.te
+++ b/policy/modules/apps/loadkeys.te
@@ -48,6 +48,12 @@ miscfiles_read_localization(loadkeys_t)
 userdom_use_user_ttys(loadkeys_t)
 userdom_list_user_home_content(loadkeys_t)
 
+ifdef(`distro_debian',`
+	optional_policy(`
+		consolesetup_read_conf(loadkeys_t)
+	')
+')
+
 optional_policy(`
 	keyboardd_read_pipes(loadkeys_t)
 ')

--- a/policy/modules/apps/loadkeys.te
+++ b/policy/modules/apps/loadkeys.te
@@ -48,10 +48,8 @@ miscfiles_read_localization(loadkeys_t)
 userdom_use_user_ttys(loadkeys_t)
 userdom_list_user_home_content(loadkeys_t)
 
-ifdef(`distro_debian',`
-	optional_policy(`
-		consolesetup_read_conf(loadkeys_t)
-	')
+optional_policy(`
+	consolesetup_read_conf(loadkeys_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/consolesetup.fc
+++ b/policy/modules/services/consolesetup.fc
@@ -1,0 +1,9 @@
+/etc/console-setup(/.*)?	gen_context(system_u:object_r:consolesetup_conf_t,s0)
+
+/etc/default/console-setup.*	--	gen_context(system_u:object_r:consolesetup_conf_t,s0)
+/etc/default/keyboard.*	--	gen_context(system_u:object_r:consolesetup_conf_t,s0)
+
+/run/console-setup(/.*)?	gen_context(system_u:object_r:consolesetup_runtime_t,s0)
+
+/usr/lib/console-setup/console-setup\.sh	--	gen_context(system_u:object_r:consolesetup_exec_t,s0)
+/usr/lib/console-setup/keyboard-setup\.sh	--	gen_context(system_u:object_r:consolesetup_exec_t,s0)

--- a/policy/modules/services/consolesetup.if
+++ b/policy/modules/services/consolesetup.if
@@ -1,0 +1,104 @@
+## <summary>console font and keymap setup program for debian</summary>
+
+########################################
+## <summary>
+##  Execute console-setup in the consolesetup domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`consolesetup_domtrans', `
+    gen_require(`
+        type consolesetup_t, consolesetup_conf_t, consolesetup_exec_t, consolesetup_runtime_t;
+    ')
+
+    corecmd_search_bin($1)
+    domtrans_pattern($1, consolesetup_exec_t, consolesetup_t)
+')
+
+########################################
+## <summary>
+##  Read console-setup configuration files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`consolesetup_read_conf',`
+	gen_require(`
+        type consolesetup_conf_t;
+	')
+
+    files_search_etc($1)
+    allow $1 consolesetup_conf_t:dir list_dir_perms;
+    allow $1 consolesetup_conf_t:file read_file_perms;
+    allow $1 consolesetup_conf_t:lnk_file read_lnk_file_perms;
+')
+
+########################################
+## <summary>
+##  Execute console-setup configuration files
+##  in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`consolesetup_exec_conf', `
+    gen_require(`
+        type consolesetup_conf_t;
+    ')
+
+    files_search_etc($1)
+    exec_files_pattern($1, consolesetup_conf_t, consolesetup_conf_t)
+')
+
+########################################
+## <summary>
+##  Allow the caller to manage
+##  consolesetup_runtime_t files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`consolesetup_manage_runtime', `
+    gen_require(`
+        type consolesetup_runtime_t;
+    ')
+
+    files_search_pids($1)
+    manage_dirs_pattern($1, consolesetup_runtime_t, consolesetup_runtime_t)
+    manage_files_pattern($1, consolesetup_runtime_t, consolesetup_runtime_t)
+')
+
+########################################
+## <summary>
+##  Create a console-setup directory in
+##  the runtime directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`consolesetup_pid_filetrans_runtime', `
+    gen_require(`
+        type consolesetup_runtime_t;
+    ')
+
+    files_pid_filetrans($1, consolesetup_runtime_t, dir, "console-setup")
+')

--- a/policy/modules/services/consolesetup.te
+++ b/policy/modules/services/consolesetup.te
@@ -1,0 +1,54 @@
+policy_module(consolesetup, 1.0)
+
+########################################
+#
+# Declarations
+#
+
+type consolesetup_t;
+type consolesetup_exec_t;
+init_daemon_domain(consolesetup_t, consolesetup_exec_t)
+
+type consolesetup_conf_t;
+files_config_file(consolesetup_conf_t)
+
+type consolesetup_runtime_t;
+files_pid_file(consolesetup_runtime_t)
+
+type consolesetup_tmp_t;
+files_tmp_file(consolesetup_tmp_t)
+
+########################################
+#
+# Local policy
+#
+
+allow consolesetup_t self:capability sys_tty_config;
+allow consolesetup_t self:fifo_file rw_inherited_fifo_file_perms;
+
+can_exec(consolesetup_t, consolesetup_conf_t)
+
+manage_files_pattern(consolesetup_t, consolesetup_conf_t, consolesetup_conf_t)
+
+manage_dirs_pattern(consolesetup_t, consolesetup_runtime_t, consolesetup_runtime_t)
+manage_files_pattern(consolesetup_t, consolesetup_runtime_t, consolesetup_runtime_t)
+files_pid_filetrans(consolesetup_t, consolesetup_runtime_t, dir, "console-setup")
+
+manage_files_pattern(consolesetup_t, consolesetup_tmp_t, consolesetup_tmp_t)
+files_tmp_filetrans(consolesetup_t, consolesetup_tmp_t, file)
+
+corecmd_exec_bin(consolesetup_t)
+corecmd_exec_shell(consolesetup_t)
+
+files_read_etc_files(consolesetup_t)
+files_read_usr_files(consolesetup_t)
+files_search_tmp(consolesetup_t)
+
+term_use_console(consolesetup_t)
+term_use_unallocated_ttys(consolesetup_t)
+
+miscfiles_read_localization(consolesetup_t)
+
+xserver_read_xkb_libs(consolesetup_t)
+
+loadkeys_domtrans(consolesetup_t)

--- a/policy/modules/system/udev.fc
+++ b/policy/modules/system/udev.fc
@@ -40,6 +40,5 @@ ifdef(`distro_redhat',`
 /run/udev(/.*)?	gen_context(system_u:object_r:udev_runtime_t,s0)
 
 ifdef(`distro_debian',`
-/run/console-setup(/.*)?	gen_context(system_u:object_r:udev_runtime_t,s0)
 /run/xen-hotplug -d	gen_context(system_u:object_r:udev_runtime_t,s0)
 ')

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -86,7 +86,6 @@ manage_files_pattern(udev_t, udev_runtime_t, udev_runtime_t)
 manage_lnk_files_pattern(udev_t, udev_runtime_t, udev_runtime_t)
 manage_sock_files_pattern(udev_t, udev_runtime_t, udev_runtime_t)
 files_pid_filetrans(udev_t, udev_runtime_t, dir, "udev")
-files_pid_filetrans(udev_t, udev_runtime_t, dir, "console-setup")
 
 kernel_load_module(udev_t)
 kernel_read_system_state(udev_t)

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -215,6 +215,12 @@ ifdef(`distro_debian',`
 		avahi_setattr_pid_dirs(udev_t)
 		avahi_filetrans_pid(udev_t, dir, "avahi-daemon")
 	')
+
+	optional_policy(`
+		consolesetup_exec_conf(udev_t)
+		consolesetup_manage_runtime(udev_t)
+		consolesetup_pid_filetrans_runtime(udev_t)
+	')
 ')
 
 ifdef(`distro_gentoo',`


### PR DESCRIPTION
This is a helper script on debian to setup the console font / keymap.

- [x] test on a debian minimal install