### PR TITLE
WIP: Add tomoyo tools

### DIFF
--- a/policy/modules/admin/tomoyo-auditd.fc
+++ b/policy/modules/admin/tomoyo-auditd.fc
@@ -1,0 +1,5 @@
+/etc/tomoyo			-d	gen_context(system_u:object_r:tomoyo_conf_t,s0)
+
+/usr/sbin/tomoyo-auditd		--	gen_context(system_u:object_r:tomoyo_auditd_exec_t,s0)
+
+/var/log/tomoyo(/.*)?			gen_context(system_u:object_r:tomoyo_log_t,s0)

--- a/policy/modules/admin/tomoyo-auditd.if
+++ b/policy/modules/admin/tomoyo-auditd.if
@@ -1,0 +1,28 @@
+## <summary>Audit log daemon for TOMOYO Linux MAC.</summary>
+
+########################################
+## <summary>
+##	All of the rules required to
+##	administrate tomoyo-auditd.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tomoyo_auditd_admin',`
+	gen_require(`
+		type tomoyo_auditd_t;
+		type tomoyo_conf_t;
+		type tomoyo_log_t;
+	')
+
+	allow $1 tomoyo_auditd_t:process { ptrace signal_perms };
+	ps_process_pattern($1, acct_t)
+
+	admin_pattern($1, tomoyo_conf_t)
+
+	logging_search_logs($1)
+	admin_pattern($1, tomoyo_log_t)
+')

--- a/policy/modules/admin/tomoyo-auditd.te
+++ b/policy/modules/admin/tomoyo-auditd.te
@@ -1,0 +1,32 @@
+policy_module(tomoyo-auditd, 1.0)
+
+########################################
+#
+# Declarations
+#
+
+type tomoyo_auditd_t;
+type tomoyo_auditd_exec_t;
+init_daemon_domain(tomoyo_auditd_t, tomoyo_auditd_exec_t)
+
+type tomoyo_conf_t;
+files_config_file(tomoyo_conf_t)
+
+type tomoyo_log_t;
+logging_log_file(tomoyo_log_t)
+
+########################################
+#
+# Tomoyo-auditd local policy
+#
+
+#dev_rw_null(tomoyo_auditd_t)
+
+files_read_etc_files(tomoyo_auditd_t)
+read_files_pattern(tomoyo_auditd_t, tomoyo_conf_t, tomoyo_conf_t)
+
+logging_log_filetrans(tomoyo_auditd_t, tomoyo_log_t, dir)
+append_files_pattern(tomoyo_auditd_t, tomoyo_log_t, tomoyo_log_t)
+
+# Allow reading /sys/kernel/security/tomoyo/audit
+tomoyo_read_logs(tomoyo_auditd_t)

--- a/policy/modules/kernel/tomoyo.fc
+++ b/policy/modules/kernel/tomoyo.fc
@@ -1,0 +1,4 @@
+/sys/kernel/security/tomoyo			-d	gen_context(system_u:object_r:tomoyo_t,s0)
+/sys/kernel/security/tomoyo/audit		--	gen_context(system_u:object_r:tomoyo_audit_t,s0)
+/sys/kernel/security/tomoyo/self_domain		--	gen_context(system_u:object_r:tomoyo_self_domain_t,s0)
+/sys/kernel/security/tomoyo/stat		--	gen_context(system_u:object_r:tomoyo_stat_t,s0)

--- a/policy/modules/kernel/tomoyo.if
+++ b/policy/modules/kernel/tomoyo.if
@@ -1,0 +1,130 @@
+## <summary>
+##	Policy for kernel security interface, in particular, TOMOYO Linux
+##	MAC.
+## </summary>
+## <required val="true">
+##	Contains the policy for the kernel TOMOYO Linux MAC security
+##	interface.
+## </required>
+
+########################################
+## <summary>
+##	Allow caller to load the policy into the kernel.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tomoyo_load_policy',`
+	gen_require(`
+		attribute can_load_policy;
+	')
+
+	dev_search_sysfs($1)
+	typeattribute $1 can_load_policy;
+	allow $1 tomoyo_t:dir list_dir_perms;
+	allow $1 tomoyo_t:file rw_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow caller to read the policy from the kernel.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tomoyo_read_policy',`
+	gen_require(`
+		type tomoyo_t;
+	')
+
+	dev_search_sysfs($1)
+	allow $1 tomoyo_t:dir list_dir_perms;
+	allow $1 tomoyo_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow caller to read the audit logs from the kernel.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tomoyo_read_logs',`
+	gen_require(`
+		type tomoyo_t;
+		type tomoyo_audit_t;
+	')
+
+	dev_search_sysfs($1)
+	allow $1 tomoyo_t:dir list_dir_perms;
+	allow $1 tomoyo_audit_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow caller to set its security domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tomoyo_set_self_domain',`
+	gen_require(`
+		type tomoyo_self_domain_t;
+	')
+
+	dev_search_sysfs($1)
+	allow $1 tomoyo_t:dir list_dir_perms;
+	allow $1 tomoyo_self_domain_t:file write_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow caller to read its security domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tomoyo_get_self_domain',`
+	gen_require(`
+		type tomoyo_self_domain_t;
+	')
+
+	dev_search_sysfs($1)
+	allow $1 tomoyo_t:dir list_dir_perms;
+	allow $1 tomoyo_self_domain_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow caller to read statistics.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tomoyo_read_stat',`
+	gen_require(`
+		type tomoyo_stat_t;
+	')
+
+	dev_search_sysfs($1)
+	allow $1 tomoyo_t:dir list_dir_perms;
+	allow $1 tomoyo_stat_t:file read_file_perms;
+')

--- a/policy/modules/kernel/tomoyo.te
+++ b/policy/modules/kernel/tomoyo.te
@@ -1,0 +1,59 @@
+policy_module(tomoyo, 1.0)
+
+########################################
+#
+# Declarations
+#
+
+type tomoyo_t;
+type tomoyo_audit_t;
+type tomoyo_self_domain_t;
+type tomoyo_stat_t;
+
+genfscon securityfs /tomoyo			gen_context(system_u:object_r:tomoyo_t,s0)
+genfscon securityfs /tomoyo/audit		gen_context(system_u:object_r:tomoyo_audit_t,s0)
+genfscon securityfs /tomoyo/domain_policy	gen_context(system_u:object_r:tomoyo_t,s0)
+genfscon securityfs /tomoyo/exception_policy	gen_context(system_u:object_r:tomoyo_t,s0)
+genfscon securityfs /tomoyo/manager		gen_context(system_u:object_r:tomoyo_t,s0)
+genfscon securityfs /tomoyo/profile		gen_context(system_u:object_r:tomoyo_t,s0)
+genfscon securityfs /tomoyo/query		gen_context(system_u:object_r:tomoyo_t,s0)
+genfscon securityfs /tomoyo/self_domain		gen_context(system_u:object_r:tomoyo_self_domain_t,s0)
+genfscon securityfs /tomoyo/stat		gen_context(system_u:object_r:tomoyo_stat_t,s0)
+genfscon securityfs /tomoyo/version		gen_context(system_u:object_r:tomoyo_t,s0)
+
+########################################
+#
+# Controlled load_policy access
+#
+
+allow can_load_policy tomoyo_t:dir list_dir_perms;
+allow can_load_policy tomoyo_t:file read_file_perms;
+
+dev_search_sysfs(can_load_policy)
+
+if(!secure_mode_policyload) {
+	allow can_load_policy tomoyo_t:file { append write };
+}
+
+########################################
+#
+# Controlled security parameters access
+#
+
+allow can_setsecparam tomoyo_t:dir list_dir_perms;
+allow can_setsecparam tomoyo_t:file rw_file_perms;
+
+dev_search_sysfs(can_setsecparam)
+
+########################################
+#
+# Unconfined access to this module
+#
+
+# read unprivileged files
+allow selinux_unconfined_type tomoyo_t:dir list_dir_perms;
+allow selinux_unconfined_type tomoyo_stat_t:file read_file_perms;
+
+# Access the self_domain API can be unconfined because self_domain
+# must be enabled by the domain_policy first.
+allow selinux_unconfined_type tomoyo_self_domain_t:file rw_file_perms;


### PR DESCRIPTION
tomoyo-auditd is a log processing daemon for TOMOYO Linux MAC. It
reads TOMOYO MAC events from /sys/kernel/security/tomoyo and puts them
to log files in /var/log/tomoyo directory.

With recent kernels, it's possible to enable and enforce both SELinux
and TOMOYO Linux MAC systems at the same time, using a kernel command
line like lsm=capability,selinux,tomoyo. This is quite useful, for
example to migrate between MAC systems.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>