### PR TITLE
sysadm: allow usage of inherited pipes from role changing domains

### DIFF
--- a/policy/modules/roles/auditadm.te
+++ b/policy/modules/roles/auditadm.te
@@ -56,7 +56,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	sysadm_role_change(auditadm_r)
+	sysadm_role_change(auditadm_r, auditadm_t)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/secadm.te
+++ b/policy/modules/roles/secadm.te
@@ -68,7 +68,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	sysadm_role_change(secadm_r)
+	sysadm_role_change(secadm_r, secadm_t)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -52,7 +52,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	sysadm_role_change(staff_r)
+	sysadm_role_change(staff_r, staff_t)
 	userdom_dontaudit_use_user_terminals(staff_t)
 ')
 

--- a/policy/modules/roles/sysadm.if
+++ b/policy/modules/roles/sysadm.if
@@ -9,14 +9,24 @@
 ##	Role allowed access.
 ##	</summary>
 ## </param>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
 ## <rolecap/>
 #
 interface(`sysadm_role_change',`
 	gen_require(`
+		type sysadm_t;
 		role sysadm_r;
 	')
 
 	allow $1 sysadm_r;
+
+	tunable_policy(`sysadm_allow_rw_inherited_fifo', `
+		allow sysadm_t $2:fifo_file rw_inherited_fifo_file_perms;
+	')
 ')
 
 ########################################

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -12,6 +12,14 @@ policy_module(sysadm, 2.15.3)
 ## </desc>
 gen_tunable(allow_ptrace, false)
 
+## <desc>
+## <p>
+## Allow sysadm to read/write to fifo files inherited from
+## a domain allowed to change role.
+## </p>
+## </desc>
+gen_tunable(sysadm_allow_rw_inherited_fifo, false)
+
 #role sysadm_r;
 
 userdom_admin_user_template(sysadm)


### PR DESCRIPTION
Allows `staff_r:staff_t`, `auditadm_r:auditadm_t`, secadm_r:secadm_t` access to inherited pipes (sudo with pipes).
e.g:
```bash
# id -Z
staff_u:staff_r:staff_t:s0
# sudo echo 1234 | cat -
1234
```