### PR TITLE
added bpf_t filesystem label

### DIFF
--- a/policy/modules/kernel/filesystem.fc
+++ b/policy/modules/kernel/filesystem.fc
@@ -11,6 +11,8 @@
 /usr/lib/udev/devices/shm	-d	gen_context(system_u:object_r:tmpfs_t,s0)
 /usr/lib/udev/devices/shm/.*	<<none>>
 
+/sys/fs/bpf(/.*)?	<<none>>
+
 /sys/fs/cgroup	-d	gen_context(system_u:object_r:cgroup_t,s0)
 /sys/fs/cgroup/.*	<<none>>
 /sys/fs/cgroup/[^/]+	-l	gen_context(system_u:object_r:cgroup_t,s0)

--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -67,6 +67,12 @@ fs_type(binfmt_misc_fs_t)
 files_mountpoint(binfmt_misc_fs_t)
 genfscon binfmt_misc / gen_context(system_u:object_r:binfmt_misc_fs_t,s0)
 
+type bpf_t;
+fs_type(bpf_t)
+files_mountpoint(bpf_t)
+dev_associate_sysfs(bpf_t)
+genfscon bpf / gen_context(system_u:object_r:bpf_t,s0)
+
 type capifs_t;
 fs_type(capifs_t)
 files_mountpoint(capifs_t)


### PR DESCRIPTION
/sys/fs/bpf is still unlabeled, which is problematic for a confined system.

**TODO:**
- [x] test on a minimal debian 10 machine