### PR TITLE
netutils: allow mtr to communicate with mtr-packet

### DIFF
--- a/policy/modules/admin/netutils.fc
+++ b/policy/modules/admin/netutils.fc
@@ -4,6 +4,7 @@
 /usr/bin/iptstate	--	gen_context(system_u:object_r:netutils_exec_t,s0)
 /usr/bin/lft		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/mtr		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
+/usr/bin/mtr-packet	--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/nmap		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/ping.* 	--	gen_context(system_u:object_r:ping_exec_t,s0)
 /usr/bin/send_arp	--	gen_context(system_u:object_r:ping_exec_t,s0)

--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -165,10 +165,13 @@ optional_policy(`
 #
 
 allow traceroute_t self:capability { net_admin net_raw setgid setuid };
+allow traceroute_t self:fifo_file rw_inherited_fifo_file_perms;
 allow traceroute_t self:process signal;
 allow traceroute_t self:rawip_socket create_socket_perms;
 allow traceroute_t self:packet_socket create_socket_perms;
 allow traceroute_t self:udp_socket create_socket_perms;
+
+can_exec(traceroute_t, traceroute_exec_t)
 
 kernel_read_system_state(traceroute_t)
 kernel_read_network_state(traceroute_t)


### PR DESCRIPTION
`mtr` executes `mtr-packet` to do the actuall testing and communicates with it over a fifo.