### PR TITLE
fix: sudo can't determine default type for sysadm_r

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -129,7 +129,7 @@ template(`sudo_role_template',`
 
 	miscfiles_read_localization($1_sudo_t)
 
-	seutil_search_default_contexts($1_sudo_t)
+	seutil_read_default_contexts($1_sudo_t)
 	seutil_libselinux_linked($1_sudo_t)
 
 	userdom_spec_domtrans_all_users($1_sudo_t)

--- a/policy/modules/system/selinuxutil.if
+++ b/policy/modules/system/selinuxutil.if
@@ -735,8 +735,7 @@ interface(`seutil_read_default_contexts',`
 	')
 
 	files_search_etc($1)
-	allow $1 selinux_config_t:dir search_dir_perms;
-	allow $1 default_context_t:dir list_dir_perms;
+	list_dirs_pattern($1, selinux_config_t, default_context_t)
 	read_files_pattern($1, default_context_t, default_context_t)
 ')
 


### PR DESCRIPTION
Expected behavior:
```bash
# id -Z
staff_u:staff_r:staff_t
# sudo -r sysadm_r -s
$ id -Z
staff_u:sysadm_r:sysadm_t
```
Instead `sudo` fails to read the default context for `sysadm_r`
The change in `sudo.if` should be syntactic sugar.

- [x] test on a debian 10 minimal install
