### PR TITLE
Setup domain for tpm2_* binaries

### DIFF
--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -202,6 +202,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	tpm2_rw_abrmd_pipes(system_dbusd_t)
+')
+
+optional_policy(`
 	udev_read_db(system_dbusd_t)
 ')
 

--- a/policy/modules/services/tpm2.fc
+++ b/policy/modules/services/tpm2.fc
@@ -1,4 +1,5 @@
 /usr/bin/tpm2-abrmd								--	gen_context(system_u:object_r:tpm2_abrmd_exec_t,s0)
+/usr/bin/tpm2_[^/]+									--	gen_context(system_u:object_r:tpm2_exec_t,s0)
 
 /usr/sbin/tpm2-abrmd								--	gen_context(system_u:object_r:tpm2_abrmd_exec_t,s0)
 

--- a/policy/modules/services/tpm2.if
+++ b/policy/modules/services/tpm2.if
@@ -2,6 +2,95 @@
 
 ########################################
 ## <summary>
+##	Execute tpm2_* processes
+##	in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tpm2_exec',`
+	gen_require(`
+		type tpm2_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, tpm2_exec_t)
+')
+
+########################################
+## <summary>
+##	Execute tpm2_* processes in the tpm2 domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`tpm2_domtrans',`
+	gen_require(`
+		type tpm2_t, tpm2_exec_t;
+	')
+
+	allow tpm2_t $1:fd use;
+	allow tpm2_t $1:fifo_file rw_file_perms;
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, tpm2_exec_t, tpm2_t)
+')
+
+########################################
+## <summary>
+##	Execute tpm2_* processes in the tpm2
+##	domain and allow the specified role
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+#
+interface(`tpm2_run',`
+	gen_require(`
+		type tpm2_t;
+	')
+
+	role $2 types tpm2_t;
+
+	tpm2_domtrans($1)
+')
+
+########################################
+## <summary>
+##   Send and receive messages from
+##   tpm2-abrmd over dbus.
+## </summary>
+## <param name="domain">
+##   <summary>
+##     Domain allowed access.
+##   </summary>
+## </param>
+#
+interface(`tpm2_dbus_chat_abrmd',`
+	gen_require(`
+		type tpm2_abrmd_t;
+		class dbus send_msg;
+	')
+
+	allow $1 tpm2_abrmd_t:dbus send_msg;
+	allow tpm2_abrmd_t $1:dbus send_msg;
+')
+
+########################################
+## <summary>
 ##	Allow specified domain to enable/disable tpm2-abrmd unit
 ## </summary>
 ## <param name="domain">
@@ -56,3 +145,23 @@ interface(`tpm2_status_abrmd',`
 
 	allow $1 tpm2_abrmd_unit_t:service status;
 ')
+
+########################################
+## <summary>
+##	access tpm2-abrmd fifos
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`tpm2_rw_abrmd_pipes',`
+	gen_require(`
+		type tpm2_abrmd_t;
+	')
+
+	allow $1 tpm2_abrmd_t:fd use;
+	allow $1 tpm2_abrmd_t:fifo_file rw_file_perms;
+')
+

--- a/policy/modules/services/tpm2.te
+++ b/policy/modules/services/tpm2.te
@@ -12,13 +12,18 @@ init_daemon_domain(tpm2_abrmd_t, tpm2_abrmd_exec_t)
 type tpm2_abrmd_unit_t;
 init_unit_file(tpm2_abrmd_unit_t)
 
+type tpm2_t;
+type tpm2_exec_t;
+application_domain(tpm2_t, tpm2_exec_t)
+
 ########################################
 #
-# Local policy
+# tpm2-abrmd local policy
 #
 
 allow tpm2_abrmd_t self:process signal;
 allow tpm2_abrmd_t self:unix_stream_socket create_socket_perms;
+allow tpm2_abrmd_t self:fifo_file { read write };
 
 dev_rw_tpm(tpm2_abrmd_t)
 
@@ -27,4 +32,31 @@ kernel_read_system_state(tpm2_abrmd_t)
 
 optional_policy(`
 	dbus_system_domain(tpm2_abrmd_t, tpm2_abrmd_exec_t)
+')
+
+
+###########################################
+# tpm2_* local policy
+#
+
+allow tpm2_t self:unix_stream_socket create_socket_perms;
+allow tpm2_t self:capability dac_override;
+
+dev_rw_tpm(tpm2_t)
+
+files_read_etc_files(tpm2_t)
+
+kernel_read_crypto_sysctls(tpm2_t)
+kernel_read_system_state(tpm2_t)
+
+miscfiles_read_generic_certs(tpm2_t)
+
+selinux_getattr_fs(tpm2_t)
+selinux_search_fs(tpm2_t)
+
+tpm2_dbus_chat_abrmd(tpm2_t)
+tpm2_rw_abrmd_pipes(tpm2_t)
+
+optional_policy(`
+	dbus_system_bus_client(tpm2_t)
 ')


### PR DESCRIPTION
The various /bin/tpm2_* binaries use dbus to communicate
with tpm2-abrmd and also can directly access /dev/tpmrm0.  This
seems like a way to help limit access to the TPM by running the
tpm_* binaries in their own domain.

I setup this domain because I have a process that needs to use
tpm2_hmac to encode something, but didn't want that domain to
have direct access to the TPM.  I did some basic testing to verify
that the other tpm2_* binaries have basically the same access needs.
But it wasn't through testing of all the tpm2_* binaries.

Signed-off-by: Dave Sugar <dsugar@tresys.com>
