### PR TITLE
Override old all_interfaces.conf.tmp file

### DIFF
--- a/Rules.modular
+++ b/Rules.modular
@@ -141,7 +141,7 @@ $(tmpdir)/global_bools.conf: $(m4support) $(tmpdir)/generated_definitions.conf $
 $(tmpdir)/all_interfaces.conf: $(m4support) $(all_interfaces) $(m4iferror)
 	@test -d $(tmpdir) || mkdir -p $(tmpdir)
 	@cat $(m4divert) > $@
-	$(verbose) $(M4) $^ >> $(tmpdir)/$(@F).tmp
+	$(verbose) $(M4) $^ > $(tmpdir)/$(@F).tmp
 	$(verbose) $(SED) -e s/dollarsstar/\$$\*/g $(tmpdir)/$(@F).tmp >> $@
 	@cat $(m4undivert) >> $@
 

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -123,7 +123,7 @@ $(tmpdir)/global_bools.conf: $(m4support) $(tmpdir)/generated_definitions.conf $
 $(tmpdir)/all_interfaces.conf: $(m4support) $(all_interfaces) $(m4iferror)
 	@test -d $(tmpdir) || mkdir -p $(tmpdir)
 	@cat $(m4divert) > $@
-	$(verbose) $(M4) $^ >> $(tmpdir)/$(@F).tmp
+	$(verbose) $(M4) $^ > $(tmpdir)/$(@F).tmp
 	$(verbose) $(SED) -e s/dollarsstar/\$$\*/g $(tmpdir)/$(@F).tmp >> $@
 	@cat $(m4undivert) >> $@
 


### PR DESCRIPTION
Do not keep interfaces from previous builds.

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>

Fixes: #235