### PR TITLE
ssh: fix for debian wrapper script

### DIFF
--- a/policy/modules/services/ssh.fc
+++ b/policy/modules/services/ssh.fc
@@ -22,3 +22,7 @@ HOME_DIR/\.ssh(/.*)?			gen_context(system_u:object_r:ssh_home_t,s0)
 /run/sshd(/.*)?			gen_context(system_u:object_r:sshd_runtime_t,s0)
 /run/sshd\.init\.pid	--	gen_context(system_u:object_r:sshd_runtime_t,s0)
 /run/sshd\.pid		--	gen_context(system_u:object_r:sshd_runtime_t,s0)
+
+ifdef(`distro_debian',`
+/run/user/%{USERID}/openssh_agent	-s	gen_context(system_u:object_r:ssh_agent_tmp_t,s0)
+')

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -408,6 +408,10 @@ template(`ssh_role_template',`
 	allow $3 $1_ssh_agent_t:fifo_file rw_inherited_fifo_file_perms;
 	allow $3 $1_ssh_agent_t:process sigchld;
 
+	ifdef(`distro_debian', `
+		userdom_user_runtime_filetrans($1_ssh_agent_t, ssh_agent_tmp_t, sock_file)
+	')
+
 	tunable_policy(`use_nfs_home_dirs',`
 		fs_manage_nfs_files($1_ssh_agent_t)
 


### PR DESCRIPTION
debian ships a wrapper script that moves the ssh-agent socket to
/run/user/$UID/openssh_agent

Signed-off-by: bauen1 <j2468h@gmail.com>