### PR TITLE
Allow systemd-coredump to stat mountpoints.

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -363,6 +363,7 @@ corecmd_read_all_executables(systemd_coredump_t)
 
 dev_write_kmsg(systemd_coredump_t)
 
+files_getattr_all_mountpoints(systemd_coredump_t)
 files_read_etc_files(systemd_coredump_t)
 files_search_var_lib(systemd_coredump_t)
 


### PR DESCRIPTION
When getting dumps from a crash in a mount namespace, systemd wants to run stat on the root in that namespace

Signed-off-by: Daniel Burgener <Daniel.Burgener@microsoft.com>