### PR TITLE
Add usbguard

### DIFF
--- a/policy/modules/admin/usbguard.fc
+++ b/policy/modules/admin/usbguard.fc
@@ -1,0 +1,7 @@
+/etc/usbguard					-d	gen_context(system_u:object_r:usbguard_conf_t,s0)
+/etc/usbguard/rules\.conf				gen_context(system_u:object_r:usbguard_rules_t,s0)
+/etc/usbguard/.+					gen_context(system_u:object_r:usbguard_conf_t,s0)
+
+/usr/sbin/usbguard-daemon			--	gen_context(system_u:object_r:usbguard_daemon_exec_t,s0)
+
+/var/log/usbguard(/.*)?					gen_context(system_u:object_r:usbguard_log_t,s0)

--- a/policy/modules/admin/usbguard.if
+++ b/policy/modules/admin/usbguard.if
@@ -1,0 +1,23 @@
+## <summary>
+## Usbguard enforces the USB device authorization policy for all USB
+## devices.
+## </summary>
+
+#####################################
+## <summary>
+##	Connect to usbguard with a unix domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`usbguard_stream_connect',`
+	gen_require(`
+		type usbguard_t, usbguard_tmpfs_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, usbguard_tmpfs_t, usbguard_tmpfs_t, usbguard_t)
+')

--- a/policy/modules/admin/usbguard.te
+++ b/policy/modules/admin/usbguard.te
@@ -1,0 +1,62 @@
+policy_module(usbguard, 1.0)
+
+########################################
+#
+# Declarations
+#
+
+## <desc>
+##	<p>
+##	Determine whether authorized users can control the daemon,
+##	which requires usbguard-daemon to be able modify its rules in
+##	/etc/usbguard.
+##	</p>
+## </desc>
+gen_tunable(usbguard_user_modify_rule_files, false)
+
+type usbguard_t;
+type usbguard_daemon_exec_t;
+init_daemon_domain(usbguard_t, usbguard_daemon_exec_t)
+
+type usbguard_conf_t;
+files_config_file(usbguard_conf_t)
+
+type usbguard_log_t;
+logging_log_file(usbguard_log_t)
+
+type usbguard_rules_t;
+files_config_file(usbguard_rules_t)
+
+# /dev/shm
+type usbguard_tmpfs_t;
+files_tmpfs_file(usbguard_tmpfs_t)
+
+########################################
+#
+# Usbguard local policy
+#
+
+allow usbguard_t self:capability { chown dac_read_search fowner };
+allow usbguard_t self:netlink_kobject_uevent_socket create_socket_perms;
+allow usbguard_t self:unix_stream_socket rw_stream_socket_perms;
+
+files_read_etc_files(usbguard_t)
+list_dirs_pattern(usbguard_t, usbguard_conf_t, usbguard_conf_t)
+read_files_pattern(usbguard_t, usbguard_conf_t, usbguard_conf_t)
+read_files_pattern(usbguard_t, usbguard_conf_t, usbguard_rules_t)
+
+manage_dirs_pattern(usbguard_t, usbguard_tmpfs_t, usbguard_tmpfs_t)
+manage_files_pattern(usbguard_t, usbguard_tmpfs_t, usbguard_tmpfs_t)
+mmap_read_files_pattern(usbguard_t, usbguard_tmpfs_t, usbguard_tmpfs_t)
+fs_tmpfs_filetrans(usbguard_t, usbguard_tmpfs_t, { dir file })
+
+append_files_pattern(usbguard_t, usbguard_log_t, usbguard_log_t)
+create_files_pattern(usbguard_t, usbguard_log_t, usbguard_log_t)
+logging_log_filetrans(usbguard_t, usbguard_log_t, file)
+setattr_files_pattern(usbguard_t, usbguard_log_t, usbguard_log_t)
+
+dev_rw_sysfs(usbguard_t)
+
+tunable_policy(`usbguard_user_modify_rule_files',`
+	manage_files_pattern(usbguard_t, usbguard_conf_t, usbguard_rules_t)
+')

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1209,6 +1209,11 @@ template(`userdom_unpriv_user_template', `
 	optional_policy(`
 		systemd_dbus_chat_logind($1_t)
 	')
+
+	# Allow controlling usbguard
+	tunable_policy(`usbguard_user_modify_rule_files',`
+		usbguard_stream_connect($1_t)
+	')
 ')
 
 #######################################


### PR DESCRIPTION
Usbguard enforces the USB device authorization policy for all USB
devices. Users can be authorized to manage rules and make device
authorization decisions using a command line tool.

Add rules for usbguard. Optionally, allow authorized users to control
the daemon, which requires usbguard-daemon to be able modify its rules
in /etc/usbguard.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>