### PR TITLE
systemd-user-runtime-dir: add policy

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -35,6 +35,7 @@
 /usr/lib/systemd/systemd-resolved	--	gen_context(system_u:object_r:systemd_resolved_exec_t,s0)
 /usr/lib/systemd/systemd-rfkill		--	gen_context(system_u:object_r:systemd_rfkill_exec_t,s0)
 /usr/lib/systemd/systemd-update-done	--	gen_context(system_u:object_r:systemd_update_done_exec_t,s0)
+/usr/lib/systemd/systemd-user-runtime-dir	--	gen_context(system_u:object_r:systemd_user_runtime_dir_exec_t,s0)
 /usr/lib/systemd/systemd-user-sessions	--	gen_context(system_u:object_r:systemd_sessions_exec_t,s0)
 
 # Systemd unit files

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -226,6 +226,10 @@ userdom_user_runtime_content(systemd_user_runtime_notify_t)
 type systemd_user_runtime_t;
 userdom_user_runtime_content(systemd_user_runtime_t)
 
+type systemd_user_runtime_dir_t;
+type systemd_user_runtime_dir_exec_t;
+init_system_domain(systemd_user_runtime_dir_t, systemd_user_runtime_dir_exec_t)
+
 #
 # Unit file types
 #
@@ -1279,3 +1283,37 @@ storage_getattr_fixed_disk_dev(systemd_user_session_type)
 # for systemd to read udev status
 udev_read_pid_files(systemd_user_session_type)
 udev_list_pids(systemd_user_session_type)
+
+#########################################
+#
+# systemd-user-runtime-dir local policy
+#
+
+allow systemd_user_runtime_dir_t self:capability { fowner chown sys_admin dac_read_search };
+allow systemd_user_runtime_dir_t self:process setfscreate;
+
+domain_obj_id_change_exemption(systemd_user_runtime_dir_t)
+
+files_read_etc_files(systemd_user_runtime_dir_t)
+
+fs_mount_tmpfs(systemd_user_runtime_dir_t)
+fs_getattr_tmpfs(systemd_user_runtime_dir_t)
+fs_list_tmpfs(systemd_user_runtime_dir_t)
+fs_unmount_tmpfs(systemd_user_runtime_dir_t)
+fs_relabelfrom_tmpfs_dirs(systemd_user_runtime_dir_t)
+
+selinux_get_enforce_mode(systemd_user_runtime_dir_t)
+selinux_getattr_fs(systemd_user_runtime_dir_t)
+
+systemd_log_parse_environment(systemd_user_runtime_dir_t)
+systemd_dbus_chat_logind(systemd_user_runtime_dir_t)
+
+seutil_read_file_contexts(systemd_user_runtime_dir_t)
+
+userdom_search_user_runtime_root(systemd_user_runtime_dir_t)
+userdom_user_runtime_root_filetrans_user_runtime(systemd_user_runtime_dir_t, dir)
+userdom_manage_user_runtime_dirs(systemd_user_runtime_dir_t)
+userdom_mounton_user_runtime_dirs(systemd_user_runtime_dir_t)
+userdom_relabelto_user_runtime_dirs(systemd_user_runtime_dir_t)
+
+dbus_system_bus_client(systemd_user_runtime_dir_t)


### PR DESCRIPTION
A policy for `systemd-user-runtime-dir`, this is to avoid adding:
```
userdom_search_user_runtime_root(systemd_user_runtime_dir_t)
userdom_user_runtime_root_filetrans_user_runtime(systemd_user_runtime_dir_t, dir)
userdom_manage_user_runtime_dirs(systemd_user_runtime_dir_t)
userdom_mounton_user_runtime_dirs(systemd_user_runtime_dir_t)
userdom_relabelto_user_runtime_dirs(systemd_user_runtime_dir_t)
```
to `initrc_t`