### PR TITLE
Allow users to use systemd run

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -24,6 +24,7 @@ template(`systemd_role_template',`
 	gen_require(`
 		attribute systemd_user_session_type, systemd_log_parse_env_type;
 		type systemd_user_runtime_t, systemd_user_runtime_notify_t;
+		type systemd_run_exec_t;
 	')
 
 	#################################
@@ -58,6 +59,8 @@ template(`systemd_role_template',`
 
 	# Allow using file descriptors for user environment generators
 	allow $3 $1_systemd_t:fd use;
+
+	can_exec($3, systemd_run_exec_t)
 ')
 
 ######################################


### PR DESCRIPTION
This can be used to e.g. create temporary units under `systemd --user`