### PR TITLE
systemd: allow sd-executor to read memfd files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -247,6 +247,9 @@ type systemd_user_runtime_dir_t;
 type systemd_user_runtime_dir_exec_t;
 init_system_domain(systemd_user_runtime_dir_t, systemd_user_runtime_dir_exec_t)
 
+type systemd_user_tmpfs_t;
+userdom_user_tmpfs_file(systemd_user_tmpfs_t)
+
 #
 # Unit file types
 #
@@ -1315,6 +1318,9 @@ userdom_user_runtime_filetrans(systemd_user_session_type, systemd_user_runtime_t
 
 allow systemd_user_session_type systemd_user_runtime_notify_t:sock_file create;
 type_transition systemd_user_session_type systemd_user_runtime_t:sock_file systemd_user_runtime_notify_t "notify";
+
+allow systemd_user_session_type systemd_user_tmpfs_t:file manage_file_perms;
+fs_tmpfs_filetrans(systemd_user_session_type, systemd_user_tmpfs_t, file)
 
 # Run generators in /usr/lib/systemd/user-environment-generators with no domain transition
 can_exec(systemd_user_session_type, systemd_generator_exec_t)


### PR DESCRIPTION
When ``systemd --user`` runs helper programs in order to generate user environment variables, it reads memfd temporary files, which are labeled `tmpfs_t`:

    type=AVC msg=audit(1569787627.183:487): avc:  denied  { getattr }
    for  pid=19182 comm="(sd-executor)"
    path=2F6D656D66643A33302D73797374656D642D656E7669726F6E6D656E742D642D67656E657261746F72202864656C6574656429
    dev="tmpfs" ino=50062 scontext=sysadm_u:sysadm_r:sysadm_systemd_t
    tcontext=sysadm_u:object_r:tmpfs_t tclass=file permissive=1

    type=SYSCALL msg=audit(1569787627.183:487): arch=c000003e syscall=5
    success=yes exit=0 a0=a a1=7ffd324679d0 a2=7ffd324679d0 a3=4 items=0
    ppid=19180 pid=19182 auid=1000 uid=1000 gid=1000 euid=1000 suid=1000
    fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=(none) ses=28
    comm="(sd-executor)" exe="/usr/lib/systemd/systemd"
    subj=sysadm_u:sysadm_r:sysadm_systemd_t key=(null)

    type=PROCTITLE msg=audit(1569787627.183:487): proctitle="(sd-executor)"

    type=AVC msg=audit(1569787627.183:488): avc:  denied  { read } for
    pid=19182 comm="(sd-executor)"
    path=2F6D656D66643A33302D73797374656D642D656E7669726F6E6D656E742D642D67656E657261746F72202864656C6574656429
    dev="tmpfs" ino=50062 scontext=sysadm_u:sysadm_r:sysadm_systemd_t
    tcontext=sysadm_u:object_r:tmpfs_t tclass=file permissive=1

    type=SYSCALL msg=audit(1569787627.183:488): arch=c000003e syscall=0
    success=yes exit=0 a0=a a1=559bf537abb0 a2=1000 a3=559bf5376010
    items=0 ppid=19180 pid=19182 auid=1000 uid=1000 gid=1000 euid=1000
    suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=(none)
    ses=28 comm="(sd-executor)" exe="/usr/lib/systemd/systemd"
    subj=sysadm_u:sysadm_r:sysadm_systemd_t key=(null)

    type=PROCTITLE msg=audit(1569787627.183:488): proctitle="(sd-executor)"

The hexadecimal path is ``/memfd:30-systemd-environment-d-generator
(deleted)``.

The name ``(sd-executor)`` is the name of a child process (cf. https://github.com/systemd/systemd/blob/v243/src/shared/exec-util.c#L222) and the name of the memfd file comes from ``open_serialization_fd(name)`` in https://github.com/systemd/systemd/blob/v243/src/shared/exec-util.c#L213.