### PR TITLE
Drop support for /dev/.udev and like

### DIFF
--- a/policy/modules/admin/acct.te
+++ b/policy/modules/admin/acct.te
@@ -79,5 +79,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(acct_t)
+	udev_read_pid_files(acct_t)
 ')

--- a/policy/modules/admin/dmesg.te
+++ b/policy/modules/admin/dmesg.te
@@ -56,5 +56,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dmesg_t)
+	udev_read_pid_files(dmesg_t)
 ')

--- a/policy/modules/admin/kudzu.te
+++ b/policy/modules/admin/kudzu.te
@@ -128,7 +128,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(kudzu_t)
+	udev_read_pid_files(kudzu_t)
 ')
 
 optional_policy(`

--- a/policy/modules/admin/mrtg.te
+++ b/policy/modules/admin/mrtg.te
@@ -147,5 +147,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(mrtg_t)
+	udev_read_pid_files(mrtg_t)
 ')

--- a/policy/modules/admin/quota.te
+++ b/policy/modules/admin/quota.te
@@ -98,7 +98,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(quota_t)
+	udev_read_pid_files(quota_t)
 ')
 
 #######################################

--- a/policy/modules/admin/sxid.te
+++ b/policy/modules/admin/sxid.te
@@ -95,5 +95,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(sxid_t)
+	udev_read_pid_files(sxid_t)
 ')

--- a/policy/modules/admin/updfstab.te
+++ b/policy/modules/admin/updfstab.te
@@ -112,5 +112,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(updfstab_t)
+	udev_read_pid_files(updfstab_t)
 ')

--- a/policy/modules/apps/chromium.te
+++ b/policy/modules/apps/chromium.te
@@ -196,7 +196,7 @@ tunable_policy(`chromium_bind_tcp_unreserved_ports',`
 
 tunable_policy(`chromium_rw_usb_dev',`
 	dev_rw_generic_usb_dev(chromium_t)
-	udev_read_db(chromium_t)
+	udev_read_pid_files(chromium_t)
 ')
 
 tunable_policy(`chromium_read_system_info',`

--- a/policy/modules/apps/games.te
+++ b/policy/modules/apps/games.te
@@ -85,7 +85,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(games_srv_t)
+	udev_read_pid_files(games_srv_t)
 ')
 
 ########################################

--- a/policy/modules/apps/mozilla.te
+++ b/policy/modules/apps/mozilla.te
@@ -586,7 +586,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(mozilla_plugin_t)
+	udev_read_pid_files(mozilla_plugin_t)
 ')
 
 optional_policy(`

--- a/policy/modules/apps/pulseaudio.te
+++ b/policy/modules/apps/pulseaudio.te
@@ -235,7 +235,6 @@ optional_policy(`
 optional_policy(`
 	udev_read_pid_files(pulseaudio_t)
 	udev_read_state(pulseaudio_t)
-	udev_read_db(pulseaudio_t)
 ')
 
 optional_policy(`

--- a/policy/modules/apps/uml.te
+++ b/policy/modules/apps/uml.te
@@ -168,5 +168,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(uml_switch_t)
+	udev_read_pid_files(uml_switch_t)
 ')

--- a/policy/modules/apps/vmware.te
+++ b/policy/modules/apps/vmware.te
@@ -158,7 +158,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(vmware_host_t)
+	udev_read_pid_files(vmware_host_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/acpi.te
+++ b/policy/modules/services/acpi.te
@@ -224,7 +224,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(acpid_t)
+	udev_read_pid_files(acpid_t)
 	udev_read_state(acpid_t)
 ')
 

--- a/policy/modules/services/apache.te
+++ b/policy/modules/services/apache.te
@@ -897,7 +897,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(httpd_t)
+	udev_read_pid_files(httpd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/arpwatch.te
+++ b/policy/modules/services/arpwatch.te
@@ -86,5 +86,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(arpwatch_t)
+	udev_read_pid_files(arpwatch_t)
 ')

--- a/policy/modules/services/asterisk.te
+++ b/policy/modules/services/asterisk.te
@@ -187,5 +187,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(asterisk_t)
+	udev_read_pid_files(asterisk_t)
 ')

--- a/policy/modules/services/automount.te
+++ b/policy/modules/services/automount.te
@@ -165,5 +165,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(automount_t)
+	udev_read_pid_files(automount_t)
 ')

--- a/policy/modules/services/avahi.te
+++ b/policy/modules/services/avahi.te
@@ -112,5 +112,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(avahi_t)
+	udev_read_pid_files(avahi_t)
 ')

--- a/policy/modules/services/bind.te
+++ b/policy/modules/services/bind.te
@@ -208,7 +208,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(named_t)
+	udev_read_pid_files(named_t)
 ')
 
 ########################################

--- a/policy/modules/services/bluetooth.te
+++ b/policy/modules/services/bluetooth.te
@@ -157,7 +157,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(bluetooth_t)
+	udev_read_pid_files(bluetooth_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/canna.te
+++ b/policy/modules/services/canna.te
@@ -91,5 +91,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(canna_t)
+	udev_read_pid_files(canna_t)
 ')

--- a/policy/modules/services/cipe.te
+++ b/policy/modules/services/cipe.te
@@ -67,5 +67,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(ciped_t)
+	udev_read_pid_files(ciped_t)
 ')

--- a/policy/modules/services/colord.te
+++ b/policy/modules/services/colord.te
@@ -133,7 +133,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(colord_t)
 	udev_read_pid_files(colord_t)
 ')
 

--- a/policy/modules/services/consolekit.te
+++ b/policy/modules/services/consolekit.te
@@ -165,7 +165,6 @@ optional_policy(`
 
 optional_policy(`
 	udev_domtrans(consolekit_t)
-	udev_read_db(consolekit_t)
 	udev_read_pid_files(consolekit_t)
 	udev_signal(consolekit_t)
 ')

--- a/policy/modules/services/courier.te
+++ b/policy/modules/services/courier.te
@@ -76,7 +76,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(courier_domain)
+	udev_read_pid_files(courier_domain)
 ')
 
 ########################################

--- a/policy/modules/services/cpucontrol.te
+++ b/policy/modules/services/cpucontrol.te
@@ -55,7 +55,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(cpucontrol_domain)
+	udev_read_pid_files(cpucontrol_domain)
 ')
 
 ########################################

--- a/policy/modules/services/cron.te
+++ b/policy/modules/services/cron.te
@@ -442,7 +442,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(crond_t)
+	udev_read_pid_files(crond_t)
 ')
 
 ########################################

--- a/policy/modules/services/cups.te
+++ b/policy/modules/services/cups.te
@@ -343,7 +343,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(cupsd_t)
+	udev_read_pid_files(cupsd_t)
 ')
 
 optional_policy(`
@@ -485,7 +485,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(cupsd_config_t)
+	udev_read_pid_files(cupsd_config_t)
 ')
 
 optional_policy(`
@@ -722,7 +722,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(hplip_t)
 	udev_read_pid_files(hplip_t)
 ')
 
@@ -787,5 +786,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(ptal_t)
+	udev_read_pid_files(ptal_t)
 ')

--- a/policy/modules/services/cyrus.te
+++ b/policy/modules/services/cyrus.te
@@ -140,5 +140,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(cyrus_t)
+	udev_read_pid_files(cyrus_t)
 ')

--- a/policy/modules/services/dante.te
+++ b/policy/modules/services/dante.te
@@ -74,5 +74,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dante_t)
+	udev_read_pid_files(dante_t)
 ')

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -206,7 +206,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(system_dbusd_t)
+	udev_read_pid_files(system_dbusd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/dcc.te
+++ b/policy/modules/services/dcc.te
@@ -236,7 +236,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dccd_t)
+	udev_read_pid_files(dccd_t)
 ')
 
 ########################################
@@ -291,7 +291,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dccifd_t)
+	udev_read_pid_files(dccifd_t)
 ')
 
 ########################################
@@ -346,5 +346,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dccm_t)
+	udev_read_pid_files(dccm_t)
 ')

--- a/policy/modules/services/ddclient.te
+++ b/policy/modules/services/ddclient.te
@@ -112,5 +112,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(ddclient_t)
+	udev_read_pid_files(ddclient_t)
 ')

--- a/policy/modules/services/devicekit.te
+++ b/policy/modules/services/devicekit.te
@@ -57,7 +57,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(devicekit_t)
+	udev_read_pid_files(devicekit_t)
 ')
 
 optional_policy(`
@@ -202,7 +202,6 @@ optional_policy(`
 
 optional_policy(`
 	udev_domtrans(devicekit_disk_t)
-	udev_read_db(devicekit_disk_t)
 	udev_read_pid_files(devicekit_disk_t)
 ')
 
@@ -363,7 +362,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(devicekit_power_t)
+	udev_read_pid_files(devicekit_power_t)
 	udev_manage_pid_files(devicekit_power_t)
 ')
 

--- a/policy/modules/services/dhcp.te
+++ b/policy/modules/services/dhcp.te
@@ -129,5 +129,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dhcpd_t)
+	udev_read_pid_files(dhcpd_t)
 ')

--- a/policy/modules/services/dictd.te
+++ b/policy/modules/services/dictd.te
@@ -81,5 +81,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dictd_t)
+	udev_read_pid_files(dictd_t)
 ')

--- a/policy/modules/services/distcc.te
+++ b/policy/modules/services/distcc.te
@@ -83,5 +83,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(distccd_t)
+	udev_read_pid_files(distccd_t)
 ')

--- a/policy/modules/services/dnsmasq.te
+++ b/policy/modules/services/dnsmasq.te
@@ -124,7 +124,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dnsmasq_t)
+	udev_read_pid_files(dnsmasq_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/dovecot.te
+++ b/policy/modules/services/dovecot.te
@@ -235,7 +235,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dovecot_t)
+	udev_read_pid_files(dovecot_t)
 ')
 
 ########################################

--- a/policy/modules/services/entropyd.te
+++ b/policy/modules/services/entropyd.te
@@ -88,5 +88,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(entropyd_t)
+	udev_read_pid_files(entropyd_t)
 ')

--- a/policy/modules/services/fetchmail.te
+++ b/policy/modules/services/fetchmail.te
@@ -109,5 +109,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(fetchmail_t)
+	udev_read_pid_files(fetchmail_t)
 ')

--- a/policy/modules/services/finger.te
+++ b/policy/modules/services/finger.te
@@ -99,5 +99,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(fingerd_t)
+	udev_read_pid_files(fingerd_t)
 ')

--- a/policy/modules/services/ftp.te
+++ b/policy/modules/services/ftp.te
@@ -407,7 +407,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(ftpd_t)
+	udev_read_pid_files(ftpd_t)
 ')
 
 ########################################

--- a/policy/modules/services/gatekeeper.te
+++ b/policy/modules/services/gatekeeper.te
@@ -98,5 +98,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(gatekeeper_t)
+	udev_read_pid_files(gatekeeper_t)
 ')

--- a/policy/modules/services/gpm.te
+++ b/policy/modules/services/gpm.te
@@ -79,5 +79,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(gpm_t)
+	udev_read_pid_files(gpm_t)
 ')

--- a/policy/modules/services/hal.te
+++ b/policy/modules/services/hal.te
@@ -314,7 +314,7 @@ optional_policy(`
 
 optional_policy(`
 	udev_domtrans(hald_t)
-	udev_read_db(hald_t)
+	udev_read_pid_files(hald_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/howl.te
+++ b/policy/modules/services/howl.te
@@ -73,5 +73,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(howl_t)
+	udev_read_pid_files(howl_t)
 ')

--- a/policy/modules/services/i18n_input.te
+++ b/policy/modules/services/i18n_input.te
@@ -121,5 +121,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(i18n_input_t)
+	udev_read_pid_files(i18n_input_t)
 ')

--- a/policy/modules/services/imaze.te
+++ b/policy/modules/services/imaze.te
@@ -79,5 +79,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(imazesrv_t)
+	udev_read_pid_files(imazesrv_t)
 ')

--- a/policy/modules/services/inetd.te
+++ b/policy/modules/services/inetd.te
@@ -191,7 +191,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(inetd_t)
+	udev_read_pid_files(inetd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/inn.te
+++ b/policy/modules/services/inn.te
@@ -118,5 +118,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(innd_t)
+	udev_read_pid_files(innd_t)
 ')

--- a/policy/modules/services/ircd.te
+++ b/policy/modules/services/ircd.te
@@ -84,5 +84,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(ircd_t)
+	udev_read_pid_files(ircd_t)
 ')

--- a/policy/modules/services/irqbalance.te
+++ b/policy/modules/services/irqbalance.te
@@ -58,5 +58,5 @@ userdom_dontaudit_use_unpriv_user_fds(irqbalance_t)
 userdom_dontaudit_search_user_home_dirs(irqbalance_t)
 
 optional_policy(`
-	udev_read_db(irqbalance_t)
+	udev_read_pid_files(irqbalance_t)
 ')

--- a/policy/modules/services/jabber.te
+++ b/policy/modules/services/jabber.te
@@ -121,7 +121,7 @@ userdom_dontaudit_use_unpriv_user_fds(jabberd_t)
 userdom_dontaudit_search_user_home_dirs(jabberd_t)
 
 optional_policy(`
-	udev_read_db(jabberd_t)
+	udev_read_pid_files(jabberd_t)
 ')
 
 ########################################

--- a/policy/modules/services/kerberos.te
+++ b/policy/modules/services/kerberos.te
@@ -164,7 +164,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(kadmind_t)
+	udev_read_pid_files(kadmind_t)
 ')
 
 ########################################
@@ -268,7 +268,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(krb5kdc_t)
+	udev_read_pid_files(krb5kdc_t)
 ')
 
 ########################################

--- a/policy/modules/services/ldap.te
+++ b/policy/modules/services/ldap.te
@@ -149,5 +149,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(slapd_t)
+	udev_read_pid_files(slapd_t)
 ')

--- a/policy/modules/services/lpd.te
+++ b/policy/modules/services/lpd.te
@@ -198,7 +198,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(lpd_t)
+	udev_read_pid_files(lpd_t)
 ')
 
 ##############################

--- a/policy/modules/services/modemmanager.te
+++ b/policy/modules/services/modemmanager.te
@@ -55,6 +55,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(modemmanager_t)
 	udev_manage_pid_files(modemmanager_t)
 ')

--- a/policy/modules/services/monop.te
+++ b/policy/modules/services/monop.te
@@ -79,5 +79,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(monopd_t)
+	udev_read_pid_files(monopd_t)
 ')

--- a/policy/modules/services/mpd.te
+++ b/policy/modules/services/mpd.te
@@ -195,7 +195,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(mpd_t)
+	udev_read_pid_files(mpd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/munin.te
+++ b/policy/modules/services/munin.te
@@ -231,7 +231,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(munin_t)
+	udev_read_pid_files(munin_t)
 ')
 
 ###################################

--- a/policy/modules/services/mysql.te
+++ b/policy/modules/services/mysql.te
@@ -152,7 +152,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(mysqld_t)
+	udev_read_pid_files(mysqld_t)
 ')
 
 #######################################

--- a/policy/modules/services/nagios.te
+++ b/policy/modules/services/nagios.te
@@ -172,7 +172,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(nagios_t)
+	udev_read_pid_files(nagios_t)
 ')
 
 ########################################
@@ -284,7 +284,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(nrpe_t)
+	udev_read_pid_files(nrpe_t)
 ')
 
 #####################################

--- a/policy/modules/services/nessus.te
+++ b/policy/modules/services/nessus.te
@@ -104,5 +104,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(nessusd_t)
+	udev_read_pid_files(nessusd_t)
 ')

--- a/policy/modules/services/networkmanager.te
+++ b/policy/modules/services/networkmanager.te
@@ -359,7 +359,6 @@ optional_policy(`
 
 optional_policy(`
 	udev_exec(NetworkManager_t)
-	udev_read_db(NetworkManager_t)
 	udev_read_pid_files(NetworkManager_t)
 ')
 

--- a/policy/modules/services/nis.te
+++ b/policy/modules/services/nis.te
@@ -141,7 +141,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(ypbind_t)
+	udev_read_pid_files(ypbind_t)
 ')
 
 ########################################
@@ -225,7 +225,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(yppasswdd_t)
+	udev_read_pid_files(yppasswdd_t)
 ')
 
 ########################################
@@ -302,7 +302,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(ypserv_t)
+	udev_read_pid_files(ypserv_t)
 ')
 
 ########################################

--- a/policy/modules/services/nscd.te
+++ b/policy/modules/services/nscd.te
@@ -133,7 +133,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(nscd_t)
+	udev_read_pid_files(nscd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/nsd.te
+++ b/policy/modules/services/nsd.te
@@ -99,7 +99,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(nsd_t)
+	udev_read_pid_files(nsd_t)
 ')
 
 ########################################

--- a/policy/modules/services/ntop.te
+++ b/policy/modules/services/ntop.te
@@ -103,5 +103,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(ntop_t)
+	udev_read_pid_files(ntop_t)
 ')

--- a/policy/modules/services/ntp.te
+++ b/policy/modules/services/ntp.te
@@ -200,5 +200,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(ntpd_t)
+	udev_read_pid_files(ntpd_t)
 ')

--- a/policy/modules/services/oav.te
+++ b/policy/modules/services/oav.te
@@ -121,5 +121,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(scannerdaemon_t)
+	udev_read_pid_files(scannerdaemon_t)
 ')

--- a/policy/modules/services/openct.te
+++ b/policy/modules/services/openct.te
@@ -63,5 +63,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(openct_t)
+	udev_read_pid_files(openct_t)
 ')

--- a/policy/modules/services/pcscd.te
+++ b/policy/modules/services/pcscd.te
@@ -89,5 +89,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(pcscd_t)
+	udev_read_pid_files(pcscd_t)
 ')

--- a/policy/modules/services/pegasus.te
+++ b/policy/modules/services/pegasus.te
@@ -175,7 +175,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(pegasus_t)
+	udev_read_pid_files(pegasus_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/perdition.te
+++ b/policy/modules/services/perdition.te
@@ -79,5 +79,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(perdition_t)
+	udev_read_pid_files(perdition_t)
 ')

--- a/policy/modules/services/portmap.te
+++ b/policy/modules/services/portmap.te
@@ -90,7 +90,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(portmap_t)
+	udev_read_pid_files(portmap_t)
 ')
 
 ########################################

--- a/policy/modules/services/portslave.te
+++ b/policy/modules/services/portslave.te
@@ -105,5 +105,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(portslave_t)
+	udev_read_pid_files(portslave_t)
 ')

--- a/policy/modules/services/postfix.te
+++ b/policy/modules/services/postfix.te
@@ -164,7 +164,7 @@ miscfiles_read_generic_tls_privkey(postfix_domain)
 userdom_dontaudit_use_unpriv_user_fds(postfix_domain)
 
 optional_policy(`
-	udev_read_db(postfix_domain)
+	udev_read_pid_files(postfix_domain)
 ')
 
 ########################################

--- a/policy/modules/services/postgresql.te
+++ b/policy/modules/services/postgresql.te
@@ -386,7 +386,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(postgresql_t)
+	udev_read_pid_files(postgresql_t)
 ')
 
 ########################################

--- a/policy/modules/services/postgrey.te
+++ b/policy/modules/services/postgrey.te
@@ -105,5 +105,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(postgrey_t)
+	udev_read_pid_files(postgrey_t)
 ')

--- a/policy/modules/services/ppp.te
+++ b/policy/modules/services/ppp.te
@@ -214,7 +214,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(pppd_t)
+	udev_read_pid_files(pppd_t)
 ')
 
 ########################################
@@ -314,7 +314,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(pptp_t)
+	udev_read_pid_files(pptp_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/privoxy.te
+++ b/policy/modules/services/privoxy.te
@@ -105,5 +105,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(privoxy_t)
+	udev_read_pid_files(privoxy_t)
 ')

--- a/policy/modules/services/pxe.te
+++ b/policy/modules/services/pxe.te
@@ -66,5 +66,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(pxe_t)
+	udev_read_pid_files(pxe_t)
 ')

--- a/policy/modules/services/radius.te
+++ b/policy/modules/services/radius.te
@@ -139,5 +139,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(radiusd_t)
+	udev_read_pid_files(radiusd_t)
 ')

--- a/policy/modules/services/radvd.te
+++ b/policy/modules/services/radvd.te
@@ -73,5 +73,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(radvd_t)
+	udev_read_pid_files(radvd_t)
 ')

--- a/policy/modules/services/rdisc.te
+++ b/policy/modules/services/rdisc.te
@@ -53,5 +53,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(rdisc_t)
+	udev_read_pid_files(rdisc_t)
 ')

--- a/policy/modules/services/resmgr.te
+++ b/policy/modules/services/resmgr.te
@@ -63,5 +63,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(resmgrd_t)
+	udev_read_pid_files(resmgrd_t)
 ')

--- a/policy/modules/services/rgmanager.te
+++ b/policy/modules/services/rgmanager.te
@@ -192,7 +192,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(rgmanager_t)
+	udev_read_pid_files(rgmanager_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/rhcs.te
+++ b/policy/modules/services/rhcs.te
@@ -320,5 +320,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(qdiskd_t)
+	udev_read_pid_files(qdiskd_t)
 ')

--- a/policy/modules/services/rhgb.te
+++ b/policy/modules/services/rhgb.te
@@ -122,5 +122,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(rhgb_t)
+	udev_read_pid_files(rhgb_t)
 ')

--- a/policy/modules/services/roundup.te
+++ b/policy/modules/services/roundup.te
@@ -83,5 +83,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(roundup_t)
+	udev_read_pid_files(roundup_t)
 ')

--- a/policy/modules/services/rpc.te
+++ b/policy/modules/services/rpc.te
@@ -135,7 +135,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(rpc_domain)
+	udev_read_pid_files(rpc_domain)
 ')
 
 ########################################

--- a/policy/modules/services/samba.te
+++ b/policy/modules/services/samba.te
@@ -504,7 +504,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(smbd_t)
+	udev_read_pid_files(smbd_t)
 ')
 
 ########################################
@@ -609,7 +609,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(nmbd_t)
+	udev_read_pid_files(nmbd_t)
 ')
 
 ########################################
@@ -955,7 +955,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(winbind_t)
+	udev_read_pid_files(winbind_t)
 ')
 
 ########################################

--- a/policy/modules/services/sasl.te
+++ b/policy/modules/services/sasl.te
@@ -111,5 +111,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(saslauthd_t)
+	udev_read_pid_files(saslauthd_t)
 ')

--- a/policy/modules/services/sendmail.te
+++ b/policy/modules/services/sendmail.te
@@ -194,7 +194,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(sendmail_t)
+	udev_read_pid_files(sendmail_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/slrnpull.te
+++ b/policy/modules/services/slrnpull.te
@@ -66,5 +66,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(slrnpull_t)
+	udev_read_pid_files(slrnpull_t)
 ')

--- a/policy/modules/services/smartmon.te
+++ b/policy/modules/services/smartmon.te
@@ -121,5 +121,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(fsdaemon_t)
+	udev_read_pid_files(fsdaemon_t)
 ')

--- a/policy/modules/services/snmp.te
+++ b/policy/modules/services/snmp.te
@@ -165,7 +165,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(snmpd_t)
+	udev_read_pid_files(snmpd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/snort.te
+++ b/policy/modules/services/snort.te
@@ -109,5 +109,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(snort_t)
+	udev_read_pid_files(snort_t)
 ')

--- a/policy/modules/services/soundserver.te
+++ b/policy/modules/services/soundserver.te
@@ -104,5 +104,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(soundd_t)
+	udev_read_pid_files(soundd_t)
 ')

--- a/policy/modules/services/spamassassin.te
+++ b/policy/modules/services/spamassassin.te
@@ -471,7 +471,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(spamd_t)
+	udev_read_pid_files(spamd_t)
 ')
 
 ########################################

--- a/policy/modules/services/speedtouch.te
+++ b/policy/modules/services/speedtouch.te
@@ -57,5 +57,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(speedmgmt_t)
+	udev_read_pid_files(speedmgmt_t)
 ')

--- a/policy/modules/services/squid.te
+++ b/policy/modules/services/squid.te
@@ -235,5 +235,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(squid_t)
+	udev_read_pid_files(squid_t)
 ')

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -367,5 +367,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(ssh_keygen_t)
+	udev_read_pid_files(ssh_keygen_t)
 ')

--- a/policy/modules/services/stunnel.te
+++ b/policy/modules/services/stunnel.te
@@ -97,7 +97,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(stunnel_t)
+	udev_read_pid_files(stunnel_t)
 ')
 
 # hack since this port has no interfaces since it doesnt

--- a/policy/modules/services/tftp.te
+++ b/policy/modules/services/tftp.te
@@ -135,5 +135,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(tftpd_t)
+	udev_read_pid_files(tftpd_t)
 ')

--- a/policy/modules/services/timidity.te
+++ b/policy/modules/services/timidity.te
@@ -69,5 +69,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(timidity_t)
+	udev_read_pid_files(timidity_t)
 ')

--- a/policy/modules/services/transproxy.te
+++ b/policy/modules/services/transproxy.te
@@ -64,5 +64,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(transproxy_t)
+	udev_read_pid_files(transproxy_t)
 ')

--- a/policy/modules/services/uptime.te
+++ b/policy/modules/services/uptime.te
@@ -69,5 +69,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(uptimed_t)
+	udev_read_pid_files(uptimed_t)
 ')

--- a/policy/modules/services/uwimap.te
+++ b/policy/modules/services/uwimap.te
@@ -102,5 +102,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(imapd_t)
+	udev_read_pid_files(imapd_t)
 ')

--- a/policy/modules/services/virt.te
+++ b/policy/modules/services/virt.te
@@ -824,7 +824,6 @@ optional_policy(`
 
 optional_policy(`
 	udev_domtrans(virtd_t)
-	udev_read_db(virtd_t)
 	udev_read_pid_files(virtd_t)
 ')
 

--- a/policy/modules/services/watchdog.te
+++ b/policy/modules/services/watchdog.te
@@ -97,5 +97,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(watchdog_t)
+	udev_read_pid_files(watchdog_t)
 ')

--- a/policy/modules/services/xfs.te
+++ b/policy/modules/services/xfs.te
@@ -81,5 +81,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(xfs_t)
+	udev_read_pid_files(xfs_t)
 ')

--- a/policy/modules/services/xprint.te
+++ b/policy/modules/services/xprint.te
@@ -76,5 +76,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(xprint_t)
+	udev_read_pid_files(xprint_t)
 ')

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -591,7 +591,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(xdm_t)
+	udev_read_pid_files(xdm_t)
 ')
 
 optional_policy(`
@@ -819,7 +819,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(xserver_t)
 	udev_read_pid_files(xserver_t)
 ')
 

--- a/policy/modules/services/zebra.te
+++ b/policy/modules/services/zebra.te
@@ -134,5 +134,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(zebra_t)
+	udev_read_pid_files(zebra_t)
 ')

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -327,7 +327,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(pam_console_t)
+	udev_read_pid_files(pam_console_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/clock.te
+++ b/policy/modules/system/clock.te
@@ -73,7 +73,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(hwclock_t)
+	udev_read_pid_files(hwclock_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/fstools.te
+++ b/policy/modules/system/fstools.te
@@ -213,7 +213,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(fsadm_t)
+	udev_read_pid_files(fsadm_t)
 
 	# Xen causes losetup to run with a presumably accidentally inherited
 	# file handle for /run/xen-hotplug/block

--- a/policy/modules/system/getty.te
+++ b/policy/modules/system/getty.te
@@ -128,5 +128,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(getty_t)
+	udev_read_pid_files(getty_t)
 ')

--- a/policy/modules/system/hotplug.te
+++ b/policy/modules/system/hotplug.te
@@ -189,7 +189,7 @@ optional_policy(`
 optional_policy(`
 	udev_domtrans(hotplug_t)
 	udev_helper_domtrans(hotplug_t)
-	udev_read_db(hotplug_t)
+	udev_read_pid_files(hotplug_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -555,7 +555,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(init_t)
+	udev_read_pid_files(init_t)
 	udev_relabelto_db(init_t)
 ')
 

--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -191,7 +191,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(ipsec_t)
+	udev_read_pid_files(ipsec_t)
 ')
 
 ########################################

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -145,7 +145,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(iptables_t)
 	# this is for iptables_t to inherit a file hande from xen vif-bridge
 	udev_manage_pid_files(iptables_t)
 ')

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -238,7 +238,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(auditd_t)
+	udev_read_pid_files(auditd_t)
 ')
 
 ########################################
@@ -366,7 +366,7 @@ ifdef(`distro_ubuntu',`
 ')
 
 optional_policy(`
-	udev_read_db(klogd_t)
+	udev_read_pid_files(klogd_t)
 ')
 
 optional_policy(`
@@ -607,7 +607,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(syslogd_t)
 	# for systemd-journal to read seat data from /run/udev/data
 	udev_read_pid_files(syslogd_t)
 ')

--- a/policy/modules/system/lvm.te
+++ b/policy/modules/system/lvm.te
@@ -155,7 +155,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(clvmd_t)
+	udev_read_pid_files(clvmd_t)
 ')
 
 ########################################
@@ -369,7 +369,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(lvm_t)
 	udev_read_pid_files(lvm_t)
 ')
 

--- a/policy/modules/system/pcmcia.te
+++ b/policy/modules/system/pcmcia.te
@@ -117,5 +117,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(cardmgr_t)
+	udev_read_pid_files(cardmgr_t)
 ')

--- a/policy/modules/system/raid.te
+++ b/policy/modules/system/raid.te
@@ -105,5 +105,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(mdadm_t)
+	udev_read_pid_files(mdadm_t)
 ')

--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -253,7 +253,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dhcpc_t)
+	udev_read_pid_files(dhcpc_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -623,7 +623,6 @@ systemd_log_parse_environment(systemd_logind_t)
 systemd_start_power_units(systemd_logind_t)
 
 udev_list_pids(systemd_logind_t)
-udev_read_db(systemd_logind_t)
 udev_read_pid_files(systemd_logind_t)
 
 userdom_delete_all_user_runtime_dirs(systemd_logind_t)
@@ -829,7 +828,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(systemd_networkd_t)
 	udev_read_pid_files(systemd_networkd_t)
 ')
 

--- a/policy/modules/system/udev.fc
+++ b/policy/modules/system/udev.fc
@@ -1,7 +1,3 @@
-/dev/\.udev(/.*)? --	gen_context(system_u:object_r:udev_tbl_t,s0)
-/dev/\.udevdb	--	gen_context(system_u:object_r:udev_tbl_t,s0)
-/dev/udev\.tbl	--	gen_context(system_u:object_r:udev_tbl_t,s0)
-
 /etc/dev\.d/.+	--	gen_context(system_u:object_r:udev_helper_exec_t,s0)
 
 /etc/hotplug\.d/default/udev.* -- gen_context(system_u:object_r:udev_helper_exec_t,s0)

--- a/policy/modules/system/udev.if
+++ b/policy/modules/system/udev.if
@@ -214,10 +214,10 @@ interface(`udev_manage_rules_files',`
 #
 interface(`udev_dontaudit_search_db',`
 	gen_require(`
-		type udev_tbl_t;
+		type udev_runtime_t;
 	')
 
-	dontaudit $1 udev_tbl_t:dir search_dir_perms;
+	dontaudit $1 udev_runtime_t:dir search_dir_perms;
 ')
 
 ########################################
@@ -237,20 +237,9 @@ interface(`udev_dontaudit_search_db',`
 ## <infoflow type="read" weight="10"/>
 #
 interface(`udev_read_db',`
-	gen_require(`
-		type udev_tbl_t;
-	')
+	refpolicywarn(`$0($*) has been deprecated, please use udev_read_pid_files() instead.')
 
-	allow $1 udev_tbl_t:dir list_dir_perms;
-
-	read_files_pattern($1, udev_tbl_t, udev_tbl_t)
-	read_lnk_files_pattern($1, udev_tbl_t, udev_tbl_t)
-
-	dev_list_all_dev_nodes($1)
-
-	files_search_etc($1)
-
-	udev_search_pids($1)
+	udev_read_pid_files($1)
 ')
 
 ########################################
@@ -265,11 +254,11 @@ interface(`udev_read_db',`
 #
 interface(`udev_rw_db',`
 	gen_require(`
-		type udev_tbl_t;
+		type udev_runtime_t;
 	')
 
-	dev_list_all_dev_nodes($1)
-	allow $1 udev_tbl_t:file rw_file_perms;
+	files_search_pids($1)
+	allow $1 udev_runtime_t:file rw_file_perms;
 ')
 
 ########################################

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -28,12 +28,9 @@ files_config_file(udev_etc_t)
 type udev_rules_t;
 files_type(udev_rules_t)
 
-type udev_runtime_t alias udev_var_run_t;
+type udev_runtime_t alias {udev_tbl_t udev_var_run_t};
 files_pid_file(udev_runtime_t)
 init_daemon_pid_file(udev_runtime_t, dir, "udev")
-
-type udev_tbl_t alias udev_tdb_t;
-files_type(udev_tbl_t)
 
 ifdef(`enable_mcs',`
 	kernel_ranged_domtrans_to(udev_t, udev_exec_t, s0 - mcs_systemhigh)
@@ -73,9 +70,6 @@ can_exec(udev_t, udev_helper_exec_t)
 
 # read udev config
 allow udev_t udev_etc_t:file read_file_perms;
-
-allow udev_t udev_tbl_t:file manage_file_perms;
-dev_filetrans(udev_t, udev_tbl_t, file)
 
 list_dirs_pattern(udev_t, udev_rules_t, udev_rules_t)
 manage_files_pattern(udev_t, udev_rules_t, udev_rules_t)
@@ -403,11 +397,8 @@ delete_files_pattern(udevadm_t, udev_runtime_t, udev_runtime_t)
 delete_lnk_files_pattern(udevadm_t, udev_runtime_t, udev_runtime_t)
 list_dirs_pattern(udevadm_t, udev_runtime_t, udev_runtime_t)
 read_files_pattern(udevadm_t, udev_runtime_t, udev_runtime_t)
+read_lnk_files_pattern(udevadm_t, udev_runtime_t, udev_runtime_t)
 allow udevadm_t udev_runtime_t:dir watch;
-
-list_dirs_pattern(udevadm_t, udev_tbl_t, udev_tbl_t)
-read_files_pattern(udevadm_t, udev_tbl_t, udev_tbl_t)
-read_lnk_files_pattern(udevadm_t, udev_tbl_t, udev_tbl_t)
 
 dev_rw_sysfs(udevadm_t)
 dev_read_urand(udevadm_t)


### PR DESCRIPTION
This location is gone for quite some times and the udevdb has been moved
to /run/udev.

Drop the udev_tbl_t and deprecate the udev_read_db() function

This inspired from changes in the Red Hat policy

Signed-off-by: Laurent Bigonville <bigon@bigon.be>

Fixes: #221