### PR TITLE
logging: allow syslogd to remove stale socket file

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -431,7 +431,7 @@ files_search_var_lib(syslogd_t)
 
 # manage runtime files
 allow syslogd_t syslogd_runtime_t:dir create_dir_perms;
-allow syslogd_t syslogd_runtime_t:sock_file { create setattr };
+allow syslogd_t syslogd_runtime_t:sock_file { create setattr unlink };
 allow syslogd_t syslogd_runtime_t:file map;
 manage_files_pattern(syslogd_t, syslogd_runtime_t, syslogd_runtime_t)
 files_pid_filetrans(syslogd_t, syslogd_runtime_t, file)


### PR DESCRIPTION
Denial:
```
----
time->Sun Mar 15 13:57:17 2020
type=AVC msg=audit(1584280637.279:10537): avc:  denied  { unlink } for  pid=62717 comm="systemd-journal" name="io.systemd.journal" dev="tmpfs" ino=12399 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:syslogd_runtime_t:s0 tclass=sock_file permissive=0
```

Required by `systemd-journald` when restarting the service.