### PR TITLE
mount: label fusermount3 like fusermount

### DIFF
--- a/policy/modules/system/mount.fc
+++ b/policy/modules/system/mount.fc
@@ -1,4 +1,5 @@
 /usr/bin/fusermount		--	gen_context(system_u:object_r:mount_exec_t,s0)
+/usr/bin/fusermount3		--	gen_context(system_u:object_r:mount_exec_t,s0)
 /usr/bin/mount(\.[^/]+)?	--	gen_context(system_u:object_r:mount_exec_t,s0)
 /usr/bin/umount(\.[^/]+)?	--	gen_context(system_u:object_r:mount_exec_t,s0)
 /usr/bin/zfs			--	gen_context(system_u:object_r:mount_exec_t,s0)


### PR DESCRIPTION
libfuse 3.0 renamed `fusermount` to `fusermount3` in order to allow both libfuse 2 and libfuse 3 to be installed together: https://github.com/libfuse/libfuse/commit/695e45a4de50a9164766a7d73656b1afc9244a56