### PR TITLE
Add a new device interface and apps permissions to watch device directories

### DIFF
--- a/policy/modules/apps/pulseaudio.te
+++ b/policy/modules/apps/pulseaudio.te
@@ -121,6 +121,7 @@ corenet_tcp_bind_soundd_port(pulseaudio_t)
 corenet_sendrecv_sap_server_packets(pulseaudio_t)
 corenet_udp_bind_sap_port(pulseaudio_t)
 
+dev_watch_dev_dirs(pulseaudio_t)
 dev_read_sound(pulseaudio_t)
 dev_write_sound(pulseaudio_t)
 dev_read_sysfs(pulseaudio_t)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -110,6 +110,24 @@ interface(`dev_getattr_fs',`
 
 ########################################
 ## <summary>
+##	Watch the directories in /dev.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_watch_dev_dirs',`
+	gen_require(`
+		type device_t;
+	')
+
+	allow $1 device_t:dir watch;
+')
+
+########################################
+## <summary>
 ##	Mount a filesystem on /dev
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Modifications required for the new SELinux **watch** permission.