### PR TITLE
virt: allow more accesses to libvirt_leaseshelper

### DIFF
--- a/policy/modules/services/virt.te
+++ b/policy/modules/services/virt.te
@@ -1305,6 +1305,8 @@ userdom_use_user_ptys(virt_bridgehelper_t)
 # Leaseshelper local policy
 #
 
+allow virt_leaseshelper_t self:process getsched;
+
 allow virt_leaseshelper_t virtd_t:fd use;
 allow virt_leaseshelper_t virtd_t:fifo_file write_fifo_file_perms;
 
@@ -1316,6 +1318,13 @@ manage_files_pattern(virt_leaseshelper_t, virt_runtime_t, virt_runtime_t)
 files_pid_filetrans(virt_leaseshelper_t, virt_runtime_t, file)
 
 kernel_dontaudit_read_system_state(virt_leaseshelper_t)
+
+# Read /sys/devices/system/node/node*/meminfo
+dev_list_sysfs(virt_leaseshelper_t)
+dev_read_sysfs(virt_leaseshelper_t)
+
+# Read /etc/libnl/classid
+files_read_etc_files(virt_leaseshelper_t)
 
 ########################################
 #


### PR DESCRIPTION
When using libvirt to manage virtual machines, `libvirt_leaseshelper` wants to:

* read `/etc/libnl/classid`
* list the content of `/sys/devices/system/node/` in order to read files such as `/sys/devices/system/node/node0/meminfo`
* use `getsched`