### PR TITLE
init: allow systemd to mount over /dev/kmsg and /proc/kmsg

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -2354,6 +2354,24 @@ interface(`dev_rw_kmsg',`
 
 ########################################
 ## <summary>
+##	Mount on the kernel messages device
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_mounton_kmsg',`
+	gen_require(`
+		type kmsg_device_t;
+	')
+
+	allow $1 kmsg_device_t:chr_file mounton;
+')
+
+########################################
+## <summary>
 ##	Get the attributes of the ksm devices.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -286,6 +286,7 @@ ifdef(`init_systemd',`
 	kernel_search_key(init_t)
 	kernel_setsched(init_t)
 	kernel_rw_unix_sysctls(init_t)
+	kernel_mounton_message_if(init_t)
 
 	# run systemd misc initializations
 	# in the initrc_t domain, as would be
@@ -297,6 +298,7 @@ ifdef(`init_systemd',`
 	dev_relabel_all_sysfs(init_t)
 	dev_relabel_generic_symlinks(init_t)
 	dev_read_urand(init_t)
+	dev_mounton_kmsg(init_t)
 	dev_write_kmsg(init_t)
 	dev_write_urand(init_t)
 	dev_rw_lvm_control(init_t)


### PR DESCRIPTION
When spawning services such as `systemd-timedated` with systemd 244, systemd now mounts an inaccessible directory on `/dev/kmsg` and `/proc/kmsg`:

    type=AVC msg=audit(1576535711.579:363): avc:  denied  { mounton }
    for  pid=1497 comm="(imedated)"
    path="/run/systemd/unit-root/dev/kmsg" dev="devtmpfs" ino=9055
    scontext=system_u:system_r:init_t
    tcontext=system_u:object_r:kmsg_device_t tclass=chr_file
    permissive=1

    type=AVC msg=audit(1576535711.583:364): avc:  denied  { getattr }
    for  pid=1497 comm="(imedated)"
    path="/run/systemd/unit-root/proc/kmsg" dev="proc" ino=4026532027
    scontext=system_u:system_r:init_t
    tcontext=system_u:object_r:proc_kmsg_t tclass=file permissive=1

    type=AVC msg=audit(1576535711.589:365): avc:  denied  { mounton }
    for  pid=1497 comm="(imedated)"
    path="/run/systemd/unit-root/proc/kmsg" dev="proc" ino=4026532027
    scontext=system_u:system_r:init_t
    tcontext=system_u:object_r:proc_kmsg_t tclass=file permissive=1

Running `findmnt` in the resulting mount namespace shows:

    |-/dev         dev                             devtmpfs   rw,...
    | `-/dev/kmsg  run[/systemd/inaccessible/chr]  tmpfs      ro,...

    |-/proc        proc                            proc       rw,...
    | `-/proc/kmsg run[/systemd/inaccessible/reg]  tmpfs      ro,...