### PR TITLE
mount: allow callers of mount to search /usr/bin

### DIFF
--- a/policy/modules/system/mount.if
+++ b/policy/modules/system/mount.if
@@ -15,6 +15,7 @@ interface(`mount_domtrans',`
 		type mount_t, mount_exec_t;
 	')
 
+	corecmd_search_bin($1)
 	domtrans_pattern($1, mount_exec_t, mount_t)
 ')
 
@@ -64,6 +65,7 @@ interface(`mount_exec',`
 	allow $1 mount_exec_t:dir list_dir_perms;
 
 	allow $1 mount_exec_t:lnk_file read_lnk_file_perms;
+	corecmd_search_bin($1)
 	can_exec($1, mount_exec_t)
 ')
 


### PR DESCRIPTION
In order to be able to invoke `/usr/bin/mount`, `/usr/bin/fusermoun`t, etc. callers need to be able to search `/usr/bin`. Otherwise, such denials are recorded:

    type=AVC msg=audit(1576534518.220:1320): avc:  denied  { search }
    for  pid=24067 comm="cryfs" name="bin" dev="vda1" ino=524829
    scontext=sysadm_u:sysadm_r:cryfs_t tcontext=system_u:object_r:bin_t
    tclass=dir permissive=0