### PR TITLE
policy for systemd-fstab-generator

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1400,7 +1400,7 @@ interface(`init_manage_pid_symlinks', `
 
 ######################################
 ## <summary>
-##  Create and write files in the /run/systemd directory.
+##  Create files in the /run/systemd directory.
 ## </summary>
 ## <param name="domain">
 ##  <summary>
@@ -1408,12 +1408,30 @@ interface(`init_manage_pid_symlinks', `
 ##  </summary>
 ## </param>
 #
-interface(`init_create_write_pid_files', `
+interface(`init_create_pid_files', `
 	gen_require(`
 		type init_runtime_t;
 	')
 
-	allow $1 init_runtime_t:file { create_file_perms write };
+	allow $1 init_runtime_t:file create_file_perms;
+')
+
+######################################
+## <summary>
+##  Write files in the /run/systemd directory.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`init_write_pid_files', `
+	gen_require(`
+		type init_runtime_t;
+	')
+
+	allow $1 init_runtime_t:file write_file_perms;
 ')
 
 ######################################

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1380,6 +1380,61 @@ interface(`init_list_pids',`
 	files_search_pids($1)
 ')
 
+######################################
+## <summary>
+##  Create symbolic links in the /run/systemd directory.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`init_manage_pid_symlinks', `
+	gen_require(`
+		type init_runtime_t;
+	')
+
+	allow $1 init_runtime_t:lnk_file create_lnk_file_perms;
+')
+
+######################################
+## <summary>
+##  Create and write files in the /run/systemd directory.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`init_create_write_pid_files', `
+	gen_require(`
+		type init_runtime_t;
+	')
+
+	allow $1 init_runtime_t:file { create_file_perms write };
+')
+
+######################################
+## <summary>
+##  Create, read, write, and delete
+##  directories in the /run/systemd directory.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`init_manage_pid_dirs', `
+	gen_require(`
+		type init_runtime_t;
+	')
+
+	manage_dirs_pattern($1, init_runtime_t, init_runtime_t)
+')
+
 ########################################
 ## <summary>
 ##	Create files in an init PID directory.

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -18,6 +18,7 @@
 /usr/bin/systemd-notify			--	gen_context(system_u:object_r:systemd_notify_exec_t,s0)
 
 # Systemd generators
+/usr/lib/systemd/system-generators/systemd-fstab-generator	    --	    gen_context(system_u:object_r:systemd_fstab_generator_exec_t,s0)
 /usr/lib/systemd/system-generators/systemd-gpt-auto-generator	    --	    gen_context(system_u:object_r:systemd_gpt_generator_exec_t,s0)
 
 /usr/lib/systemd/systemd-activate	--	gen_context(system_u:object_r:systemd_activate_exec_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1003,7 +1003,7 @@ auth_use_nsswitch(systemd_resolved_t)
 
 files_watch_root_dirs(systemd_resolved_t)
 files_watch_runtime_dirs(systemd_resolved_t)
- 
+
 init_dgram_send(systemd_resolved_t)
 
 seutil_read_file_contexts(systemd_resolved_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -52,6 +52,10 @@ init_unit_file(systemd_binfmt_unit_t)
 type systemd_conf_t;
 files_config_file(systemd_conf_t)
 
+type systemd_fstab_generator_t;
+type systemd_fstab_generator_exec_t;
+init_system_domain(systemd_fstab_generator_t, systemd_fstab_generator_exec_t)
+
 type systemd_gpt_generator_t;
 type systemd_gpt_generator_exec_t;
 init_system_domain(systemd_gpt_generator_t, systemd_gpt_generator_exec_t)
@@ -257,6 +261,27 @@ systemd_log_parse_environment(systemd_binfmt_t)
 files_read_etc_files(systemd_binfmt_t)
 
 fs_register_binary_executable_type(systemd_binfmt_t)
+
+#######################################
+#
+# fstab generator local policy
+#
+
+corecmd_search_bin(systemd_fstab_generator_t)
+
+files_read_etc_files(systemd_fstab_generator_t)
+files_search_pids(systemd_fstab_generator_t)
+
+fstools_exec(systemd_fstab_generator_t)
+
+init_create_write_pid_files(systemd_fstab_generator_t)
+init_manage_pid_dirs(systemd_fstab_generator_t)
+init_manage_pid_symlinks(systemd_fstab_generator_t)
+init_search_pids(systemd_fstab_generator_t)
+
+kernel_read_kernel_sysctls(systemd_fstab_generator_t)
+
+systemd_log_parse_environment(systemd_fstab_generator_t)
 
 #######################################
 #

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -274,10 +274,11 @@ files_search_pids(systemd_fstab_generator_t)
 
 fstools_exec(systemd_fstab_generator_t)
 
-init_create_write_pid_files(systemd_fstab_generator_t)
+init_create_pid_files(systemd_fstab_generator_t)
 init_manage_pid_dirs(systemd_fstab_generator_t)
 init_manage_pid_symlinks(systemd_fstab_generator_t)
 init_search_pids(systemd_fstab_generator_t)
+init_write_pid_files(systemd_fstab_generator_t)
 
 kernel_read_kernel_sysctls(systemd_fstab_generator_t)
 


### PR DESCRIPTION
Implementing a policy for systemd-fstab-generator instead of allowing `initrc_t` to write to `init_runtime_t`.

Tested on:
- [x] debian minimal install (enforcing=1)

Comments are appreciated.