### PR TITLE
Allow user domains to read/write the wireless devices (e.g. rfkill)

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -605,6 +605,7 @@ template(`userdom_common_user_template',`
 	dev_read_sound($1_t)
 	dev_read_sound_mixer($1_t)
 	dev_write_sound_mixer($1_t)
+	dev_rw_wireless($1_t)
 
 	files_exec_etc_files($1_t)
 	files_search_locks($1_t)


### PR DESCRIPTION
Allow userdomain to read and write the wireless devices (for
example for querying their state, enabling and/or disabling
them using userspace tools such as "rfkill" from util-linux):
this is tunable policy.

See also:
https://wireless.wiki.kernel.org/en/users/documentation/rfkill

Make the same access tunable throughout the rest of the policy
as it is generally controlled directly and interactively by
the user.

--
 policy/modules/admin/blueman.te           |    5 ++++-
 policy/modules/apps/wm.te                 |    5 ++++-
 policy/modules/kernel/devices.te          |    9 +++++++++
 policy/modules/services/bluetooth.te      |    5 ++++-
 policy/modules/services/hostapd.te        |    5 ++++-
 policy/modules/services/networkmanager.te |    5 ++++-
 policy/modules/system/systemd.te          |    5 ++++-
 policy/modules/system/userdomain.if       |    4 ++++
 8 files changed, 37 insertions(+), 6 deletions(-)