### PR TITLE
mozilla: allow firefox to use user namespaces for sandboxing

### DIFF
--- a/policy/modules/apps/mozilla.te
+++ b/policy/modules/apps/mozilla.te
@@ -74,7 +74,8 @@ xdg_cache_content(mozilla_xdg_cache_t)
 #
 
 allow mozilla_t self:capability { setgid setuid sys_nice };
-allow mozilla_t self:process { sigkill signal setsched getsched setrlimit };
+allow mozilla_t self:cap_userns { sys_admin sys_chroot sys_ptrace };
+allow mozilla_t self:process { sigkill signal setcap setsched getsched setrlimit };
 allow mozilla_t self:fifo_file rw_fifo_file_perms;
 allow mozilla_t self:shm create_shm_perms;
 allow mozilla_t self:sem create_sem_perms;


### PR DESCRIPTION
See https://wiki.mozilla.org/Security/Sandbox/Specifics#Linux for reference.