### PR TITLE
Vagrantfile: allow unconfined and sysadm SSH login

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,9 @@ $install_refpolicy = <<-SHELL
   # allow every domain to use /dev/urandom
   semanage boolean --modify --on global_ssp
 
+  # allow opening SSH sessions as unconfined_u and sysadm_u
+  semanage boolean --modify --on ssh_sysadm_login
+
   # allow systemd-tmpfiles to manage every file
   semanage boolean --modify --on systemd_tmpfiles_manage_all
 


### PR DESCRIPTION
Since commit 210b64f10a44 ("Remove shell automatic domain transitions to unconfined_t from various pam login programs"), setting `ssh_sysadm_login` is mandatory in order to allow `vagrant` user to use SSH while using `unconfined_u` or `sysadm_u`.