### PR TITLE
Fix bird2

### DIFF
--- a/policy/modules/services/bird.fc
+++ b/policy/modules/services/bird.fc
@@ -11,3 +11,5 @@
 /var/log/bird\.log.*	--	gen_context(system_u:object_r:bird_log_t,s0)
 
 /run/bird\.ctl	-s	gen_context(system_u:object_r:bird_runtime_t,s0)
+
+/run/bird(/.*)?		gen_context(system_u:object_r:bird_runtime_t,s0)

--- a/policy/modules/services/bird.if
+++ b/policy/modules/services/bird.if
@@ -36,4 +36,6 @@ interface(`bird_admin',`
 
 	files_list_pids($1)
 	admin_pattern($1, bird_runtime_t)
+
+	stream_connect_pattern($1, bird_runtime_t, bird_runtime_t, bird_t)
 ')

--- a/policy/modules/services/bird.te
+++ b/policy/modules/services/bird.te
@@ -26,17 +26,23 @@ files_pid_file(bird_runtime_t)
 # Local policy
 #
 
-allow bird_t self:capability net_admin;
+allow bird_t self:capability { net_admin net_raw };
 allow bird_t self:netlink_route_socket create_netlink_socket_perms;
 allow bird_t self:tcp_socket create_stream_socket_perms;
+allow bird_t self:unix_stream_socket create_stream_socket_perms;
+allow bird_t self:rawip_socket { create read write setopt };
 
 allow bird_t bird_etc_t:file read_file_perms;
+allow bird_t bird_etc_t:dir list_dir_perms;
 
 allow bird_t bird_log_t:file { create_file_perms append_file_perms setattr_file_perms };
 logging_log_filetrans(bird_t, bird_log_t, file)
 
 allow bird_t bird_runtime_t:sock_file manage_sock_file_perms;
-files_pid_filetrans(bird_t, bird_runtime_t, sock_file)
+allow bird_t bird_runtime_t:dir manage_dir_perms;
+files_pid_filetrans(bird_t, bird_runtime_t, { sock_file dir })
+
+kernel_read_crypto_sysctls(bird_t)
 
 corenet_all_recvfrom_unlabeled(bird_t)
 corenet_all_recvfrom_netlabel(bird_t)


### PR DESCRIPTION
On debian the bird socket has moved to `/run/bird/bird.ctl` and config files are now under `/etc/bird/`