### PR TITLE
Build and install Netfilter rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /file_contexts
 /homedir_template
 /net_contexts
+/net_contexts.nft
 /policy.conf
 /policy.[0-9]*
 /policy/booleans.conf

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,6 @@ contextpath := $(installdir)/contexts
 homedirpath := $(contextpath)/files/homedir_template
 fcpath := $(contextpath)/files/file_contexts
 fcsubspath := $(contextpath)/files/file_contexts.subs_dist
-ncpath := $(contextpath)/netfilter_contexts
 sharedir := $(prefix)/share/selinux
 modpkgdir := $(sharedir)/$(strip $(NAME))
 headerdir := $(modpkgdir)/include
@@ -258,6 +257,8 @@ user_default_contexts := $(wildcard config/appconfig-$(TYPE)/*_default_contexts)
 user_default_contexts_names := $(addprefix $(contextpath)/users/,$(subst _default_contexts,,$(notdir $(user_default_contexts))))
 appfiles := $(addprefix $(appdir)/,default_contexts default_type initrc_context failsafe_context userhelper_context removable_context dbus_contexts sepgsql_contexts x_contexts customizable_types securetty_types lxc_contexts openrc_contexts virtual_domain_context virtual_image_context) $(contextpath)/files/media $(fcsubspath) $(user_default_contexts_names)
 net_contexts := $(builddir)net_contexts
+net_contexts_nft := $(builddir)net_contexts.nft
+docfiles += $(net_contexts) $(net_contexts_nft)
 
 all_layers := $(shell find $(moddir)/* -maxdepth 0 -type d)
 ifdef LOCAL_ROOT
@@ -390,6 +391,10 @@ $(moddir)/kernel/corenetwork.te: $(m4divert) $(moddir)/kernel/corenetwork.te.m4 
 $(net_contexts): $(moddir)/kernel/corenetwork.te.in
 	@echo "Creating netfilter network labeling rules"
 	$(verbose) $(gennetfilter) $^ > $@
+
+$(net_contexts_nft): $(moddir)/kernel/corenetwork.te.in
+	@echo "Creating netfilter NFT network labeling rules"
+	$(verbose) $(gennetfilter) --nft $^ > $@
 
 ########################################
 #
@@ -553,7 +558,7 @@ endif
 #
 # Install policy documentation
 #
-install-docs: $(tmpdir)/html
+install-docs: $(tmpdir)/html $(docfiles)
 	@mkdir -p $(docsdir)/html
 	@echo "Installing policy documentation"
 	$(verbose) $(INSTALL) -m 644 $(docfiles) $(docsdir)

--- a/Rules.modular
+++ b/Rules.modular
@@ -222,7 +222,7 @@ clean:
 	$(verbose) rm -f $(base_conf)
 	$(verbose) rm -f $(base_fc)
 	$(verbose) rm -f $(builddir)*.pp
-	$(verbose) rm -f $(net_contexts)
+	$(verbose) rm -f $(net_contexts) $(net_contexts_nft)
 	$(verbose) rm -fR $(tmpdir)
 
 .PHONY: default all policy base modules install load clean validate

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -202,15 +202,6 @@ $(fcpath): $(fc) $(loadpath) $(userpath)/system.users
 
 ########################################
 #
-# Intall netfilter_contexts
-#
-$(ncpath): $(net_contexts)
-	@echo "Installing $(NAME) netfilter_contexts."
-	@$(INSTALL) -d -m 0755 $(@D)
-	$(verbose) $(INSTALL) -m 0644 $^ $@
-
-########################################
-#
 # Validate file contexts
 #
 validate: $(fc) $(polver)
@@ -253,7 +244,7 @@ clean:
 	$(verbose) rm -f $(polver)
 	$(verbose) rm -f $(fc)
 	$(verbose) rm -f $(homedir_template)
-	$(verbose) rm -f $(net_contexts)
+	$(verbose) rm -f $(net_contexts) $(net_contexts_nft)
 	$(verbose) rm -f *.res
 	$(verbose) rm -fR $(tmpdir)
 


### PR DESCRIPTION
Build SECMARK rules for iptables and NFT, install them as
/etc/selinux/$NAME/contexts/netfilter_contexts{,.nft}.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>