### PR TITLE
Allow systemd-networkd to handle ICMP and DHCP packets

### DIFF
--- a/policy/modules/kernel/corenetwork.if.m4
+++ b/policy/modules/kernel/corenetwork.if.m4
@@ -872,6 +872,13 @@ create_packet_interfaces($1_client)
 create_packet_interfaces($1_server)
 ')
 
+#
+# network_packet_simple(packet_name)
+#
+define(`network_packet_simple',`
+create_packet_interfaces($1)
+')
+
 # create_ibpkey_*_interfaces(name, subnet_prefix, pkeynum,mls_sensitivity)
 # (these wrap create_port_interfaces to handle attributes and types)
 define(`create_ibpkey_type_interfaces',`create_ibpkey_interfaces($1,ibpkey_t,type,determine_reserved_capability(shift($*)))')

--- a/policy/modules/kernel/corenetwork.te.in
+++ b/policy/modules/kernel/corenetwork.te.in
@@ -43,6 +43,11 @@ dev_node(tun_tap_device_t)
 type client_packet_t, packet_type, client_packet_type;
 
 #
+# ICMP and ICMPv6
+#
+network_packet_simple(icmp)
+
+#
 # The netlabel_peer_t is used by the kernel's NetLabel subsystem for network
 # connections using NetLabel which do not carry full SELinux contexts.
 #

--- a/policy/modules/kernel/corenetwork.te.m4
+++ b/policy/modules/kernel/corenetwork.te.m4
@@ -112,6 +112,13 @@ type $1_client_packet_t, packet_type, client_packet_type;
 type $1_server_packet_t, packet_type, server_packet_type;
 ')
 
+#
+# network_packet_simple(packet_name)
+#
+define(`network_packet_simple',`
+type $1_packet_t, packet_type;
+')
+
 define(`declare_ibpkeycons',`dnl
 ibpkeycon $2 $3 gen_context(system_u:object_r:$1,$4)
 ifelse(`$5',`',`',`declare_ibpkeycons($1,shiftn(4,$*))')dnl

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -794,6 +794,8 @@ kernel_rw_net_sysctls(systemd_networkd_t)
 corecmd_bin_entry_type(systemd_networkd_t)
 corecmd_exec_bin(systemd_networkd_t)
 
+corenet_sendrecv_icmp_packets(systemd_networkd_t)
+corenet_sendrecv_dhcpd_client_packets(systemd_networkd_t)
 corenet_rw_tun_tap_dev(systemd_networkd_t)
 corenet_udp_bind_dhcpc_port(systemd_networkd_t)
 corenet_udp_bind_generic_node(systemd_networkd_t)


### PR DESCRIPTION
Allow systemd-networkd to send and receive ICMPv6 Router Solicitation
and Router Advertisement packets (in reality all unlabeled packets)
and DHCP client packets.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>