### PR TITLE
Associate role unconfined_r to wine_t

### DIFF
--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -223,7 +223,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	wine_domtrans(unconfined_t)
+	wine_run(unconfined_t, unconfined_r)
 ')
 
 optional_policy(`


### PR DESCRIPTION
When an unconfined user runs wine, there is an issue because `wine_domtrans()` causes a transition to `unconfined_u:unconfined_r:wine_t` without `unconfined_r` being associated with `wine_t`:

    type=SELINUX_ERR msg=audit(1579963774.148:1047):
    op=security_compute_sid
    invalid_context="unconfined_u:unconfined_r:wine_t"
    scontext=unconfined_u:unconfined_r:wine_t
    tcontext=system_u:object_r:wine_exec_t tclass=process

This is fixed with `roleattribute unconfined_r wine_roles;`, which is provided by interface `wine_run()`.