### PR TITLE
Vagrant: allow VirtualBox provisionning to use dhclient and ip

### DIFF
--- a/support/vagrant-vm.cil
+++ b/support/vagrant-vm.cil
@@ -5,6 +5,8 @@
 ; spawned from the provision scripts. Define an attribute for those processes.
 (typeattribute vagrant_provisioning_cmd_type)
 (typeattributeset vagrant_provisioning_cmd_type (
+    dhcpc_t
+    ifconfig_t
     load_policy_t
     semanage_t
     setfiles_t


### PR DESCRIPTION
When provisioning a Debian test virtual machine with VirtualBox (using the main `Vagrantfile`), `vagrant` runs commands `dhclient` and `ip` from a ssh session because of this directive:

    debian.vm.network "private_network", type: "dhcp"

This triggers:

    type=AVC msg=audit(1578749426.820:68): avc:  denied  { write } for
    pid=541 comm="dhclient" path="pipe:[14006]" dev="pipefs" ino=14006
    scontext=unconfined_u:unconfined_r:dhcpc_t
    tcontext=system_u:system_r:sshd_t tclass=fifo_file permissive=1

    type=PROCTITLE msg=audit(1578749426.820:68):
    proctitle=2F7362696E2F6468636C69656E74002D34002D76002D69002D72002D
    7066002F72756E2F6468636C69656E742E657468312E706964002D6C66002F7661
    722F6C69622F646863702F6468636C69656E742E657468312E6C6561736573002D
    49002D6466002F7661722F6C69622F646863702F6468636C69656E74362E657468
    31

    type=AVC msg=audit(1578749427.868:69): avc:  denied  { read } for
    pid=544 comm="ip" path="pipe:[14005]" dev="pipefs" ino=14005
    scontext=unconfined_u:unconfined_r:ifconfig_t
    tcontext=system_u:system_r:sshd_t tclass=fifo_file permissive=1

    type=AVC msg=audit(1578749427.868:69): avc:  denied  { write } for
    pid=544 comm="ip" path="pipe:[14006]" dev="pipefs" ino=14006
    scontext=unconfined_u:unconfined_r:ifconfig_t
    tcontext=system_u:system_r:sshd_t tclass=fifo_file permissive=1

    type=PROCTITLE msg=audit(1578749427.868:69):
    proctitle=6970002D34006164647200666C757368006465760065746831006C61
    62656C0065746831

Handle this by adding attribute `vagrant_provisioning_cmd_type` to the relevant domains, in the policy module specific to the Vagrant test environments.