### PR TITLE
sysadm: allow using hostnamectl

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1103,6 +1103,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_dbus_chat_hostnamed(sysadm_t)
+')
+
+optional_policy(`
 	tboot_run_txtstat(sysadm_t, sysadm_r)
 ')
 


### PR DESCRIPTION
Command `hostnamectl` communicates with `systemd_hostnamed_t` through DBUS:

    type=USER_AVC msg=audit(1576535282.679:345): pid=285 uid=81
    auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t
    msg='avc:  denied  { send_msg } for msgtype=method_call
    interface=org.freedesktop.DBus.Properties member=GetAll
    dest=org.freedesktop.hostname1 spid=1449 tpid=1450
    scontext=sysadm_u:sysadm_r:sysadm_t
    tcontext=system_u:system_r:systemd_hostnamed_t tclass=dbus
    permissive=1  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=?
    terminal=?'

    type=USER_AVC msg=audit(1576535282.683:347): pid=285 uid=81
    auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t
    msg='avc:  denied  { send_msg } for msgtype=method_return
    dest=:1.269 spid=1450 tpid=1449
    scontext=system_u:system_r:systemd_hostnamed_t
    tcontext=sysadm_u:sysadm_r:sysadm_t tclass=dbus permissive=1
    exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'