### PR TITLE
Interfaces needed to support IMA/EVM keys

### DIFF
--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -1489,6 +1489,32 @@ interface(`domain_all_recvfrom_all_domains',`
 
 ########################################
 ## <summary>
+##	Allow all domains to search specified type keys.
+## </summary>
+## <desc>
+##	<p>
+##	When setting up IMA/EVM key(s) are added to the 
+##	kernel keyring but the type of the key is the domain
+##	adding the key.  This interface will allow all domains
+##	search the key so IMA/EVM validation can happen.
+##	</p>
+## </desc>
+## <param name="type">
+##	<summary>
+##	Type of key to be searched.
+##	</summary>
+## </param>
+#
+interface(`domain_public_key',`
+	gen_require(`
+		attribute domain;
+	')
+
+	allow domain $1:key search;
+')
+
+########################################
+## <summary>
 ##	Send generic signals to the unconfined domain.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -493,6 +493,24 @@ interface(`kernel_dontaudit_view_key',`
 
 ########################################
 ## <summary>
+##	allow write access to the kernel key ring.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to allow.
+##	</summary>
+## </param>
+#
+interface(`kernel_write_key',`
+	gen_require(`
+		type kernel_t;
+	')
+
+	allow $1 kernel_t:key write;
+')
+
+########################################
+## <summary>
 ##	Allows caller to read the ring buffer.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
I have been working to support IMA/EVM on a system.  It
requires having keys added to the kernel keyring.  Keys
added with keyctl and evmctl.  I am creating keys in the
ima_key_t type.  Once the keys are created, many domains
then need search permission on the type of the key.  The
following changes are needed to get things to work.

Need to add keys to the kernel keyring (keyctl).

type=AVC msg=audit(1585420717.704:1868): avc:  denied  { write } for pid=8622 comm="keyctl" scontext=system_u:system_r:cleanup_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=key permissive=1

Allow all domains to search key

type=AVC msg=audit(1587936822.802:556): avc:  denied  { search } for  pid=5963 comm="kworker/u16:6" scontext=system_u:system_r:kernel_t:s0 tcontext=system_u:object_r:ima_key_t:s0 tclass=key permissive=1
type=AVC msg=audit(1587936822.804:559): avc:  denied  { search } for  pid=5963 comm="systemd-cgroups" scontext=system_u:system_r:systemd_cgroups_t:s0 tcontext=system_u:object_r:ima_key_t:s0 tclass=key permissive=1
type=AVC msg=audit(1587936822.809:560): avc:  denied  { search } for  pid=5964 comm="(sysctl)" scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:ima_key_t:s0 tclass=key permissive=1
type=AVC msg=audit(1587936822.813:562): avc:  denied  { search } for  pid=5964 comm="sysctl" scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:ima_key_t:s0 tclass=key permissive=1
type=AVC msg=audit(1587936823.149:604): avc:  denied  { search } for  pid=5987 comm="setsebool" scontext=system_u:system_r:semanage_t:s0 tcontext=system_u:object_r:ima_key_t:s0 tclass=key permissive=1

Signed-off-by: Dave Sugar <dsugar@tresys.com>