### PR TITLE
fix ifupdown2 executable mislabeled as lib_t

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -313,6 +313,7 @@ ifdef(`distro_gentoo',`
 /usr/share/gnucash/finance-quote-helper -- gen_context(system_u:object_r:bin_t,s0)
 /usr/share/hal/device-manager/hal-device-manager -- gen_context(system_u:object_r:bin_t,s0)
 /usr/share/hal/scripts(/.*)?		gen_context(system_u:object_r:bin_t,s0)
+/usr/share/ifupdown2/__main__\.py	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/libalpm/scripts(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/mc/extfs/.*		--	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/Modules/init(/.*)?		gen_context(system_u:object_r:bin_t,s0)


### PR DESCRIPTION
(ifupdown2)[https://github.com/CumulusNetworks/ifupdown2] is an alternative of `ifupdown` written in python.
This means that the `ifup` and friends are symlinks to the actual entry point (`/usr/share/ifupdown2/__main__.py`).
Currently the entry point has the label `lib_t`, when it should be `bin_t`

- [x] Tested on a debian 10 minimal install