### PR TITLE
Remove unneeded semicolons after interface and macro calls

### DIFF
--- a/policy/modules/services/wireguard.te
+++ b/policy/modules/services/wireguard.te
@@ -42,7 +42,7 @@ allow wireguard_t self:netlink_route_socket r_netlink_socket_perms;
 allow wireguard_t self:udp_socket create_socket_perms;
 allow wireguard_t self:unix_stream_socket create_socket_perms;
 
-manage_files_pattern(wireguard_t, wireguard_etc_t, wireguard_etc_t);
+manage_files_pattern(wireguard_t, wireguard_etc_t, wireguard_etc_t)
 files_read_etc_files(wireguard_t)
 
 manage_files_pattern(wireguard_t, wireguard_runtime_t, wireguard_runtime_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -99,7 +99,7 @@ type systemd_hw_exec_t;
 init_system_domain(systemd_hw_t, systemd_hw_exec_t)
 
 type systemd_hwdb_t;
-files_type(systemd_hwdb_t);
+files_type(systemd_hwdb_t)
 
 type systemd_journal_t;
 files_type(systemd_journal_t)


### PR DESCRIPTION
Signed-off-by: Daniel Burgener <dburgener@tresys.com>