### PR TITLE
Fix mismatches between object class and permission macro.

### DIFF
--- a/policy/modules/admin/apt.if
+++ b/policy/modules/admin/apt.if
@@ -133,7 +133,7 @@ interface(`apt_rw_pipes',`
 		type apt_t;
 	')
 
-	allow $1 apt_t:fifo_file rw_file_perms;
+	allow $1 apt_t:fifo_file rw_fifo_file_perms;
 ')
 
 ########################################

--- a/policy/modules/admin/dpkg.if
+++ b/policy/modules/admin/dpkg.if
@@ -100,7 +100,7 @@ interface(`dpkg_domtrans_script',`
 
 	corecmd_shell_domtrans($1, dpkg_script_t)
 	allow dpkg_script_t $1:fd use;
-	allow dpkg_script_t $1:fifo_file rw_file_perms;
+	allow dpkg_script_t $1:fifo_file rw_inherited_fifo_file_perms;
 	allow dpkg_script_t $1:process sigchld;
 ')
 
@@ -120,7 +120,7 @@ interface(`dpkg_script_rw_pipes',`
 	')
 
 	allow $1 dpkg_script_t:fd use;
-	allow $1 dpkg_script_t:fifo_file rw_file_perms;
+	allow $1 dpkg_script_t:fifo_file rw_fifo_file_perms;
 ')
 
 ########################################
@@ -213,7 +213,7 @@ interface(`dpkg_script_rw_inherited_pipes',`
 	')
 
 	allow $1 dpkg_script_t:fd use;
-	allow $1 dpkg_script_t:fifo_file rw_inherited_file_perms;
+	allow $1 dpkg_script_t:fifo_file rw_inherited_fifo_file_perms;
 ')
 
 ########################################

--- a/policy/modules/admin/portage.if
+++ b/policy/modules/admin/portage.if
@@ -200,7 +200,7 @@ interface(`portage_compile_domain',`
 	# some gui ebuilds want to interact with X server, like xawtv
 	optional_policy(`
 		allow $1 xdm_xserver_tmp_t:dir { add_entry_dir_perms del_entry_dir_perms };
-		allow $1 xdm_xserver_tmp_t:sock_file { create_file_perms delete_file_perms write_file_perms };
+		allow $1 xdm_xserver_tmp_t:sock_file { create_sock_file_perms delete_sock_file_perms write_sock_file_perms };
 	')
 	') dnl end TODO
 ')

--- a/policy/modules/admin/su.if
+++ b/policy/modules/admin/su.if
@@ -55,7 +55,7 @@ template(`su_restricted_domain_template', `
 	# By default, revert to the calling domain when a shell is executed.
 	corecmd_shell_domtrans($1_su_t,$2)
 	allow $2 $1_su_t:fd use;
-	allow $2 $1_su_t:fifo_file rw_file_perms;
+	allow $2 $1_su_t:fifo_file rw_fifo_file_perms;
 	allow $2 $1_su_t:process sigchld;
 
 	kernel_read_system_state($1_su_t)
@@ -164,7 +164,7 @@ template(`su_role_template',`
 	# By default, revert to the calling domain when a shell is executed.
 	corecmd_shell_domtrans($1_su_t, $3)
 	allow $3 $1_su_t:fd use;
-	allow $3 $1_su_t:fifo_file rw_file_perms;
+	allow $3 $1_su_t:fifo_file rw_fifo_file_perms;
 	allow $3 $1_su_t:process sigchld;
 
 	kernel_read_system_state($1_su_t)

--- a/policy/modules/admin/su.if
+++ b/policy/modules/admin/su.if
@@ -55,7 +55,7 @@ template(`su_restricted_domain_template', `
 	# By default, revert to the calling domain when a shell is executed.
 	corecmd_shell_domtrans($1_su_t,$2)
 	allow $2 $1_su_t:fd use;
-	allow $2 $1_su_t:fifo_file rw_fifo_file_perms;
+	allow $2 $1_su_t:fifo_file rw_inherited_fifo_file_perms;
 	allow $2 $1_su_t:process sigchld;
 
 	kernel_read_system_state($1_su_t)
@@ -164,7 +164,7 @@ template(`su_role_template',`
 	# By default, revert to the calling domain when a shell is executed.
 	corecmd_shell_domtrans($1_su_t, $3)
 	allow $3 $1_su_t:fd use;
-	allow $3 $1_su_t:fifo_file rw_fifo_file_perms;
+	allow $3 $1_su_t:fifo_file rw_inherited_fifo_file_perms;
 	allow $3 $1_su_t:process sigchld;
 
 	kernel_read_system_state($1_su_t)

--- a/policy/modules/apps/evolution.te
+++ b/policy/modules/apps/evolution.te
@@ -91,7 +91,7 @@ xdg_data_content(evolution_xdg_data_t)
 
 allow evolution_t self:capability { setgid setuid sys_nice };
 allow evolution_t self:process { execmem getsched setsched signal signull };
-allow evolution_t self:fifo_file rw_file_perms;
+allow evolution_t self:fifo_file rw_fifo_file_perms;
 
 allow evolution_t evolution_home_t:dir manage_dir_perms;
 allow evolution_t evolution_home_t:file manage_file_perms;

--- a/policy/modules/apps/games.te
+++ b/policy/modules/apps/games.te
@@ -93,7 +93,7 @@ optional_policy(`
 # Client local policy
 #
 
-allow games_t self:fifo_file rw_file_perms;
+allow games_t self:fifo_file rw_fifo_file_perms;
 allow games_t self:sem create_sem_perms;
 allow games_t self:tcp_socket { accept listen };
 

--- a/policy/modules/apps/qemu.if
+++ b/policy/modules/apps/qemu.if
@@ -29,7 +29,7 @@ template(`qemu_domain_template',`
 
 	allow $1_t self:capability { dac_override dac_read_search };
 	allow $1_t self:process { execstack execmem signal getsched };
-	allow $1_t self:fifo_file rw_file_perms;
+	allow $1_t self:fifo_file rw_fifo_file_perms;
 	allow $1_t self:shm create_shm_perms;
 	allow $1_t self:unix_stream_socket create_stream_socket_perms;
 	allow $1_t self:tcp_socket create_stream_socket_perms;

--- a/policy/modules/apps/seunshare.te
+++ b/policy/modules/apps/seunshare.te
@@ -18,7 +18,7 @@ role system_r types seunshare_t;
 allow seunshare_t self:capability { dac_override setpcap setuid sys_admin };
 allow seunshare_t self:process { setexec signal getcap setcap };
 
-allow seunshare_t self:fifo_file rw_file_perms;
+allow seunshare_t self:fifo_file rw_fifo_file_perms;
 allow seunshare_t self:unix_stream_socket create_stream_socket_perms;
 
 corecmd_exec_shell(seunshare_t)

--- a/policy/modules/apps/uml.te
+++ b/policy/modules/apps/uml.te
@@ -47,7 +47,7 @@ allow uml_t self:tcp_socket { accept listen };
 allow uml_t self:tun_socket create;
 allow uml_t self:unix_dgram_socket { create_socket_perms sendto };
 
-allow uml_t uml_devpts_t:chr_file { rw_file_perms setattr_chr_file_perms };
+allow uml_t uml_devpts_t:chr_file { rw_chr_file_perms setattr_chr_file_perms };
 term_create_pty(uml_t, uml_devpts_t)
 
 manage_dirs_pattern(uml_t, uml_tmp_t, uml_tmp_t)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -712,7 +712,7 @@ interface(`dev_rw_generic_blk_files',`
 		type device_t;
 	')
 
-	allow $1 device_t:blk_file rw_chr_file_perms;
+	allow $1 device_t:blk_file rw_blk_file_perms;
 ')
 
 ########################################
@@ -2713,7 +2713,7 @@ interface(`dev_dontaudit_rw_lvm_control',`
 		type lvm_control_t;
 	')
 
-	dontaudit $1 lvm_control_t:chr_file rw_file_perms;
+	dontaudit $1 lvm_control_t:chr_file rw_chr_file_perms;
 ')
 
 ########################################
@@ -3086,7 +3086,7 @@ interface(`dev_dontaudit_rw_misc',`
 		type misc_device_t;
 	')
 
-	dontaudit $1 misc_device_t:chr_file rw_file_perms;
+	dontaudit $1 misc_device_t:chr_file rw_chr_file_perms;
 ')
 
 ########################################

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -171,7 +171,7 @@ allow unconfined_domain_type domain:netlink_xfrm_socket { nlmsg_write nlmsg_read
 
 # Use descriptors and pipes created by any domain.
 allow unconfined_domain_type domain:fd use;
-allow unconfined_domain_type domain:fifo_file rw_file_perms;
+allow unconfined_domain_type domain:fifo_file rw_fifo_file_perms;
 
 # Act upon any other process.
 allow unconfined_domain_type domain:process { fork signal_perms ptrace getsched setsched getsession getpgid setpgid getcap setcap share getattr setexec setfscreate noatsecure siginh setrlimit rlimitinh setcurrent setkeycreate setsockcreate getrlimit };

--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -419,7 +419,7 @@ interface(`storage_rw_fuse',`
 		type fuse_device_t;
 	')
 
-	allow $1 fuse_device_t:chr_file rw_file_perms;
+	allow $1 fuse_device_t:chr_file rw_chr_file_perms;
 ')
 
 ########################################
@@ -438,7 +438,7 @@ interface(`storage_dontaudit_rw_fuse',`
 		type fuse_device_t;
 	')
 
-	dontaudit $1 fuse_device_t:chr_file rw_file_perms;
+	dontaudit $1 fuse_device_t:chr_file rw_chr_file_perms;
 ')
 
 ########################################
@@ -567,7 +567,7 @@ interface(`storage_dontaudit_rw_scsi_generic',`
 		type scsi_generic_device_t;
 	')
 
-	dontaudit $1 scsi_generic_device_t:chr_file rw_file_perms;
+	dontaudit $1 scsi_generic_device_t:chr_file rw_chr_file_perms;
 ')
 
 ########################################

--- a/policy/modules/kernel/terminal.if
+++ b/policy/modules/kernel/terminal.if
@@ -187,7 +187,7 @@ interface(`term_create_pty',`
 	')
 
 	dev_list_all_dev_nodes($1)
-	allow $1 ptmx_t:chr_file rw_file_perms;
+	allow $1 ptmx_t:chr_file rw_chr_file_perms;
 
 	allow $1 devpts_t:dir list_dir_perms;
 	allow $1 devpts_t:filesystem getattr;
@@ -821,7 +821,7 @@ interface(`term_use_ptmx',`
 	')
 
 	dev_list_all_dev_nodes($1)
-	allow $1 ptmx_t:chr_file rw_file_perms;
+	allow $1 ptmx_t:chr_file rw_chr_file_perms;
 ')
 
 ########################################

--- a/policy/modules/roles/sysadm.if
+++ b/policy/modules/roles/sysadm.if
@@ -76,7 +76,7 @@ interface(`sysadm_shell_domtrans',`
 
 	corecmd_shell_domtrans($1, sysadm_t)
 	allow sysadm_t $1:fd use;
-	allow sysadm_t $1:fifo_file rw_file_perms;
+	allow sysadm_t $1:fifo_file rw_fifo_file_perms;
 	allow sysadm_t $1:process sigchld;
 ')
 
@@ -97,7 +97,7 @@ interface(`sysadm_bin_spec_domtrans',`
 
 	corecmd_bin_spec_domtrans($1, sysadm_t)
 	allow sysadm_t $1:fd use;
-	allow sysadm_t $1:fifo_file rw_file_perms;
+	allow sysadm_t $1:fifo_file rw_fifo_file_perms;
 	allow sysadm_t $1:process sigchld;
 ')
 
@@ -120,7 +120,7 @@ interface(`sysadm_entry_spec_domtrans',`
 
 	domain_entry_file_spec_domtrans($1, sysadm_t)
 	allow sysadm_t $1:fd use;
-	allow sysadm_t $1:fifo_file rw_file_perms;
+	allow sysadm_t $1:fifo_file rw_fifo_file_perms;
 	allow sysadm_t $1:process sigchld;
 ')
 
@@ -155,7 +155,7 @@ interface(`sysadm_entry_spec_domtrans_to',`
 
 	domain_entry_file_spec_domtrans(sysadm_t, $1)
 	allow $1 sysadm_t:fd use;
-	allow $1 sysadm_t:fifo_file rw_file_perms;
+	allow $1 sysadm_t:fifo_file rw_fifo_file_perms;
 	allow $1 sysadm_t:process sigchld;
 ')
 
@@ -189,7 +189,7 @@ interface(`sysadm_bin_spec_domtrans_to',`
 
 	corecmd_bin_spec_domtrans(sysadm_t, $1)
 	allow $1 sysadm_t:fd use;
-	allow $1 sysadm_t:fifo_file rw_file_perms;
+	allow $1 sysadm_t:fifo_file rw_fifo_file_perms;
 	allow $1 sysadm_t:process sigchld;
 ')
 

--- a/policy/modules/roles/sysadm.if
+++ b/policy/modules/roles/sysadm.if
@@ -76,7 +76,7 @@ interface(`sysadm_shell_domtrans',`
 
 	corecmd_shell_domtrans($1, sysadm_t)
 	allow sysadm_t $1:fd use;
-	allow sysadm_t $1:fifo_file rw_fifo_file_perms;
+	allow sysadm_t $1:fifo_file rw_inherited_fifo_file_perms;
 	allow sysadm_t $1:process sigchld;
 ')
 
@@ -97,7 +97,7 @@ interface(`sysadm_bin_spec_domtrans',`
 
 	corecmd_bin_spec_domtrans($1, sysadm_t)
 	allow sysadm_t $1:fd use;
-	allow sysadm_t $1:fifo_file rw_fifo_file_perms;
+	allow sysadm_t $1:fifo_file rw_inherited_fifo_file_perms;
 	allow sysadm_t $1:process sigchld;
 ')
 
@@ -120,7 +120,7 @@ interface(`sysadm_entry_spec_domtrans',`
 
 	domain_entry_file_spec_domtrans($1, sysadm_t)
 	allow sysadm_t $1:fd use;
-	allow sysadm_t $1:fifo_file rw_fifo_file_perms;
+	allow sysadm_t $1:fifo_file rw_inherited_fifo_file_perms;
 	allow sysadm_t $1:process sigchld;
 ')
 
@@ -155,7 +155,7 @@ interface(`sysadm_entry_spec_domtrans_to',`
 
 	domain_entry_file_spec_domtrans(sysadm_t, $1)
 	allow $1 sysadm_t:fd use;
-	allow $1 sysadm_t:fifo_file rw_fifo_file_perms;
+	allow $1 sysadm_t:fifo_file rw_inherited_fifo_file_perms;
 	allow $1 sysadm_t:process sigchld;
 ')
 
@@ -189,7 +189,7 @@ interface(`sysadm_bin_spec_domtrans_to',`
 
 	corecmd_bin_spec_domtrans(sysadm_t, $1)
 	allow $1 sysadm_t:fd use;
-	allow $1 sysadm_t:fifo_file rw_fifo_file_perms;
+	allow $1 sysadm_t:fifo_file rw_inherited_fifo_file_perms;
 	allow $1 sysadm_t:process sigchld;
 ')
 

--- a/policy/modules/services/apache.te
+++ b/policy/modules/services/apache.te
@@ -1120,7 +1120,7 @@ optional_policy(`
 # Common script local policy
 #
 
-allow httpd_script_domains self:fifo_file rw_file_perms;
+allow httpd_script_domains self:fifo_file rw_fifo_file_perms;
 allow httpd_script_domains self:unix_stream_socket connectto;
 
 allow httpd_script_domains httpd_sys_content_t:dir search_dir_perms;

--- a/policy/modules/services/apcupsd.te
+++ b/policy/modules/services/apcupsd.te
@@ -34,7 +34,7 @@ init_unit_file(apcupsd_unit_t)
 
 allow apcupsd_t self:capability { dac_override setgid sys_tty_config };
 allow apcupsd_t self:process signal;
-allow apcupsd_t self:fifo_file rw_file_perms;
+allow apcupsd_t self:fifo_file rw_fifo_file_perms;
 allow apcupsd_t self:unix_stream_socket create_stream_socket_perms;
 allow apcupsd_t self:tcp_socket create_stream_socket_perms;
 

--- a/policy/modules/services/condor.te
+++ b/policy/modules/services/condor.te
@@ -199,7 +199,7 @@ allow condor_schedd_t self:capability { chown dac_override setgid setuid };
 allow condor_schedd_t condor_master_t:tcp_socket rw_stream_socket_perms;
 allow condor_schedd_t condor_master_t:udp_socket getattr;
 
-allow condor_schedd_t condor_var_lock_t:dir manage_file_perms;
+allow condor_schedd_t condor_var_lock_t:dir manage_dir_perms;
 
 domtrans_pattern(condor_schedd_t, condor_procd_exec_t, condor_procd_t)
 domtrans_pattern(condor_schedd_t, condor_startd_exec_t, condor_startd_t)

--- a/policy/modules/services/dirmngr.te
+++ b/policy/modules/services/dirmngr.te
@@ -36,7 +36,7 @@ userdom_user_home_content(dirmngr_home_t)
 # Local policy
 #
 
-allow dirmngr_t self:fifo_file rw_file_perms;
+allow dirmngr_t self:fifo_file rw_fifo_file_perms;
 allow dirmngr_t self:unix_stream_socket rw_stream_socket_perms;
 
 allow dirmngr_t dirmngr_conf_t:dir list_dir_perms;

--- a/policy/modules/services/mon.te
+++ b/policy/modules/services/mon.te
@@ -110,7 +110,7 @@ optional_policy(`
 # mon_net_test_t is for running tests that need network access
 #
 
-allow mon_net_test_t self:fifo_file rw_file_perms;
+allow mon_net_test_t self:fifo_file rw_fifo_file_perms;
 
 can_exec(mon_net_test_t, mon_net_test_exec_t)
 manage_files_pattern(mon_net_test_t, mon_var_lib_t, mon_var_lib_t)
@@ -157,7 +157,7 @@ optional_policy(`
 #
 
 allow mon_local_test_t self:capability sys_admin;
-allow mon_local_test_t self:fifo_file rw_file_perms;
+allow mon_local_test_t self:fifo_file rw_fifo_file_perms;
 allow mon_local_test_t self:process getsched;
 
 can_exec(mon_local_test_t, mon_local_test_exec_t)

--- a/policy/modules/services/munin.te
+++ b/policy/modules/services/munin.te
@@ -315,7 +315,7 @@ selinux_get_enforce_mode(selinux_munin_plugin_t)
 # Service local policy
 #
 
-allow services_munin_plugin_t self:shm create_sem_perms;
+allow services_munin_plugin_t self:shm create_shm_perms;
 allow services_munin_plugin_t self:sem create_sem_perms;
 allow services_munin_plugin_t self:tcp_socket create_stream_socket_perms;
 allow services_munin_plugin_t self:udp_socket create_socket_perms;

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -58,7 +58,7 @@ template(`ssh_basic_client_template',`
 	allow $1_ssh_t self:capability { dac_override dac_read_search setgid setuid };
 	allow $1_ssh_t self:process { transition signal_perms getsched setsched getsession getpgid setpgid getcap setcap share getattr noatsecure siginh rlimitinh dyntransition setkeycreate setsockcreate getrlimit };
 	allow $1_ssh_t self:fd use;
-	allow $1_ssh_t self:fifo_file rw_fifo_file_perms;
+	allow $1_ssh_t self:fifo_file rw_inherited_fifo_file_perms;
 	allow $1_ssh_t self:unix_dgram_socket { create_socket_perms sendto };
 	allow $1_ssh_t self:unix_stream_socket { create_stream_socket_perms connectto };
 	allow $1_ssh_t self:shm create_shm_perms;
@@ -405,7 +405,7 @@ template(`ssh_role_template',`
 	userdom_search_user_home_content($1_ssh_agent_t)
 	userdom_user_home_domtrans($1_ssh_agent_t, $3)
 	allow $3 $1_ssh_agent_t:fd use;
-	allow $3 $1_ssh_agent_t:fifo_file rw_fifo_file_perms;
+	allow $3 $1_ssh_agent_t:fifo_file rw_inherited_fifo_file_perms;
 	allow $3 $1_ssh_agent_t:process sigchld;
 
 	tunable_policy(`use_nfs_home_dirs',`

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -351,7 +351,7 @@ template(`ssh_role_template',`
 
 	allow $1_ssh_agent_t self:process { setrlimit signal };
 	allow $1_ssh_agent_t self:capability setgid;
-	allow $1_ssh_agent_t self:fifo_file rw_file_perms;
+	allow $1_ssh_agent_t self:fifo_file rw_fifo_file_perms;
 
 	allow $1_ssh_agent_t { $1_ssh_agent_t $3 }:process signull;
 
@@ -405,7 +405,7 @@ template(`ssh_role_template',`
 	userdom_search_user_home_content($1_ssh_agent_t)
 	userdom_user_home_domtrans($1_ssh_agent_t, $3)
 	allow $3 $1_ssh_agent_t:fd use;
-	allow $3 $1_ssh_agent_t:fifo_file rw_file_perms;
+	allow $3 $1_ssh_agent_t:fifo_file rw_fifo_file_perms;
 	allow $3 $1_ssh_agent_t:process sigchld;
 
 	tunable_policy(`use_nfs_home_dirs',`

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -183,7 +183,7 @@ tunable_policy(`allow_ssh_keysign',`
 	domain_auto_transition_pattern(ssh_t, ssh_keysign_exec_t, ssh_keysign_t)
 	allow ssh_keysign_t ssh_t:fd use;
 	allow ssh_keysign_t ssh_t:process sigchld;
-	allow ssh_keysign_t ssh_t:fifo_file rw_fifo_file_perms;
+	allow ssh_keysign_t ssh_t:fifo_file rw_inherited_fifo_file_perms;
 ')
 
 tunable_policy(`use_nfs_home_dirs',`

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -180,10 +180,7 @@ userdom_use_user_terminals(ssh_t)
 userdom_read_user_tmp_files(ssh_t)
 
 tunable_policy(`allow_ssh_keysign',`
-	domain_auto_transition_pattern(ssh_t, ssh_keysign_exec_t, ssh_keysign_t)
-	allow ssh_keysign_t ssh_t:fd use;
-	allow ssh_keysign_t ssh_t:process sigchld;
-	allow ssh_keysign_t ssh_t:fifo_file rw_inherited_fifo_file_perms;
+	domtrans_pattern(ssh_t, ssh_keysign_exec_t, ssh_keysign_t)
 ')
 
 tunable_policy(`use_nfs_home_dirs',`

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -183,7 +183,7 @@ tunable_policy(`allow_ssh_keysign',`
 	domain_auto_transition_pattern(ssh_t, ssh_keysign_exec_t, ssh_keysign_t)
 	allow ssh_keysign_t ssh_t:fd use;
 	allow ssh_keysign_t ssh_t:process sigchld;
-	allow ssh_keysign_t ssh_t:fifo_file rw_file_perms;
+	allow ssh_keysign_t ssh_t:fifo_file rw_fifo_file_perms;
 ')
 
 tunable_policy(`use_nfs_home_dirs',`

--- a/policy/modules/services/virt.te
+++ b/policy/modules/services/virt.te
@@ -1078,7 +1078,7 @@ sysnet_domtrans_ifconfig(virtd_lxc_t)
 
 allow svirt_lxc_domain self:capability { dac_override kill setgid setuid sys_boot };
 allow svirt_lxc_domain self:process { execstack execmem getattr signal_perms getsched setsched setcap setpgid };
-allow svirt_lxc_domain self:fifo_file manage_file_perms;
+allow svirt_lxc_domain self:fifo_file manage_fifo_file_perms;
 allow svirt_lxc_domain self:sem create_sem_perms;
 allow svirt_lxc_domain self:shm create_shm_perms;
 allow svirt_lxc_domain self:msgq create_msgq_perms;

--- a/policy/modules/services/zosremote.te
+++ b/policy/modules/services/zosremote.te
@@ -19,7 +19,7 @@ role zos_remote_roles types zos_remote_t;
 #
 
 allow zos_remote_t self:process signal;
-allow zos_remote_t self:fifo_file rw_file_perms;
+allow zos_remote_t self:fifo_file rw_fifo_file_perms;
 allow zos_remote_t self:unix_stream_socket { accept listen };
 
 auth_use_nsswitch(zos_remote_t)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -167,7 +167,7 @@ allow pam_t self:process { transition signal_perms getsched setsched getsession 
 dontaudit pam_t self:capability sys_tty_config;
 
 allow pam_t self:fd use;
-allow pam_t self:fifo_file rw_file_perms;
+allow pam_t self:fifo_file rw_fifo_file_perms;
 allow pam_t self:unix_dgram_socket create_socket_perms;
 allow pam_t self:unix_stream_socket rw_stream_socket_perms;
 allow pam_t self:unix_dgram_socket sendto;

--- a/policy/modules/system/hotplug.te
+++ b/policy/modules/system/hotplug.te
@@ -27,7 +27,7 @@ dontaudit hotplug_t self:capability { sys_admin sys_module sys_ptrace sys_tty_co
 # for access("/etc/bashrc", X_OK) on Red Hat
 dontaudit hotplug_t self:capability { dac_override dac_read_search };
 allow hotplug_t self:process { setpgid getsession getattr signal_perms };
-allow hotplug_t self:fifo_file rw_file_perms;
+allow hotplug_t self:fifo_file rw_fifo_file_perms;
 allow hotplug_t self:netlink_route_socket r_netlink_socket_perms;
 allow hotplug_t self:udp_socket create_socket_perms;
 allow hotplug_t self:tcp_socket connected_stream_socket_perms;

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -147,10 +147,8 @@ files_pid_filetrans(init_t, init_runtime_t, file)
 # for /run/initctl
 allow init_t init_runtime_t:fifo_file manage_fifo_file_perms;
 
-allow init_t init_runtime_t:lnk_file manage_lnk_file_perms;
-
 # for systemd to manage service file symlinks
-allow init_t init_runtime_t:file manage_lnk_file_perms;
+allow init_t init_runtime_t:lnk_file manage_lnk_file_perms;
 
 allow init_t initctl_t:fifo_file manage_fifo_file_perms;
 dev_filetrans(init_t, initctl_t, fifo_file)
@@ -582,7 +580,7 @@ allow initrc_t self:unix_dgram_socket create_socket_perms;
 allow initrc_t self:unix_stream_socket { create listen accept ioctl read getattr write setattr append bind connect getopt setopt shutdown connectto };
 allow initrc_t self:tcp_socket create_stream_socket_perms;
 allow initrc_t self:udp_socket create_socket_perms;
-allow initrc_t self:fifo_file rw_file_perms;
+allow initrc_t self:fifo_file rw_fifo_file_perms;
 
 allow initrc_t initrc_devpts_t:chr_file rw_term_perms;
 term_create_pty(initrc_t, initrc_devpts_t)

--- a/policy/modules/system/selinuxutil.if
+++ b/policy/modules/system/selinuxutil.if
@@ -353,7 +353,7 @@ interface(`seutil_labeled_init_script_domtrans_runinit',`
 	domain_auto_transition_pattern($1, $2, run_init_t)
 
 	allow run_init_t $1:fd use;
-	allow run_init_t $1:fifo_file rw_file_perms;
+	allow run_init_t $1:fifo_file rw_inherited_fifo_file_perms;
 	allow run_init_t $1:process sigchld;
 ')
 
@@ -381,7 +381,7 @@ interface(`seutil_init_script_domtrans_runinit',`
 	init_script_file_domtrans($1, run_init_t)
 
 	allow run_init_t $1:fd use;
-	allow run_init_t $1:fifo_file rw_file_perms;
+	allow run_init_t $1:fifo_file rw_inherited_fifo_file_perms;
 	allow run_init_t $1:process sigchld;
 ')
 

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -404,7 +404,7 @@ allow run_init_roles system_r;
 
 allow run_init_t self:process setexec;
 allow run_init_t self:capability setuid;
-allow run_init_t self:fifo_file rw_file_perms;
+allow run_init_t self:fifo_file rw_fifo_file_perms;
 allow run_init_t self:netlink_audit_socket { create_netlink_socket_perms nlmsg_relay };
 
 # often the administrator runs such programs from a directory that is owned
@@ -572,7 +572,7 @@ optional_policy(`
 
 allow setfiles_t self:capability { dac_override dac_read_search fowner };
 dontaudit setfiles_t self:capability sys_tty_config;
-allow setfiles_t self:fifo_file rw_file_perms;
+allow setfiles_t self:fifo_file rw_fifo_file_perms;
 
 allow setfiles_t { policy_src_t policy_config_t file_context_t default_context_t }:dir list_dir_perms;
 allow setfiles_t { policy_src_t policy_config_t file_context_t default_context_t }:file read_file_perms;

--- a/policy/modules/system/udev.if
+++ b/policy/modules/system/udev.if
@@ -289,7 +289,7 @@ interface(`udev_relabelto_db',`
 
 	files_search_pids($1)
 	allow $1 udev_runtime_t:file relabelto_file_perms;
-	allow $1 udev_runtime_t:lnk_file relabelto_file_perms;
+	allow $1 udev_runtime_t:lnk_file relabelto_lnk_file_perms;
 ')
 
 ########################################

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -197,7 +197,7 @@ interface(`unconfined_shell_domtrans',`
 
 	corecmd_shell_domtrans($1, unconfined_t)
 	allow unconfined_t $1:fd use;
-	allow unconfined_t $1:fifo_file rw_file_perms;
+	allow unconfined_t $1:fifo_file rw_inherited_fifo_file_perms;
 	allow unconfined_t $1:process sigchld;
 ')
 
@@ -418,7 +418,7 @@ interface(`unconfined_dontaudit_rw_pipes',`
 		type unconfined_t;
 	')
 
-	dontaudit $1 unconfined_t:fifo_file rw_file_perms;
+	dontaudit $1 unconfined_t:fifo_file rw_fifo_file_perms;
 ')
 
 ########################################

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -3968,7 +3968,7 @@ interface(`userdom_spec_domtrans_all_users',`
 
 	corecmd_shell_spec_domtrans($1, userdomain)
 	allow userdomain $1:fd use;
-	allow userdomain $1:fifo_file rw_fifo_file_perms;
+	allow userdomain $1:fifo_file rw_inherited_fifo_file_perms;
 	allow userdomain $1:process sigchld;
 ')
 
@@ -3991,7 +3991,7 @@ interface(`userdom_xsession_spec_domtrans_all_users',`
 
 	xserver_xsession_spec_domtrans($1, userdomain)
 	allow userdomain $1:fd use;
-	allow userdomain $1:fifo_file rw_fifo_file_perms;
+	allow userdomain $1:fifo_file rw_inherited_fifo_file_perms;
 	allow userdomain $1:process sigchld;
 ')
 
@@ -4014,7 +4014,7 @@ interface(`userdom_spec_domtrans_unpriv_users',`
 
 	corecmd_shell_spec_domtrans($1, unpriv_userdomain)
 	allow unpriv_userdomain $1:fd use;
-	allow unpriv_userdomain $1:fifo_file rw_fifo_file_perms;
+	allow unpriv_userdomain $1:fifo_file rw_inherited_fifo_file_perms;
 	allow unpriv_userdomain $1:process sigchld;
 ')
 
@@ -4037,7 +4037,7 @@ interface(`userdom_xsession_spec_domtrans_unpriv_users',`
 
 	xserver_xsession_spec_domtrans($1, unpriv_userdomain)
 	allow unpriv_userdomain $1:fd use;
-	allow unpriv_userdomain $1:fifo_file rw_fifo_file_perms;
+	allow unpriv_userdomain $1:fifo_file rw_inherited_fifo_file_perms;
 	allow unpriv_userdomain $1:process sigchld;
 ')
 
@@ -4134,7 +4134,7 @@ interface(`userdom_bin_spec_domtrans_unpriv_users',`
 
 	corecmd_bin_spec_domtrans($1, unpriv_userdomain)
 	allow unpriv_userdomain $1:fd use;
-	allow unpriv_userdomain $1:fifo_file rw_fifo_file_perms;
+	allow unpriv_userdomain $1:fifo_file rw_inherited_fifo_file_perms;
 	allow unpriv_userdomain $1:process sigchld;
 ')
 
@@ -4157,7 +4157,7 @@ interface(`userdom_entry_spec_domtrans_unpriv_users',`
 
 	domain_entry_file_spec_domtrans($1, unpriv_userdomain)
 	allow unpriv_userdomain $1:fd use;
-	allow unpriv_userdomain $1:fifo_file rw_fifo_file_perms;
+	allow unpriv_userdomain $1:fifo_file rw_inherited_fifo_file_perms;
 	allow unpriv_userdomain $1:process sigchld;
 ')
 

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -2607,7 +2607,7 @@ interface(`userdom_dontaudit_manage_user_certs',`
 
 	dontaudit $1 user_cert_t:dir manage_dir_perms;
 	dontaudit $1 user_cert_t:file manage_file_perms;
-	dontaudit $1 user_cert_t:lnk_file manage_file_perms;
+	dontaudit $1 user_cert_t:lnk_file manage_lnk_file_perms;
 ')
 
 ########################################
@@ -3489,7 +3489,7 @@ interface(`userdom_delete_all_user_runtime_symlinks',`
 	')
 
 	allow $1 user_runtime_content_type:dir list_dir_perms;
-	allow $1 user_runtime_content_type:fifo_file delete_lnk_file_perms;
+	allow $1 user_runtime_content_type:lnk_file delete_lnk_file_perms;
 ')
 
 ########################################
@@ -3527,7 +3527,7 @@ interface(`userdom_delete_all_user_runtime_named_sockets',`
 	')
 
 	allow $1 user_runtime_content_type:dir list_dir_perms;
-	allow $1 user_runtime_content_type:file delete_sock_file_perms;
+	allow $1 user_runtime_content_type:sock_file delete_sock_file_perms;
 ')
 
 ########################################
@@ -3968,7 +3968,7 @@ interface(`userdom_spec_domtrans_all_users',`
 
 	corecmd_shell_spec_domtrans($1, userdomain)
 	allow userdomain $1:fd use;
-	allow userdomain $1:fifo_file rw_file_perms;
+	allow userdomain $1:fifo_file rw_fifo_file_perms;
 	allow userdomain $1:process sigchld;
 ')
 
@@ -3991,7 +3991,7 @@ interface(`userdom_xsession_spec_domtrans_all_users',`
 
 	xserver_xsession_spec_domtrans($1, userdomain)
 	allow userdomain $1:fd use;
-	allow userdomain $1:fifo_file rw_file_perms;
+	allow userdomain $1:fifo_file rw_fifo_file_perms;
 	allow userdomain $1:process sigchld;
 ')
 
@@ -4014,7 +4014,7 @@ interface(`userdom_spec_domtrans_unpriv_users',`
 
 	corecmd_shell_spec_domtrans($1, unpriv_userdomain)
 	allow unpriv_userdomain $1:fd use;
-	allow unpriv_userdomain $1:fifo_file rw_file_perms;
+	allow unpriv_userdomain $1:fifo_file rw_fifo_file_perms;
 	allow unpriv_userdomain $1:process sigchld;
 ')
 
@@ -4037,7 +4037,7 @@ interface(`userdom_xsession_spec_domtrans_unpriv_users',`
 
 	xserver_xsession_spec_domtrans($1, unpriv_userdomain)
 	allow unpriv_userdomain $1:fd use;
-	allow unpriv_userdomain $1:fifo_file rw_file_perms;
+	allow unpriv_userdomain $1:fifo_file rw_fifo_file_perms;
 	allow unpriv_userdomain $1:process sigchld;
 ')
 
@@ -4134,7 +4134,7 @@ interface(`userdom_bin_spec_domtrans_unpriv_users',`
 
 	corecmd_bin_spec_domtrans($1, unpriv_userdomain)
 	allow unpriv_userdomain $1:fd use;
-	allow unpriv_userdomain $1:fifo_file rw_file_perms;
+	allow unpriv_userdomain $1:fifo_file rw_fifo_file_perms;
 	allow unpriv_userdomain $1:process sigchld;
 ')
 
@@ -4157,7 +4157,7 @@ interface(`userdom_entry_spec_domtrans_unpriv_users',`
 
 	domain_entry_file_spec_domtrans($1, unpriv_userdomain)
 	allow unpriv_userdomain $1:fd use;
-	allow unpriv_userdomain $1:fifo_file rw_file_perms;
+	allow unpriv_userdomain $1:fifo_file rw_fifo_file_perms;
 	allow unpriv_userdomain $1:process sigchld;
 ')
 
@@ -4277,7 +4277,7 @@ interface(`userdom_dontaudit_use_user_ptys',`
 		type user_devpts_t;
 	')
 
-	dontaudit $1 user_devpts_t:chr_file rw_file_perms;
+	dontaudit $1 user_devpts_t:chr_file rw_chr_file_perms;
 ')
 
 ########################################
@@ -4369,7 +4369,7 @@ interface(`userdom_dontaudit_use_user_ttys',`
 		type user_tty_device_t;
 	')
 
-	dontaudit $1 user_tty_device_t:chr_file rw_file_perms;
+	dontaudit $1 user_tty_device_t:chr_file rw_chr_file_perms;
 ')
 
 ########################################


### PR DESCRIPTION
In many cases, this won't result in a change in the actual policy generated, but if the definitions of macros are changed going forward, the mismatches could cause issues.