### PR TITLE
Remove obsolete gentoo specific rule

### DIFF
--- a/policy/modules/system/logging.fc
+++ b/policy/modules/system/logging.fc
@@ -63,10 +63,6 @@ ifdef(`distro_suse', `
 /var/log/audit(/.*)?		gen_context(system_u:object_r:auditd_log_t,mls_systemhigh)
 /var/log/syslog-ng(/.*)? 	gen_context(system_u:object_r:syslogd_runtime_t,mls_systemhigh)
 
-ifndef(`distro_gentoo',`
-/var/log/audit\.log	--	gen_context(system_u:object_r:auditd_log_t,mls_systemhigh)
-')
-
 ifdef(`distro_redhat',`
 /var/named/chroot/var/log -d	gen_context(system_u:object_r:var_log_t,s0)
 /var/named/chroot/dev/log -s	gen_context(system_u:object_r:devlog_t,s0)


### PR DESCRIPTION
Looking at all audit versions in gentoo (2.8.5 to 2.6.4) every single one of them has `var/log/audit` as a directory and not as a file.

Tested on gentoo.