### PR TITLE
usermanage: add groupadd to lookup dynamic users from systemd

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -278,6 +278,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_use_nss(groupadd_t)
+')
+
+optional_policy(`
 	unconfined_use_fds(groupadd_t)
 ')
 

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -1,5 +1,6 @@
 /etc/\.updated				--	gen_context(system_u:object_r:systemd_update_run_t,s0)
 
+/etc/systemd/dont-synthesize-nobody	--	gen_context(system_u:object_r:systemd_conf_t,s0)
 /etc/udev/hwdb\.bin			--	gen_context(system_u:object_r:systemd_hwdb_t,s0)
 
 /run/log/journal(/.*)?				gen_context(system_u:object_r:systemd_journal_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -81,6 +81,34 @@ interface(`systemd_log_parse_environment',`
 
 ######################################
 ## <summary>
+##   Allow domain to use systemd's Name Service Switch (NSS) module.
+##   This module provides UNIX user and group name resolution for dynamic users
+##   and groups allocated through the DynamicUser= option in systemd unit files
+## </summary>
+## <param name="domain">
+##   <summary>
+##     Domain allowed access
+##   </summary>
+## </param>
+#
+interface(`systemd_use_nss',`
+	gen_require(`
+		type systemd_conf_t;
+	')
+
+	# Get attributes of /etc/systemd/dont-synthesize-nobody
+	files_search_etc($1)
+	allow $1 systemd_conf_t:file getattr;
+
+	optional_policy(`
+		dbus_system_bus_client($1)
+		# For GetDynamicUser(), LookupDynamicUserByName()... of org.freedesktop.systemd1.Manager
+		init_dbus_chat($1)
+	')
+')
+
+######################################
+## <summary>
 ##   Allow domain to be used as a systemd service with a unit
 ##   that uses PrivateDevices=yes in section [Service].
 ## </summary>

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -49,6 +49,9 @@ init_system_domain(systemd_binfmt_t, systemd_binfmt_exec_t)
 type systemd_binfmt_unit_t;
 init_unit_file(systemd_binfmt_unit_t)
 
+type systemd_conf_t;
+files_config_file(systemd_conf_t)
+
 type systemd_gpt_generator_t;
 type systemd_gpt_generator_exec_t;
 init_system_domain(systemd_gpt_generator_t, systemd_gpt_generator_exec_t)


### PR DESCRIPTION
On a Debian 10 test virtual machine, when installing packages adds a group, the following AVC occurs:

    type=USER_AVC msg=audit(1578863991.588:575): pid=381 uid=104
    auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t
    msg='avc:  denied  { send_msg } for msgtype=method_call
    interface=org.freedesktop.systemd1.Manager
    member=LookupDynamicUserByName dest=org.freedesktop.systemd1
    spid=13759 tpid=1 scontext=unconfined_u:unconfined_r:groupadd_t
    tcontext=system_u:system_r:init_t tclass=dbus permissive=1
    exe="/usr/bin/dbus-daemon" sauid=104 hostname=? addr=? terminal=?'

Allow `groupadd` to call DBUS method `LookupDynamicUserByName()`.