### PR TITLE
Add dnl builtins to places in support macros where blocks ending in n…

### DIFF
--- a/policy/support/loadable_module.spt
+++ b/policy/support/loadable_module.spt
@@ -81,7 +81,7 @@ define(`interface',` dnl
 	`define(`$1',` dnl
 	pushdef(`policy_call_depth',incr(policy_call_depth)) dnl
 	policy_m4_comment(policy_call_depth,begin `$1'(dollarsstar)) dnl
-	$2
+	$2 dnl
 	popdef(`policy_call_depth') dnl
 	policy_m4_comment(policy_call_depth,end `$1'(dollarsstar)) dnl
 	'')


### PR DESCRIPTION
…ewlines are being included.

This was done in many places previously, but not all.

Signed-off-by: Daniel Burgener <Daniel.Burgener@microsoft.com>