### PR TITLE
systemd: allow reading options from EFI variable SystemdOptions

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -416,6 +416,9 @@ kernel_read_system_state(systemd_log_parse_env_type)
 
 dev_write_kmsg(systemd_log_parse_env_type)
 
+# For /sys/firmware/efi/efivars/SystemdOptions-8cf2644b-4b0b-428f-9387-6d876050dc67
+fs_read_efivarfs_files(systemd_log_parse_env_type)
+
 term_use_console(systemd_log_parse_env_type)
 
 init_read_state(systemd_log_parse_env_type)


### PR DESCRIPTION
Since systemd 244, systemd can parse EFI variable `SystemdOptions-8cf2644b-4b0b-428f-9387-6d876050dc67` like `/proc/cmdline` in order to find options. systemd's `NEWS` file [1] states:

    systemd will also read configuration options from the EFI variable
    SystemdOptions. This may be used to configure systemd behaviour when
    modifying the kernel command line is inconvenient, but configuration
    on disk is read too late, for example for the options related to
    cgroup hierarchy setup. 'bootctl systemd-efi-options' may be used to
    set the EFI variable.

In practice, all callers of `log_parse_environment()` read this EFI variable, because:

* `log_parse_environment()` is a macro which is expanded to  `log_parse_environment_realm(LOG_REALM)` [2].
* `log_parse_environment_realm()` calls `proc_cmdline_parse()` when being used in system daemons [3].
* `proc_cmdline_parse()` always calls `systemd_efi_options_variable()` [4].
* `systemd_efi_options_variable()` reads `SystemdOptions` variable [5].

For SELinux, this means that every domain with attribute `systemd_log_parse_env_type` wants to read an EFI variable. Allow this access.

[1] https://github.com/systemd/systemd/blob/v244/NEWS#L18-L23
[2] https://github.com/systemd/systemd/blob/v244/src/basic/log.h#L84
[3] https://github.com/systemd/systemd/blob/v244/src/basic/log.c#L1116
[4] https://github.com/systemd/systemd/blob/v244/src/basic/proc-cmdline.c#L122
[5] https://github.com/systemd/systemd/blob/v244/src/basic/efivars.c#L242