### PR TITLE
ntpd: fixes for systemd-timesyncd after linux 5.4

### DIFF
--- a/policy/modules/services/ntp.te
+++ b/policy/modules/services/ntp.te
@@ -118,6 +118,8 @@ files_manage_etc_symlinks(ntpd_t)
 files_read_etc_runtime_files(ntpd_t)
 files_read_usr_files(ntpd_t)
 files_list_var_lib(ntpd_t)
+files_watch_root_dirs(ntpd_t)
+files_watch_runtime_dirs(ntpd_t)
 
 fs_getattr_all_fs(ntpd_t)
 fs_search_auto_mountpoints(ntpd_t)


### PR DESCRIPTION
Adds missing watch permissions required for correct functionality after linux 5.4

Signed-off-by: bauen1 <j2468h@gmail.com>