### PR TITLE
audit daemon can halt system, allow this to happen.

### DIFF
--- a/policy/modules/services/chronyd.te
+++ b/policy/modules/services/chronyd.te
@@ -100,6 +100,8 @@ miscfiles_read_localization(chronyd_t)
 chronyd_dgram_send_cli(chronyd_t)
 chronyd_read_config(chronyd_t)
 
+init_systemd_conditional(chronyd_conf_t)
+
 optional_policy(`
 	gpsd_rw_shm(chronyd_t)
 ')

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -3232,6 +3232,32 @@ interface(`init_reload_all_units',`
 	allow $1 { init_script_file_type systemdunit }:service reload;
 ')
 
+
+########################################
+## <summary>
+##      Allow init_t getattr permissions.  Generally
+##      needed for types that are used in a Condition
+##      predicate.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      type accessible by init_t
+##      </summary>
+## </param>
+#
+interface(`init_systemd_conditional',`
+	gen_require(`
+		type init_t;
+	')
+	allow init_t $1:dir search_dir_perms;
+	allow init_t $1:lnk_file read_lnk_file_perms;
+	allow init_t $1:fifo_file getattr_fifo_file_perms;
+	allow init_t $1:sock_file getattr_sock_file_perms;
+	allow init_t $1:file getattr_file_perms;
+	allow init_t $1:blk_file getattr_blk_file_perms;
+	allow init_t $1:chr_file getattr_chr_file_perms;
+')
+
 ########################################
 ## <summary>
 ##      Allow unconfined access to send instructions to init

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -223,6 +223,12 @@ ifdef(`distro_ubuntu',`
 	')
 ')
 
+ifdef(`init_systemd',`
+	init_list_unit_dirs(auditd_t)
+	systemd_start_power_units(auditd_t)
+	systemd_status_power_units(auditd_t)
+')
+
 optional_policy(`
 	mta_send_mail(auditd_t)
 ')

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -775,6 +775,26 @@ interface(`systemd_start_power_units',`
 
 ########################################
 ## <summary>
+##	Get the system status information about power units
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_status_power_units',`
+	gen_require(`
+		type power_unit_t;
+		class service status;
+	')
+
+	allow $1 power_unit_t:service status;
+')
+
+
+########################################
+## <summary>
 ##	Make the specified type usable for
 ##	systemd tmpfiles config files.
 ## </summary>


### PR DESCRIPTION
auditd can halt the system for several reasons based on configuration.
These mostly revovle around audit partition full issues.  I am seeing
the following denials when attempting to halt the system.

Jan 12 03:38:48 localhost audispd: node=localhost type=USER_AVC msg=audit(1578800328.122:1943): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { start } for auid=n/a uid=0 gid=0 path="/usr/lib/systemd/system/poweroff.target" cmdline="/sbin/init 0" scontext=system_u:system_r:auditd_t:s0 tcontext=system_u:object_r:power_unit_t:s0 tclass=service exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'

Jan 12 03:38:48 localhost audispd: node=localhost type=USER_AVC msg=audit(1578800328.147:1944): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { status } for auid=n/a uid=0 gid=0 path="/usr/lib/systemd/system/poweroff.target" cmdline="/sbin/init 0" scontext=system_u:system_r:auditd_t:s0 tcontext=system_u:object_r:power_unit_t:s0 tclass=service exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'

Jan 12 04:44:54 localhost audispd: node=localhost type=AVC msg=audit(1578804294.103:1923): avc:  denied  { getattr } for  pid=6936 comm="systemctl" path="/run/systemd/system" dev="tmpfs" ino=45 scontext=system_u:system_r:auditd_t:s0 tcontext=system_u:object_r:systemd_unit_t:s0 tclass=dir permissive=1
