### PR TITLE
Add divert to generated_definitions creation.

### DIFF
--- a/Rules.modular
+++ b/Rules.modular
@@ -128,9 +128,11 @@ $(tmpdir)/pre_te_files.conf: $(base_pre_te_files)
 $(tmpdir)/generated_definitions.conf:
 	@test -d $(tmpdir) || mkdir -p $(tmpdir)
 # define all available object classes
-	$(verbose) $(genperm) $(avs) $(secclass) > $@
+	@cat $(m4divert) > $@
+	$(verbose) $(genperm) $(avs) $(secclass) >> $@
 	$(verbose) $(call create-base-per-role-tmpl,$(patsubst %.te,%,$(base_mods)),$@)
 	$(verbose) test -f $(booleans) && $(setbools) $(booleans) >> $@ || true
+	@cat $(m4undivert) >> $@
 
 $(tmpdir)/global_bools.conf: M4PARAM += -D self_contained_policy
 $(tmpdir)/global_bools.conf: $(m4support) $(tmpdir)/generated_definitions.conf $(globalbool) $(globaltun)
@@ -138,10 +140,10 @@ $(tmpdir)/global_bools.conf: $(m4support) $(tmpdir)/generated_definitions.conf $
 
 $(tmpdir)/all_interfaces.conf: $(m4support) $(all_interfaces) $(m4iferror)
 	@test -d $(tmpdir) || mkdir -p $(tmpdir)
-	@echo "divert(-1)" > $@
+	@cat $(m4divert) > $@
 	$(verbose) $(M4) $^ >> $(tmpdir)/$(@F).tmp
 	$(verbose) $(SED) -e s/dollarsstar/\$$\*/g $(tmpdir)/$(@F).tmp >> $@
-	@echo "divert" >> $@
+	@cat $(m4undivert) >> $@
 
 $(tmpdir)/all_te_files.conf: M4PARAM += -D self_contained_policy
 $(tmpdir)/all_te_files.conf: $(m4support) $(tmpdir)/generated_definitions.conf $(tmpdir)/all_interfaces.conf $(base_te_files) $(m4terminate)

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -111,19 +111,21 @@ $(tmpdir)/pre_te_files.conf: $(pre_te_files)
 $(tmpdir)/generated_definitions.conf: $(all_te_files)
 	@test -d $(tmpdir) || mkdir -p $(tmpdir)
 # define all available object classes
-	$(verbose) $(genperm) $(avs) $(secclass) > $@
+	@cat $(m4divert) > $@
+	$(verbose) $(genperm) $(avs) $(secclass) >> $@
 	$(verbose) $(call create-base-per-role-tmpl,$(basename $(notdir $(all_modules))),$@)
 	$(verbose) test -f $(booleans) && $(setbools) $(booleans) >> $@ || true
+	@cat $(m4undivert) >> $@
 
 $(tmpdir)/global_bools.conf: $(m4support) $(tmpdir)/generated_definitions.conf $(globalbool) $(globaltun)
 	$(verbose) $(M4) $(M4PARAM) $^ > $@
 
 $(tmpdir)/all_interfaces.conf: $(m4support) $(all_interfaces) $(m4iferror)
 	@test -d $(tmpdir) || mkdir -p $(tmpdir)
-	@echo "divert(-1)" > $@
+	@cat $(m4divert) > $@
 	$(verbose) $(M4) $^ >> $(tmpdir)/$(@F).tmp
 	$(verbose) $(SED) -e s/dollarsstar/\$$\*/g $(tmpdir)/$(@F).tmp >> $@
-	@echo "divert" >> $@
+	@cat $(m4undivert) >> $@
 
 $(tmpdir)/all_te_files.conf: $(m4support) $(tmpdir)/generated_definitions.conf $(tmpdir)/all_interfaces.conf $(all_te_files) $(m4terminate)
 ifeq "$(strip $(all_te_files))" ""


### PR DESCRIPTION
During normal m4 parsing, m4 outputs a blank line for each define() call.  This results in the first roughly 500 lines of the .tmp files for each module being largely blank lines.  Adding divert() calls to the m4 generation for generated_definitions redirects this output, so the beginning of the actual policy appears near the top of the .tmp files.

Signed-off-by: Daniel Burgener <Daniel.Burgener@microsoft.com>