### PR TITLE
Consider jitterentropy to belong to entropyd family

### DIFF
--- a/policy/modules/services/entropyd.fc
+++ b/policy/modules/services/entropyd.fc
@@ -1,12 +1,14 @@
-/etc/rc\.d/init\.d/((audio-entropyd)|(haveged))	--	gen_context(system_u:object_r:entropyd_initrc_exec_t,s0)
+/etc/rc\.d/init\.d/((audio-entropyd)|(haveged)|(jitterentropy-rngd))	--	gen_context(system_u:object_r:entropyd_initrc_exec_t,s0)
 
 /usr/lib/systemd/system/haveged.*\.service	--	gen_context(system_u:object_r:entropyd_unit_t,s0)
+/usr/lib/systemd/system/jitterentropy.*\.service	--	gen_context(system_u:object_r:entropyd_unit_t,s0)
 
 /usr/bin/audio-entropyd	--	gen_context(system_u:object_r:entropyd_exec_t,s0)
 /usr/bin/haveged	--	gen_context(system_u:object_r:entropyd_exec_t,s0)
 
 /usr/sbin/audio-entropyd	--	gen_context(system_u:object_r:entropyd_exec_t,s0)
 /usr/sbin/haveged	--	gen_context(system_u:object_r:entropyd_exec_t,s0)
+/usr/sbin/jitterentropy-rngd	--	gen_context(system_u:object_r:entropyd_exec_t,s0)
 
 /run/audio-entropyd\.pid	--	gen_context(system_u:object_r:entropyd_runtime_t,s0)
 /run/haveged\.pid	--	gen_context(system_u:object_r:entropyd_runtime_t,s0)

--- a/policy/modules/services/entropyd.te
+++ b/policy/modules/services/entropyd.te
@@ -42,6 +42,7 @@ files_pid_filetrans(entropyd_t, entropyd_runtime_t, file)
 
 kernel_read_system_state(entropyd_t)
 kernel_rw_kernel_sysctl(entropyd_t)
+kernel_read_crypto_sysctls(entropyd_t)
 
 dev_read_sysfs(entropyd_t)
 dev_read_urand(entropyd_t)


### PR DESCRIPTION
Also allow jitterentropy (or rather some libs) to read
/proc/crypto/fips_enabled.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>