### PR TITLE
netutils: allow ping to send and receive ICMP packets

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -113,6 +113,7 @@ allow ping_t self:netlink_route_socket create_netlink_socket_perms;
 
 corenet_all_recvfrom_unlabeled(ping_t)
 corenet_all_recvfrom_netlabel(ping_t)
+corenet_sendrecv_icmp_packets(ping_t)
 corenet_tcp_sendrecv_generic_if(ping_t)
 corenet_raw_sendrecv_generic_if(ping_t)
 corenet_raw_sendrecv_generic_node(ping_t)


### PR DESCRIPTION
Let ping send and receive ICMP packets when Netfilter SECMARK packet
labeling is active.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>