### PR TITLE
Remove old exception

### DIFF
--- a/policy/modules/kernel/terminal.fc
+++ b/policy/modules/kernel/terminal.fc
@@ -37,10 +37,3 @@
 /dev/vcs[^/]*		-c	gen_context(system_u:object_r:tty_device_t,s0)
 
 /dev/xvc[0-9]*		-c	gen_context(system_u:object_r:tty_device_t,s0)
-
-ifdef(`distro_gentoo',`
-/dev/tts/[0-9]+		-c	gen_context(system_u:object_r:tty_device_t,s0)
-
-# used by init scripts to initally populate udev /dev
-/usr/lib/udev/devices/console -c	gen_context(system_u:object_r:console_device_t,s0)
-')


### PR DESCRIPTION
This exception goes back 14 years to commit 85c20af3c10867e3d62afa4326ea3d0f5dec4e41 and 11a0508edeaa33538abdb74bb5ba033742a77a07.
The tts exception is covered by a distro agnostic rule further up, and the udev rule doesn't even work (it's supposed to be /lib/udev/ not /usr/lib/udev on gentoo) so I seriously doubt anyone is going to miss them.