### PR TITLE
modutils: allow init to execute kmod with nnp

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -479,10 +479,6 @@ ifdef(`init_systemd',`
 	')
 
 	optional_policy(`
-		modutils_domtrans(init_t)
-	')
-
-	optional_policy(`
 		# for systemd --user:
 		unconfined_search_keys(init_t)
 		unconfined_create_keys(init_t)
@@ -1228,7 +1224,6 @@ optional_policy(`
 
 optional_policy(`
 	modutils_read_module_config(initrc_t)
-	modutils_domtrans(initrc_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/modutils.te
+++ b/policy/modules/system/modutils.te
@@ -9,10 +9,9 @@ attribute_role kmod_roles;
 
 type kmod_t;
 type kmod_exec_t;
-application_domain(kmod_t, kmod_exec_t)
+init_system_domain(kmod_t, kmod_exec_t)
 kernel_domtrans_to(kmod_t, kmod_exec_t)
 mls_file_write_all_levels(kmod_t)
-roleattribute system_r kmod_roles;
 role kmod_roles types kmod_t;
 
 # module loading config


### PR DESCRIPTION
kmod_t should have been an init_system_daemon in the first place.