### PR TITLE
Restrict down wireless device permissions to prevent DoS attack

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -5065,6 +5065,24 @@ interface(`dev_write_watchdog',`
 
 ########################################
 ## <summary>
+##	Read the wireless device.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_read_wireless',`
+	gen_require(`
+		type device_t, wireless_device_t;
+	')
+
+	read_chr_files_pattern($1, device_t, wireless_device_t)
+')
+
+########################################
+## <summary>
 ##	Read and write the the wireless device.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -605,7 +605,7 @@ template(`userdom_common_user_template',`
 	dev_read_sound($1_t)
 	dev_read_sound_mixer($1_t)
 	dev_write_sound_mixer($1_t)
-	dev_rw_wireless($1_t)
+	dev_read_wireless($1_t)
 
 	files_exec_etc_files($1_t)
 	files_search_locks($1_t)
@@ -1309,6 +1309,7 @@ template(`userdom_admin_user_template',`
 	dev_rename_all_blk_files($1_t)
 	dev_rename_all_chr_files($1_t)
 	dev_create_generic_symlinks($1_t)
+	dev_rw_wireless($1_t)
 
 	domain_setpriority_all_domains($1_t)
 	domain_read_all_domains_state($1_t)


### PR DESCRIPTION
This patch improves a previous commit by restricting down
the permissions to write the wireless device in order to
prevent a possible Denial of Service (DoS) attack from an
unprivileged process bringing down the wireless interfaces.

Only administrative users can now enable/disable the wireless
interfaces, while normal users can only read their status.

---
 policy/modules/kernel/devices.if    |   18 ++++++++++++++++++
 policy/modules/system/userdomain.if |    3 ++-
 2 files changed, 20 insertions(+), 1 deletion(-)