### PR TITLE
systemd_tmpfiles_t: Allow systemd_tempfiles_t to change permissions i…

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -4397,6 +4397,26 @@ interface(`dev_relabel_all_sysfs',`
 
 ########################################
 ## <summary>
+##  Set the attributes of sysfs files, directories and symlinks.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`dev_setattr_all_sysfs',`
+    gen_require(`
+        attribute sysfs_types;
+    ')
+
+    allow $1 sysfs_types:dir { search_dir_perms setattr };
+    allow $1 sysfs_types:file setattr;
+    allow $1 sysfs_types:lnk_file { read_lnk_file_perms setattr };
+')
+
+########################################
+## <summary>
 ##	Read and write the TPM device.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1087,6 +1087,7 @@ dev_manage_all_dev_nodes(systemd_tmpfiles_t)
 dev_read_urand(systemd_tmpfiles_t)
 dev_relabel_all_sysfs(systemd_tmpfiles_t)
 dev_read_urand(systemd_tmpfiles_t)
+dev_setattr_all_sysfs(systemd_tmpfiles_t)
 dev_manage_all_dev_nodes(systemd_tmpfiles_t)
 
 files_create_lock_dirs(systemd_tmpfiles_t)


### PR DESCRIPTION
…n sysfs

Rules specified in system tmpfiles.d configuration files are often used to
change permissions on files in sysfs.

https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html

Signed-off-by: Peter Morrow <pemorrow@linux.microsoft.com>