### PR TITLE
systemd: make systemd --user run generators without transition

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1316,6 +1316,9 @@ userdom_user_runtime_filetrans(systemd_user_session_type, systemd_user_runtime_t
 allow systemd_user_session_type systemd_user_runtime_notify_t:sock_file create;
 type_transition systemd_user_session_type systemd_user_runtime_t:sock_file systemd_user_runtime_notify_t "notify";
 
+# Run generators in /usr/lib/systemd/user-environment-generators with no domain transition
+can_exec(systemd_user_session_type, systemd_generator_exec_t)
+
 dev_write_sysfs_dirs(systemd_user_session_type)
 dev_read_sysfs(systemd_user_session_type)
 


### PR DESCRIPTION
On Debian 10, ``systemd --user`` runs some generators in `/usr/lib/systemd/user-environment-generators` when a user session starts. Here is what is logged in audit.log for a `sysadm` user.

    type=AVC msg=audit(1586962888.516:65): avc:  denied  { getattr } for
    pid=309 comm="(sd-executor)"
    path="/usr/lib/systemd/user-environment-generators/90gpg-agent"
    dev="vda1" ino=662897 scontext=sysadm_u:sysadm_r:sysadm_systemd_t
    tcontext=system_u:object_r:systemd_generator_exec_t tclass=file
    permissive=1

    type=AVC msg=audit(1586962888.516:66): avc:  denied  { map } for
    pid=310 comm="30-systemd-envi"
    path="/usr/lib/systemd/user-environment-generators/30-systemd-environment-d-generator"
    dev="vda1" ino=655822 scontext=sysadm_u:sysadm_r:sysadm_systemd_t
    tcontext=system_u:object_r:systemd_generator_exec_t tclass=file
    permissive=1

    type=AVC msg=audit(1586962888.516:66): avc:  denied
    { execute_no_trans } for  pid=310 comm="(direxec)"
    path="/usr/lib/systemd/user-environment-generators/30-systemd-environment-d-generator"
    dev="vda1" ino=655822 scontext=sysadm_u:sysadm_r:sysadm_systemd_t
    tcontext=system_u:object_r:systemd_generator_exec_t tclass=file
    permissive=1

Run these program without domain transition.

This follows a discussion that took place in https://github.com/SELinuxProject/refpolicy/pull/224 and supersedes https://github.com/SELinuxProject/refpolicy/pull/223