### PR TITLE
allow init_t to use the linux keyring

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -301,6 +301,7 @@ ifdef(`init_systemd',`
 	kernel_unmount_debugfs(init_t)
 	kernel_search_key(init_t)
 	kernel_setsched(init_t)
+	kernel_link_key(init_t)
 	kernel_rw_unix_sysctls(init_t)
 
 	# run systemd misc initializations

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -239,6 +239,7 @@ ifdef(`init_systemd',`
 	allow init_t self:netlink_route_socket create_netlink_socket_perms;
 	allow init_t initrc_t:unix_dgram_socket create_socket_perms;
 	allow init_t self:capability2 audit_read;
+	allow init_t self:key { search setattr write };
 	allow init_t self:bpf { map_create map_read map_write prog_load prog_run };
 
 	allow init_t init_mountpoint_type:dir_file_class_set { getattr mounton };


### PR DESCRIPTION
These denials only ocure if the `unconfined` module is removed during boot with `systemd` but they're required for correct functioning.