### PR TITLE
Python string fix

### DIFF
--- a/support/gennetfilter.py
+++ b/support/gennetfilter.py
@@ -9,7 +9,7 @@
 
 import sys,getopt,re
 
-NETPORT = re.compile("^network_port\(\s*\w+\s*(\s*,\s*\w+\s*,\s*\w+\s*,\s*\w+\s*)+\s*\)\s*(#|$)")
+NETPORT = re.compile(r"^network_port\(\s*\w+\s*(\s*,\s*\w+\s*,\s*\w+\s*,\s*\w+\s*)+\s*\)\s*(#|$)")
 
 DEFAULT_INPUT_PACKET = "server_packet_t"
 DEFAULT_OUTPUT_PACKET = "client_packet_t"
@@ -101,7 +101,7 @@ def parse_corenet(file_name):
 			# parse out the parameters
 			openparen = corenet_line.find('(')+1
 			closeparen = corenet_line.find(')',openparen)
-			parms = re.split('\W+',corenet_line[openparen:closeparen])
+			parms = re.split(r'\W+',corenet_line[openparen:closeparen])
 			name = parms[0]
 			del parms[0]
 


### PR DESCRIPTION
Use raw string constants to avoid errors from python3.8:
```
    NETPORT = re.compile("^network_port\(\s*\w+\s*(\s*,\s*\w+\s*,\s*\w+\s*,\s*\w+\s*)+\s*\)\s*(#|$)")
                         ^
SyntaxError: invalid escape sequence \(
```
Signed-off-by: Topi Miettinen <toiwoton@gmail.com>