### PR TITLE
Add perf_event access vectors.

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -1041,3 +1041,13 @@ class bpf
 
 class xdp_socket
 inherits socket
+
+class perf_event
+{
+	open
+	cpu
+	kernel
+	tracepoint
+	read
+	write
+}

--- a/policy/flask/security_classes
+++ b/policy/flask/security_classes
@@ -194,4 +194,6 @@ class bpf
 
 class xdp_socket
 
+class perf_event
+
 # FLASK


### PR DESCRIPTION
Added in Linux v5.5.

Signed-off-by: Chris PeBenito <chpebeni@linux.microsoft.com>