### PR TITLE
Parallel segenxml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,11 +122,13 @@ polxml := $(docs)/policy.xml
 tunxml := $(docs)/global_tunables.xml
 boolxml := $(docs)/global_booleans.xml
 htmldir := $(docs)/html
+doctmpdir := $(docs)/tmp
 else
 polxml := $(LOCAL_ROOT)/doc/policy.xml
 tunxml := $(LOCAL_ROOT)/doc/global_tunables.xml
 boolxml := $(LOCAL_ROOT)/doc/global_booleans.xml
 htmldir := $(LOCAL_ROOT)/doc/html
+doctmpdir := $(LOCAL_ROOT)/doc/tmp
 endif
 
 # config file paths
@@ -270,9 +272,9 @@ generated_fc := $(basename $(foreach dir,$(all_layers),$(wildcard $(dir)/*.fc.in
 # when a generated file is already generated
 detected_mods := $(sort $(foreach dir,$(all_layers),$(wildcard $(dir)/*.te)) $(generated_te))
 
-modxml := $(addprefix $(tmpdir)/,$(patsubst $(moddir)/%,%,$(filter $(moddir)/%,$(detected_mods:.te=.xml))))
-localmodxml := $(addprefix $(tmpdir)/,$(patsubst $(local_moddir)/%,%,$(filter $(local_moddir)/%,$(detected_mods:.te=.xml))))
-layerxml := $(sort $(addprefix $(tmpdir)/, $(notdir $(addsuffix .xml,$(all_layers)))))
+modxml := $(addprefix $(doctmpdir)/,$(patsubst $(moddir)/%,%,$(filter $(moddir)/%,$(detected_mods:.te=.xml))))
+localmodxml := $(addprefix $(doctmpdir)/,$(patsubst $(local_moddir)/%,%,$(filter $(local_moddir)/%,$(detected_mods:.te=.xml))))
+layerxml := $(sort $(addprefix $(doctmpdir)/, $(notdir $(addsuffix .xml,$(all_layers)))))
 layer_names := $(sort $(notdir $(all_layers)))
 all_metaxml = $(call detect-metaxml, $(layer_names))
 
@@ -407,31 +409,31 @@ conf.intermediate: $(polxml)
 #
 # Documentation generation
 #
-iftemplates: $(tmpdir)/iftemplates
-$(tmpdir)/iftemplates:
-	@echo "Generating interface templates into $(tmpdir)/iftemplates"
-	@test -d $(tmpdir)/iftemplates || mkdir -p $(tmpdir)/iftemplates
-	$(verbose) $(gentemplates) -g -s $(moddir) -t $(tmpdir)/iftemplates
+iftemplates: $(doctmpdir)/iftemplates
+$(doctmpdir)/iftemplates:
+	@echo "Generating interface templates into $(doctmpdir)/iftemplates"
+	@test -d $(doctmpdir)/iftemplates || mkdir -p $(doctmpdir)/iftemplates
+	$(verbose) $(gentemplates) -g -s $(moddir) -t $(doctmpdir)/iftemplates
 ifdef LOCAL_ROOT
-	$(verbose) $(gentemplates) -g -s $(local_moddir) -t $(tmpdir)/iftemplates
+	$(verbose) $(gentemplates) -g -s $(local_moddir) -t $(doctmpdir)/iftemplates
 endif
-	@touch $(tmpdir)/iftemplates
+	@touch $(doctmpdir)/iftemplates
 
-$(layerxml): %.xml: $(tmpdir)/iftemplates $(all_metaxml) $(modxml) $(localmodxml)
-	@test -d $(tmpdir) || mkdir -p $(tmpdir)
+$(layerxml): %.xml: $(doctmpdir)/iftemplates $(all_metaxml) $(modxml) $(localmodxml)
+	@test -d $(doctmpdir) || mkdir -p $(doctmpdir)
 	$(verbose) cat $(filter %/$(notdir $*)/$(metaxml), $(all_metaxml)) > $@
-	$(verbose) cat $(filter $(addprefix $(tmpdir)/, $(notdir $*))%, $(modxml)) >> $@
+	$(verbose) cat $(filter $(addprefix $(doctmpdir)/, $(notdir $*))%, $(modxml)) >> $@
 ifdef LOCAL_ROOT
-	$(verbose) cat $(filter $(addprefix $(tmpdir)/, $(notdir $*))%, $(localmodxml)) >> $@
+	$(verbose) cat $(filter $(addprefix $(doctmpdir)/, $(notdir $*))%, $(localmodxml)) >> $@
 endif
 
-$(modxml): $(tmpdir)/%.xml: $(tmpdir)/iftemplates $(moddir)/%.te $(moddir)/%.if
-	@test -d $(tmpdir)/$(dir $*) || mkdir -p $(tmpdir)/$(dir $*)
-	$(verbose) $(genxml) -w -T $(tmpdir)/iftemplates -m $(moddir)/$* > $@
+$(modxml): $(doctmpdir)/%.xml: $(doctmpdir)/iftemplates $(moddir)/%.te $(moddir)/%.if
+	@test -d $(doctmpdir)/$(dir $*) || mkdir -p $(doctmpdir)/$(dir $*)
+	$(verbose) $(genxml) -w -T $(doctmpdir)/iftemplates -m $(moddir)/$* > $@
 
-$(localmodxml): $(tmpdir)/%.xml: $(tmpdir)/iftemplates $(local_moddir)/%.te $(local_moddir)/%.if
-	@test -d $(tmpdir)/$(dir $*) || mkdir -p $(tmpdir)/$(dir $*)
-	$(verbose) $(genxml) -w -T $(tmpdir)/iftemplates -m $(local_moddir)/$* > $@
+$(localmodxml): $(doctmpdir)/%.xml: $(doctmpdir)/iftemplates $(local_moddir)/%.te $(local_moddir)/%.if
+	@test -d $(doctmpdir)/$(dir $*) || mkdir -p $(doctmpdir)/$(dir $*)
+	$(verbose) $(genxml) -w -T $(doctmpdir)/iftemplates -m $(local_moddir)/$* > $@
 
 $(tunxml): $(globaltun)
 	$(verbose) $(genxml) -w -t $< > $@
@@ -442,11 +444,11 @@ $(boolxml): $(globalbool)
 $(polxml): $(layerxml) $(tunxml) $(boolxml)
 	@echo "Creating $(@F)"
 	@test -d $(dir $(polxml)) || mkdir -p $(dir $(polxml))
-	@test -d $(tmpdir) || mkdir -p $(tmpdir)
+	@test -d $(doctmpdir) || mkdir -p $(doctmpdir)
 	$(verbose) echo '<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>' > $@
 	$(verbose) echo '<!DOCTYPE policy SYSTEM "$(notdir $(xmldtd))">' >> $@
 	$(verbose) echo '<policy>' >> $@
-	$(verbose) for i in $(basename $(notdir $(layerxml))); do echo "<layer name=\"$$i\">" >> $@; cat $(tmpdir)/$$i.xml >> $@; echo "</layer>" >> $@; done
+	$(verbose) for i in $(basename $(notdir $(layerxml))); do echo "<layer name=\"$$i\">" >> $@; cat $(doctmpdir)/$$i.xml >> $@; echo "</layer>" >> $@; done
 	$(verbose) cat $(tunxml) $(boolxml) >> $@
 	$(verbose) echo '</policy>' >> $@
 	$(verbose) if test -x $(XMLLINT) && test -f $(xmldtd); then \
@@ -637,8 +639,7 @@ resetlabels:
 #
 bare: clean
 	$(verbose) rm -f $(polxml)
-	$(verbose) rm -f $(layerxml)
-	$(verbose) rm -f $(modxml)
+	$(verbose) rm -fR $(doctmpdir)
 	$(verbose) rm -f $(tunxml)
 	$(verbose) rm -f $(boolxml)
 	$(verbose) rm -f $(mod_conf)


### PR DESCRIPTION
*  Makefile: Parallelize XML documentation generation
   This can decrease the time for 'make conf',
   e.g. with 4 cores from 8.8 to 4.9 seconds.

*  Makefile: generate temporary files for configuration in separate directory
   Use a separate directory so the clean target from Rules.* does not remove them.