### PR TITLE
devices: label /dev/sysdig0

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -113,6 +113,7 @@
 /dev/snapshot		-c	gen_context(system_u:object_r:acpi_bios_t,s0)
 /dev/sndstat		-c	gen_context(system_u:object_r:sound_device_t,s0)
 /dev/sonypi		-c	gen_context(system_u:object_r:v4l_device_t,s0)
+/dev/sysdig[0-9]	-c	gen_context(system_u:object_r:sysdig_device_t,s0)
 /dev/tee[0-9]		-c	gen_context(system_u:object_r:tee_device_t,s0)
 /dev/teepriv[0-9]	-c	gen_context(system_u:object_r:tee_priv_device_t,s0)
 /dev/tlk[0-3]		-c	gen_context(system_u:object_r:v4l_device_t,s0)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -4178,6 +4178,25 @@ interface(`dev_manage_smartcard',`
 
 ########################################
 ## <summary>
+##	Read, write and map the sysdig device.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_rw_sysdig',`
+	gen_require(`
+		type device_t, sysdig_device_t;
+	')
+
+	rw_chr_files_pattern($1, device_t, sysdig_device_t)
+	allow $1 sysdig_device_t:chr_file map;
+')
+
+########################################
+## <summary>
 ##	Mount a filesystem on sysfs.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -256,6 +256,12 @@ type sound_device_t;
 dev_node(sound_device_t)
 
 #
+# Type for sysdig device
+#
+type sysdig_device_t;
+dev_node(sysdig_device_t)
+
+#
 # sysfs_t is the type for the /sys pseudofs
 #
 type sysfs_t, sysfs_types;


### PR DESCRIPTION
`sysdig` is a tool that enables introspecting the system, debugging it, etc. It uses a driver that creates `/dev/sysdig0`. Define a specific label in order to be able to allow using it.