### PR TITLE
Add interface to read/write /dev/ipmi

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -2189,6 +2189,24 @@ interface(`dev_manage_input_dev',`
 
 ########################################
 ## <summary>
+##	Read and write ipmi devices (/dev/ipmi*).
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_rw_ipmi_dev',`
+	gen_require(`
+		type device_t, ipmi_device_t;
+	')
+
+	rw_chr_files_pattern($1, device_t, ipmi_device_t)
+')
+
+########################################
+## <summary>
 ##	Get the attributes of the framebuffer device node.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
/dev/ipmi is labeled, but no interfaces exist to grant access to the device.
Adding interface for read/write access, I'm not sure of read-only access is usefull. ipmitool seems to only read and write

I'm seeing the following denials.
type=AVC msg=audit(1581618155.319:786): avc:  denied  { read write } for pid=4498 comm="ipmitool" name="ipmi0" dev="devtmpfs" ino=10460 scontext=system_u:system_r:ipmi_t:s0 tcontext=system_u:object_r:ipmi_device_t:s0 tclass=chr_file permissive=1
type=AVC msg=audit(1581618155.319:786): avc:  denied  { open } for pid=4498 comm="ipmitool" path="/dev/ipmi0" dev="devtmpfs" ino=10460 scontext=system_u:system_r:ipmi_t:s0 tcontext=system_u:object_r:ipmi_device_t:s0 tclass=chr_file permissive=1
type=AVC msg=audit(1581618155.320:787): avc:  denied  { ioctl } for pid=4498 comm="ipmitool" path="/dev/ipmi0" dev="devtmpfs" ino=10460 ioctlcmd=6910 scontext=system_u:system_r:ipmi_t:s0 tcontext=system_u:object_r:ipmi_device_t:s0 tclass=chr_file permissive=1