### PR TITLE
wm: add KWin

### DIFF
--- a/policy/modules/apps/wm.fc
+++ b/policy/modules/apps/wm.fc
@@ -1,5 +1,6 @@
 /usr/bin/gnome-shell	--	gen_context(system_u:object_r:wm_exec_t,s0)
 /usr/bin/openbox	--	gen_context(system_u:object_r:wm_exec_t,s0)
+/usr/bin/kwin_((wayland)|(x11))	--	gen_context(system_u:object_r:wm_exec_t,s0)
 /usr/bin/metacity	--	gen_context(system_u:object_r:wm_exec_t,s0)
 /usr/bin/mutter		--	gen_context(system_u:object_r:wm_exec_t,s0)
 /usr/bin/twm	--	gen_context(system_u:object_r:wm_exec_t,s0)

--- a/policy/modules/apps/wm.te
+++ b/policy/modules/apps/wm.te
@@ -38,6 +38,7 @@ files_tmp_filetrans(wm_domain, wm_tmp_t, { dir file lnk_file })
 
 manage_dirs_pattern(wm_domain, wm_tmpfs_t, wm_tmpfs_t)
 manage_files_pattern(wm_domain, wm_tmpfs_t, wm_tmpfs_t)
+mmap_read_files_pattern(wm_domain, wm_tmpfs_t, wm_tmpfs_t)
 manage_lnk_files_pattern(wm_domain, wm_tmpfs_t, wm_tmpfs_t)
 fs_tmpfs_filetrans(wm_domain, wm_tmpfs_t, { dir file lnk_file })
 


### PR DESCRIPTION
Add KWin to list of window managers and allow it to mmap wm_tmpfs_t
files to avoid a crash. Related audit event:
type=AVC msg=audit(04/24/2020 15:39:25.287:679) : avc:  denied  { map } for  pid=1309 comm=kwin_x11 path=/memfd:JSVMStack:/lib/x86_64-linux-gnu/libQt5Qml.so.5 (deleted) dev="tmpfs" ino=45261 scontext=user_u:user_r:user_wm_t:s0 tcontext=user_u:object_r:wm_tmpfs_t:s0 tclass=file permissive=0

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>