### PR TITLE
systemd: make systemd --user run generators in the user domain

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -23,7 +23,7 @@
 template(`systemd_role_template',`
 	gen_require(`
 		attribute systemd_user_session_type, systemd_log_parse_env_type;
-		type systemd_user_runtime_t, systemd_user_runtime_notify_t;
+		type systemd_generator_exec_t, systemd_user_runtime_t, systemd_user_runtime_notify_t;
 	')
 
 	#################################
@@ -55,6 +55,10 @@ template(`systemd_role_template',`
 	allow $1_systemd_t $3:process { setsched rlimitinh };
 	corecmd_shell_domtrans($1_systemd_t, $3)
 	corecmd_bin_domtrans($1_systemd_t, $3)
+
+	# Run generators in /usr/lib/systemd/user-environment-generators in the user domain
+	domain_entry_file($3, systemd_generator_exec_t)
+	domtrans_pattern($1_systemd_t, systemd_generator_exec_t, $3)
 
 	# Allow using file descriptors for user environment generators
 	allow $3 $1_systemd_t:fd use;


### PR DESCRIPTION
On Debian 10, ``systemd --user`` runs some generators in ``/usr/lib/systemd/user-environment-generators`` when a user session starts. Here is what is logged in audit.log for a ``sysadm`` user.

    type=AVC msg=audit(1586962888.516:65): avc:  denied  { getattr } for
    pid=309 comm="(sd-executor)"
    path="/usr/lib/systemd/user-environment-generators/90gpg-agent"
    dev="vda1" ino=662897 scontext=sysadm_u:sysadm_r:sysadm_systemd_t
    tcontext=system_u:object_r:systemd_generator_exec_t tclass=file
    permissive=1

    type=AVC msg=audit(1586962888.516:66): avc:  denied  { map } for
    pid=310 comm="30-systemd-envi"
    path="/usr/lib/systemd/user-environment-generators/30-systemd-environment-d-generator"
    dev="vda1" ino=655822 scontext=sysadm_u:sysadm_r:sysadm_systemd_t
    tcontext=system_u:object_r:systemd_generator_exec_t tclass=file
    permissive=1

    type=AVC msg=audit(1586962888.516:66): avc:  denied
    { execute_no_trans } for  pid=310 comm="(direxec)"
    path="/usr/lib/systemd/user-environment-generators/30-systemd-environment-d-generator"
    dev="vda1" ino=655822 scontext=sysadm_u:sysadm_r:sysadm_systemd_t
    tcontext=system_u:object_r:systemd_generator_exec_t tclass=file
    permissive=1

Making `sysadm_systemd_t` transition to `sysadm_t` when running these programs seems to make sense (for example `90gpg-agent` is a bash script that involves `gpgconf` and it makes little sense to make `90gpg-agent` run in a dedicated context for this).