### PR TITLE
Escape unescaped . in file context regular expression.

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -249,7 +249,7 @@ ifdef(`distro_gentoo',`
 /usr/lib/xfce4/xfconf/xfconfd	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/xfce4/xfwm4/helper-dialog --	gen_context(system_u:object_r:bin_t,s0)
 
-/usr/lib/couchdb/erlang/lib/couch-[0-9.]+/priv/couchspawnkillable -- gen_context(system_u:object_r:bin_t,s0)
+/usr/lib/couchdb/erlang/lib/couch-[0-9\.]+/priv/couchspawnkillable -- gen_context(system_u:object_r:bin_t,s0)
 
 /usr/lib/debug/bin(/.*)?	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/debug/sbin(/.*)?	--	gen_context(system_u:object_r:bin_t,s0)


### PR DESCRIPTION
Signed-off-by: Daniel Burgener <dburgener@tresys.com>