### PR TITLE
Remove out of date "hack" from stunnel.  The underlying problem needing

### DIFF
--- a/policy/modules/services/stunnel.te
+++ b/policy/modules/services/stunnel.te
@@ -100,9 +100,3 @@ optional_policy(`
 	udev_read_db(stunnel_t)
 ')
 
-# hack since this port has no interfaces since it doesnt
-# have net_contexts
-gen_require(`
-	type stunnel_port_t;
-')
-allow stunnel_t stunnel_port_t:tcp_socket name_bind;


### PR DESCRIPTION
a require was fixed back in 2011, so using corenet_tcp_bind_stunnel_port
would be an option now, but stunnel_t already has
corenet_tcp_bind_all_ports, so this access is redundant.