### PR TITLE
ntp: watch systemd networkd runtime dirs

### DIFF
--- a/policy/modules/services/ntp.te
+++ b/policy/modules/services/ntp.te
@@ -157,6 +157,8 @@ ifdef(`init_systemd',`
 	# for /run/systemd/netif/state
 	systemd_read_networkd_runtime(ntpd_t)
 
+	systemd_watch_networkd_runtime_dirs(ntpd_t)
+
 	optional_policy(`
 		chronyd_enabledisable(ntpd_t)
 		chronyd_startstop(ntpd_t)


### PR DESCRIPTION
This is required after linux 5.4