### PR TITLE
dbus: Add tunable - dbus_can_pass_tuntap_fd

### DIFF
--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -9,6 +9,15 @@ gen_require(`
 # Declarations
 #
 
+## <desc>
+## <p>
+## Allow dbus-daemon system bus to access /dev/net/tun
+## which is needed to pass tun/tap device file descriptors
+## over D-Bus.  This is needed by openvpn3-linux.
+## </p>
+## </desc>
+gen_tunable(dbus_can_pass_tuntap_fd, false)
+
 attribute dbusd_unconfined;
 attribute session_bus_type;
 
@@ -163,6 +172,10 @@ ifdef(`init_systemd', `
 
 	# Recent versions of dbus are started as Type=notify
 	init_write_runtime_socket(system_dbusd_t)
+')
+
+tunable_policy(`dbus_can_pass_tuntap_fd',`
+        corenet_rw_tun_tap_dev(system_dbusd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
D-Bus services wanting to pass file descriptors for
tun/tap devices need to read/write privileges to /dev/tun.

Without this privilege the following denial will happen:

    type=AVC msg=audit(1582227542.557:3045): avc:  denied  { read write } for  pid=1741 comm="dbus-daemon" path="/dev/net/tun" dev="devtmpfs" ino=486 scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:tun_tap_device_t:s0 tclass=chr_file permissive=0

This is needed by OpenVPN 3 Linux, where an unprivileged
process (openvpn3-service-client) requests a tun device
from a privileged service (openvpn3-service-netcfg) over
the D-Bus system bus.

GitHub-Issue: #190
Signed-off-by: David Sommerseth <davids@openvpn.net>