### PR TITLE
Rules: allow the usage of class sets in context_defaults

### DIFF
--- a/Rules.modular
+++ b/Rules.modular
@@ -16,7 +16,7 @@ users_extra := $(tmpdir)/users_extra
 
 base_sections := $(tmpdir)/pre_te_files.conf $(tmpdir)/all_attrs_types.conf $(tmpdir)/global_bools.conf $(tmpdir)/only_te_rules.conf $(tmpdir)/all_post.conf
 
-base_pre_te_files := $(secclass) $(isids) $(avs) $(ctx_defaults) $(m4support) $(poldir)/mls $(poldir)/mcs $(policycaps)
+base_pre_te_files := $(secclass) $(isids) $(avs) $(m4support) $(ctx_defaults) $(poldir)/mls $(poldir)/mcs $(policycaps)
 base_te_files := $(base_mods)
 base_post_te_files := $(user_files) $(poldir)/constraints
 base_fc_files := $(base_mods:.te=.fc)

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -32,7 +32,7 @@ all_interfaces := $(all_modules:.te=.if) $(off_mods:.te=.if)
 all_te_files := $(all_modules)
 all_fc_files := $(all_modules:.te=.fc)
 
-pre_te_files := $(secclass) $(isids) $(avs) $(ctx_defaults) $(m4support) $(poldir)/mls $(poldir)/mcs $(policycaps)
+pre_te_files := $(secclass) $(isids) $(avs) $(m4support) $(ctx_defaults) $(poldir)/mls $(poldir)/mcs $(policycaps)
 post_te_files := $(user_files) $(poldir)/constraints
 
 policy_sections := $(tmpdir)/pre_te_files.conf $(tmpdir)/all_attrs_types.conf $(tmpdir)/global_bools.conf $(tmpdir)/only_te_rules.conf $(tmpdir)/all_post.conf


### PR DESCRIPTION
Allow class sets , e.g. defined in policy/support/obj_perm_sets.spt, to
be used in default_* statements in the file policy/context_defaults