### PR TITLE
Vagrantfile: remove older installed modules before "make install"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,7 @@ $install_refpolicy = <<-SHELL
   sudo -su vagrant make -C /vagrant conf
   sudo -su vagrant make -C /vagrant all
   sudo -su vagrant make -C /vagrant validate
+  rm -f /usr/share/selinux/refpolicy/*.pp
   make -C /vagrant install
   make -C /vagrant install-headers
   semodule -s refpolicy -i /usr/share/selinux/refpolicy/*.pp


### PR DESCRIPTION
When testing issues in older versions of refpolicy (for example when git-bisecting a regression), the newer policy modules are kept in `/usr/share/selinux/refpolicy/` and trigger errors when they fail to be loaded by `semodule -s refpolicy -i /usr/share/selinux/refpolicy/*.pp`.

Avoid this situation by removed old modules from `/usr/share/selinux/refpolicy/` before running `make install`.