### PR TITLE
systemd-user-runtime-dir: add missed required permissions

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1363,13 +1363,15 @@ fs_list_tmpfs(systemd_user_runtime_dir_t)
 fs_unmount_tmpfs(systemd_user_runtime_dir_t)
 fs_relabelfrom_tmpfs_dirs(systemd_user_runtime_dir_t)
 
+kernel_read_kernel_sysctls(systemd_user_runtime_dir_t)
+
 selinux_get_enforce_mode(systemd_user_runtime_dir_t)
-selinux_getattr_fs(systemd_user_runtime_dir_t)
 
 systemd_log_parse_environment(systemd_user_runtime_dir_t)
 systemd_dbus_chat_logind(systemd_user_runtime_dir_t)
 
 seutil_read_file_contexts(systemd_user_runtime_dir_t)
+seutil_libselinux_linked(systemd_user_runtime_dir_t)
 
 userdom_search_user_runtime_root(systemd_user_runtime_dir_t)
 userdom_user_runtime_root_filetrans_user_runtime(systemd_user_runtime_dir_t, dir)


### PR DESCRIPTION
systemd-user-runtime-dir reads /proc/sys/kernel/osrelease and the
selinux config

Missed these in #183 or they where required by a recent upgrade of my server from debian stable to unstable.