### PR TITLE
Add policy for CryFS, encfs and gocryptfs

### DIFF
--- a/policy/modules/apps/cryfs.fc
+++ b/policy/modules/apps/cryfs.fc
@@ -1,0 +1,3 @@
+/usr/bin/cryfs		--	gen_context(system_u:object_r:cryfs_exec_t,s0)
+/usr/bin/encfs		--	gen_context(system_u:object_r:cryfs_exec_t,s0)
+/usr/bin/gocryptfs	--	gen_context(system_u:object_r:cryfs_exec_t,s0)

--- a/policy/modules/apps/cryfs.if
+++ b/policy/modules/apps/cryfs.if
@@ -1,0 +1,40 @@
+## <summary>CryFS and similar other tools which mount encrypted directories using FUSE.</summary>
+
+########################################
+## <summary>
+##	Role access for CryFS.
+## </summary>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <param name="domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+#
+interface(`cryfs_role',`
+	gen_require(`
+		attribute_role cryfs_roles;
+		type cryfs_t, cryfs_exec_t;
+	')
+
+	########################################
+	#
+	# Declarations
+	#
+
+	roleattribute $1 cryfs_roles;
+
+	########################################
+	#
+	# Policy
+	#
+
+	domtrans_pattern($2, cryfs_exec_t, cryfs_t)
+
+	allow $2 cryfs_t:process signal_perms;
+	ps_process_pattern($2, cryfs_t)
+')

--- a/policy/modules/apps/cryfs.te
+++ b/policy/modules/apps/cryfs.te
@@ -1,0 +1,65 @@
+policy_module(cryfs, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+attribute_role cryfs_roles;
+
+type cryfs_t;
+type cryfs_exec_t;
+userdom_user_application_domain(cryfs_t, cryfs_exec_t)
+role cryfs_roles types cryfs_t;
+
+########################################
+#
+# Local policy
+#
+
+allow cryfs_t self:capability { dac_read_search sys_admin };
+allow cryfs_t self:process { getsched signal };
+allow cryfs_t self:fifo_file rw_fifo_file_perms;
+
+# CryFS 0.9.10 can check for updates everytime it runs, if it is not compiled with CRYFS_NO_UPDATE_CHECKS (option -DCRYFS_UPDATE_CHECKS=off).
+# When update checks are disabled (for example with Debian package), libcurl is nonetheless initialized.
+# curl_global_init() calls Curl_ipv6works(), which uses socket(PF_INET6, SOCK_DGRAM, 0) to check for IPv6 support.
+# Hide this useless access.
+dontaudit cryfs_t self:udp_socket create;
+
+# gocryptfs re-executes itself
+allow cryfs_t cryfs_exec_t:file execute_no_trans;
+
+# gocryptfs runs logger
+corecmd_exec_bin(cryfs_t)
+
+domain_use_interactive_fds(cryfs_t)
+
+files_mounton_all_mountpoints(cryfs_t)
+files_read_etc_files(cryfs_t)
+
+fs_getattr_xattr_fs(cryfs_t)
+fs_mount_fusefs(cryfs_t)
+
+# For /proc/sys/crypto/fips_enabled
+kernel_read_crypto_sysctls(cryfs_t)
+# gocryptfs reads /proc/sys/fs/pipe-max-size
+kernel_read_fs_sysctls(cryfs_t)
+# gocryptfs reads /proc/sys/net/core/somaxconn
+kernel_read_net_sysctls(cryfs_t)
+# gocryptfs reads /proc/cpuinfo
+kernel_read_system_state(cryfs_t)
+
+logging_send_syslog_msg(cryfs_t)
+
+miscfiles_read_generic_certs(cryfs_t)
+miscfiles_read_localization(cryfs_t)
+
+# Run fusermount in the same domain
+mount_exec(cryfs_t)
+
+# Use /dev/fuse
+storage_rw_fuse(cryfs_t)
+
+userdom_use_user_terminals(cryfs_t)
+userdom_user_content_access_template(cryfs, cryfs_t)

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1300,6 +1300,10 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
+		cryfs_role(sysadm_r, sysadm_t)
+	')
+
+	optional_policy(`
 		dbus_role_template(sysadm, sysadm_r, sysadm_t)
 
 		optional_policy(`


### PR DESCRIPTION
CryFS (https://www.cryfs.org/) is a software that can be run by non-root users that have access to `/dev/fuse`. Its command is directly used to mount a directory (`/usr/bin/cryfs basedir mountpoint`), like command `mount`. Unmounting a mountpoint is done with `fusermount -u mountpoint`, `/usr/bin/fusermount` being a setuid-`root` program labeled `mount_exec_t`.

EncFS (https://www.arg0.net/encfs) is a similar software that has been considered insecure since a security audit in 2014 found vulnerabilities that are not yet fixed (like https://github.com/vgough/encfs/issues/9).

gocryptfs (https://nuetzlich.net/gocryptfs/) is a similar software that has been inspired by EncFS.

Allow users with role `sysadm` to use all these projects.