### PR TITLE
Allow using sysadm_u with Vagrantfile configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -128,8 +128,8 @@ Vagrant.configure("2") do |config|
     end
 
     # redefine the /vagrant as a synced folder (not an NFS share), in order to work cleanly on it
-    config.vm.synced_folder ".", "/vagrant", disabled: true
-    config.vm.synced_folder ".", "/vagrant", type: "rsync",
+    debian.vm.synced_folder ".", "/vagrant", disabled: true
+    debian.vm.synced_folder ".", "/vagrant", type: "rsync",
       rsync__exclude: ".vagrant/"
 
     debian.vm.provision "shell", run: "once", inline: <<-SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,43 +15,43 @@ $install_refpolicy = <<-SHELL
   sudo -su vagrant make -C /vagrant conf
   sudo -su vagrant make -C /vagrant all
   sudo -su vagrant make -C /vagrant validate
-  sudo -s make -C /vagrant install
-  sudo -s make -C /vagrant install-headers
-  sudo -s semodule -s refpolicy -i /usr/share/selinux/refpolicy/*.pp
+  make -C /vagrant install
+  make -C /vagrant install-headers
+  semodule -s refpolicy -i /usr/share/selinux/refpolicy/*.pp
 
   if ! (LANG=C sestatus -v | grep '^Loaded policy name:\s*refpolicy$' > /dev/null)
   then
       # Use the reference policy
       sed -i -e 's/^\\(SELINUXTYPE=\\).*/SELINUXTYPE=refpolicy/' /etc/selinux/config
   fi
-  sudo -s semodule --reload
+  semodule --reload
 
   # allow every domain to use /dev/urandom
-  sudo -s semanage boolean --modify --on global_ssp
+  semanage boolean --modify --on global_ssp
 
   # allow systemd-tmpfiles to manage every file
-  sudo -s semanage boolean --modify --on systemd_tmpfiles_manage_all
+  semanage boolean --modify --on systemd_tmpfiles_manage_all
 
   # make vagrant user use unconfined_u context
-  if ! (sudo -s semanage login -l | grep '^vagrant' > /dev/null)
+  if ! (semanage login -l | grep '^vagrant' > /dev/null)
   then
       echo "Configuring SELinux context for vagrant user"
-      sudo -s semanage login -a -s unconfined_u vagrant
+      semanage login -a -s unconfined_u vagrant
   fi
 
   # label /vagrant as vagrant's home files
-  if sudo -s semanage fcontext --list | grep '^/vagrant(/\.\*)?'
+  if semanage fcontext --list | grep '^/vagrant(/\.\*)?'
   then
-      sudo -s semanage fcontext -m -s unconfined_u -t user_home_t '/vagrant(/.*)?'
+      semanage fcontext -m -s unconfined_u -t user_home_t '/vagrant(/.*)?'
   else
-      sudo -s semanage fcontext -a -s unconfined_u -t user_home_t '/vagrant(/.*)?'
+      semanage fcontext -a -s unconfined_u -t user_home_t '/vagrant(/.*)?'
   fi
 
   # Update interface_info
-  sudo -s sepolgen-ifgen -o /var/lib/sepolgen/interface_info -i /usr/share/selinux/refpolicy
+  sepolgen-ifgen -o /var/lib/sepolgen/interface_info -i /usr/share/selinux/refpolicy
 
   echo "Relabelling the system..."
-  sudo -s restorecon -RF /
+  restorecon -RF /
 
   echo "If this is a fresh install, you need to reboot in order to enable enforcing mode"
 SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,9 @@ $install_refpolicy = <<-SHELL
   make -C /vagrant install-headers
   semodule -s refpolicy -i /usr/share/selinux/refpolicy/*.pp
 
+  # Load the module specific to Vagrant VM
+  semodule -s refpolicy -i /vagrant/support/vagrant-vm.cil
+
   if ! (LANG=C sestatus -v | grep '^Loaded policy name:\s*refpolicy$' > /dev/null)
   then
       # Use the reference policy

--- a/support/vagrant-vm.cil
+++ b/support/vagrant-vm.cil
@@ -1,0 +1,21 @@
+; SELinux policy module for running virtual machines with Vagrant
+
+; Vagrant performs "ssh sudo ..." without allocating a pseudo-terminal.
+; This leads sudo to directly using sshd pipes, as well as other processes
+; spawned from the provision scripts. Define an attribute for those processes.
+(typeattribute vagrant_provisioning_cmd_type)
+(typeattributeset vagrant_provisioning_cmd_type (
+    load_policy_t
+    semanage_t
+    setfiles_t
+    sudodomain
+))
+(allow vagrant_provisioning_cmd_type sshd_t (fifo_file (append getattr ioctl read write)))
+
+; "vagrant rsync" makes Vagrant invoke "sudo rsync" without a shell which would
+; make sudo transition out of sysadm_sudo_t.
+; Therefore add a transition from sysadm_sudo_t to sysadm_t through rsync_exec_t
+(optional sysadm_sudo_rsync_transition
+    (allow sysadm_t rsync_exec_t (file (entrypoint)))
+    (typetransition sysadm_sudo_t rsync_exec_t process sysadm_t)
+)


### PR DESCRIPTION
Hi,
Currently, `Vagrantfile` is configured to use `unconfined_u` for user `vagrant`. In order to test a system without `unconfined`, it is possible to use `sysadm_u` instead, but this triggers several issues.
* The most important one is caused by the way Vagrant syncs files when `vagrant rsync` is used. It runs `sudo rsync`, which makes a first transition to `sysadm_sudo_t` and then tries to execute `rsync_exec_t`, which does not work well. This issue can be solved by adding a transition to `sysadm_t` to the policy for this specific situation.
* Another issue comes from the fact that `vagrant` does not allocate a pseudo-terminal when running provisioning scripts. So every command that is run wants to use `sshd_t` `fifo_file`. This can also be solved by adding rules to the policy. I tried to fix this by using `sudo -s` everywhere in `Vagrantfile` when I changed it a few month ago, but this did not help at all. This is why I am removing the useless `sudo -s` prefixes.

Adding the needed policy rules directly to refpolicy does not make sense, as they are very specific to the setup of the test virtual machine. Instead, create a new module, `support/vagrant-vm.cil`, and load it in `Vagrantfile`.

While changing `Vagrantfile`, I noticed a `config.vm.synced_folder` that should be `debian.vm.synced_folder`. The first commit fixes this.

With these changes, it is possible to remove the `setenforce 0` command from `Vagrantfile` and boot the Debian 10 virtual machine without `unconfined`. As I did not test the Fedora VM, I did not include removing `setenforce 0` in this Pull Request.
