### PR TITLE
systemd-logind: allow using BootLoaderEntries DBUS property

### DIFF
--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -106,6 +106,39 @@ interface(`storage_raw_read_fixed_disk',`
 
 ########################################
 ## <summary>
+##	Allow the caller to directly read from a fixed disk
+##	if a tunable is set.
+##	This is extremely dangerous as it can bypass the
+##	SELinux protections for filesystem objects, and
+##	should only be used by trusted domains.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="tunable">
+##	<summary>
+##	Tunable to depend on
+##	</summary>
+## </param>
+#
+interface(`storage_raw_read_fixed_disk_cond',`
+	gen_require(`
+		attribute fixed_disk_raw_read;
+		type fixed_disk_device_t;
+	')
+
+	typeattribute $1 fixed_disk_raw_read;
+	tunable_policy($2, `
+		dev_list_all_dev_nodes($1)
+		allow $1 fixed_disk_device_t:blk_file read_blk_file_perms;
+		allow $1 fixed_disk_device_t:chr_file read_chr_file_perms;
+	')
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts made by the caller to read
 ##	fixed disk device nodes.
 ## </summary>

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -559,11 +559,10 @@ tunable_policy(`systemd_logind_get_bootloader',`
 	fs_getattr_dos_fs(systemd_logind_t)
 	fs_list_dos(systemd_logind_t)
 	fs_read_dos_files(systemd_logind_t)
-
-	# systemd-logind uses util-linux's blkid in order to find the ESP (EFI System Partition).
-	# This reads the first sectors of fixed disk devices.
-	storage_raw_read_fixed_disk(systemd_logind_t)
 ')
+# systemd-logind uses util-linux's blkid in order to find the ESP (EFI System Partition).
+# This reads the first sectors of fixed disk devices.
+storage_raw_read_fixed_disk_cond(systemd_logind_t, systemd_logind_get_bootloader)
 
 optional_policy(`
 	dbus_connect_system_bus(systemd_logind_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -20,6 +20,15 @@ gen_tunable(systemd_tmpfiles_manage_all, false)
 ## </desc>
 gen_tunable(systemd_nspawn_labeled_namespace, false)
 
+## <desc>
+## <p>
+## Allow systemd-logind to interact with the bootloader (read which one is
+## installed on fixed disks, enumerate entries for dbus property
+## BootLoaderEntries, etc.)
+## </p>
+## </desc>
+gen_tunable(systemd_logind_get_bootloader, false)
+
 attribute systemd_log_parse_env_type;
 attribute systemd_tmpfiles_conf_type;
 attribute systemd_user_session_type;
@@ -544,6 +553,16 @@ userdom_use_user_ttys(systemd_logind_t)
 ifdef(`distro_redhat',`
 	userdom_user_run_filetrans_user_runtime(systemd_logind_t, dir)
 	userdom_user_runtime_root_filetrans_user_runtime(systemd_logind_t, dir)
+')
+
+tunable_policy(`systemd_logind_get_bootloader',`
+	fs_getattr_dos_fs(systemd_logind_t)
+	fs_list_dos(systemd_logind_t)
+	fs_read_dos_files(systemd_logind_t)
+
+	# systemd-logind uses util-linux's blkid in order to find the ESP (EFI System Partition).
+	# This reads the first sectors of fixed disk devices.
+	storage_raw_read_fixed_disk(systemd_logind_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
`systemd-logind` exposes several properties reload to the bootloader. One of them is `BootLoaderEntries` [1], which scans the disks using util-linux's blkid in order to find the ESP (EFI System Partition) [2][3].

This triggers the following logs in `audit.log` (where `/dev/sda1` is the ESP, mounted on `/boot`):

    type=AVC msg=audit(1577692922.834:310): avc:  denied  { getattr }
    for  pid=690 comm="systemd-logind" name="/" dev="sda1" ino=1
    scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:dosfs_t tclass=filesystem permissive=1

    type=AVC msg=audit(1577692922.841:311): avc:  denied  { search } for
    pid=690 comm="systemd-logind" name="/" dev="sda1" ino=1
    scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:dosfs_t tclass=dir permissive=1

    type=AVC msg=audit(1577692922.841:312): avc:  denied  { getattr }
    for  pid=690 comm="systemd-logind" path="/boot" dev="sda1" ino=1
    scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:dosfs_t tclass=dir permissive=1

    type=AVC msg=audit(1577692922.841:313): avc:  denied  { read } for
    pid=690 comm="systemd-logind" name="sda1" dev="devtmpfs" ino=2496
    scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:fixed_disk_device_t tclass=blk_file
    permissive=1

    type=AVC msg=audit(1577692922.841:313): avc:  denied  { open } for
    pid=690 comm="systemd-logind" path="/dev/sda1" dev="devtmpfs"
    ino=2496 scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:fixed_disk_device_t tclass=blk_file
    permissive=1

    type=AVC msg=audit(1577692922.844:314): avc:  denied  { getattr }
    for  pid=690 comm="systemd-logind" path="/dev/sda1" dev="devtmpfs"
    ino=2496 scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:fixed_disk_device_t tclass=blk_file
    permissive=1

    type=AVC msg=audit(1577692922.844:315): avc:  denied  { ioctl } for
    pid=690 comm="systemd-logind" path="/dev/sda1" dev="devtmpfs"
    ino=2496 ioctlcmd=0x1272 scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:fixed_disk_device_t tclass=blk_file
    permissive=1

    type=AVC msg=audit(1577692922.851:316): avc:  denied  { read } for
    pid=690 comm="systemd-logind" name="loader.conf" dev="sda1" ino=4
    scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:dosfs_t tclass=file permissive=1

    type=AVC msg=audit(1577692922.851:316): avc:  denied  { open } for
    pid=690 comm="systemd-logind" path="/boot/loader/loader.conf"
    dev="sda1" ino=4 scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:dosfs_t tclass=file permissive=1

    type=AVC msg=audit(1577692922.851:317): avc:  denied  { getattr }
    for  pid=690 comm="systemd-logind" path="/boot/loader/loader.conf"
    dev="sda1" ino=4 scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:dosfs_t tclass=file permissive=1

    type=AVC msg=audit(1577692922.851:318): avc:  denied  { ioctl } for
    pid=690 comm="systemd-logind" path="/boot/loader/loader.conf"
    dev="sda1" ino=4 ioctlcmd=0x5401
    scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:dosfs_t tclass=file permissive=1

    type=AVC msg=audit(1577692922.851:319): avc:  denied  { read } for
    pid=690 comm="systemd-logind" name="entries" dev="sda1" ino=5
    scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:dosfs_t tclass=dir permissive=1

    type=AVC msg=audit(1577692922.851:319): avc:  denied  { open } for
    pid=690 comm="systemd-logind" path="/boot/loader/entries" dev="sda1"
    ino=5 scontext=system_u:system_r:systemd_logind_t
    tcontext=system_u:object_r:dosfs_t tclass=dir permissive=1

[1] https://github.com/systemd/systemd/blob/v244/src/login/logind-dbus.c#L3315
[2] https://github.com/systemd/systemd/blob/v244/src/login/logind-dbus.c#L3118
[3] https://github.com/systemd/systemd/blob/v244/src/shared/bootspec.c#L835