### PR TITLE
Misc cleanup

### DIFF
--- a/doc/example.te
+++ b/doc/example.te
@@ -1,5 +1,5 @@
 
-policy_module(myapp,1.0.0)
+policy_module(example,1.0.0) # a non-base module name must match the file name
 
 ########################################
 #

--- a/policy/modules/admin/portage.if
+++ b/policy/modules/admin/portage.if
@@ -195,14 +195,6 @@ interface(`portage_compile_domain',`
 		fs_manage_nfs_files($1)
 		fs_manage_nfs_symlinks($1)
 	')
-
-	ifdef(`TODO',`
-	# some gui ebuilds want to interact with X server, like xawtv
-	optional_policy(`
-		allow $1 xdm_xserver_tmp_t:dir { add_entry_dir_perms del_entry_dir_perms };
-		allow $1 xdm_xserver_tmp_t:sock_file { create_sock_file_perms delete_sock_file_perms write_sock_file_perms };
-	')
-	') dnl end TODO
 ')
 
 ########################################

--- a/policy/modules/admin/portage.te
+++ b/policy/modules/admin/portage.te
@@ -234,12 +234,6 @@ optional_policy(`
 	usermanage_run_useradd(portage_t, portage_roles)
 ')
 
-ifdef(`TODO',`
-# seems to work ok without these
-dontaudit portage_t device_t:{ blk_file chr_file } getattr;
-dontaudit portage_t proc_t:dir setattr_dir_perms;
-')
-
 ##########################################
 #
 # Portage fetch domain

--- a/policy/modules/apps/chromium.fc
+++ b/policy/modules/apps/chromium.fc
@@ -3,21 +3,18 @@
 /opt/google/chrome/chrome-sandbox			--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
 /opt/google/chrome/google-chrome			--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /opt/google/chrome/nacl_.*				--	gen_context(system_u:object_r:chromium_naclhelper_exec_t,s0)
-/opt/google/chrome/libudev\.so\.0				gen_context(system_u:object_r:lib_t,s0)
 
 /opt/google/chrome-beta/chrome				--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /opt/google/chrome-beta/chrome_sandbox			--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
 /opt/google/chrome-beta/chrome-sandbox			--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
 /opt/google/chrome-beta/google-chrome			--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /opt/google/chrome-beta/nacl_helper_bootstrap		--	gen_context(system_u:object_r:chromium_naclhelper_exec_t,s0)
-/opt/google/chrome-beta/libudev\.so\.0				gen_context(system_u:object_r:lib_t,s0)
 
 /opt/google/chrome-unstable/chrome			--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /opt/google/chrome-unstable/chrome_sandbox		--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
 /opt/google/chrome-unstable/chrome-sandbox		--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)
 /opt/google/chrome-unstable/google-chrome		--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /opt/google/chrome-unstable/nacl_helper_bootstrap	--	gen_context(system_u:object_r:chromium_naclhelper_exec_t,s0)
-/opt/google/chrome-unstable/libudev\.so\.0			gen_context(system_u:object_r:lib_t,s0)
 
 /usr/lib/chromium/chromium				--	gen_context(system_u:object_r:chromium_exec_t,s0)
 /usr/lib/chromium/chrome-sandbox			--	gen_context(system_u:object_r:chromium_sandbox_exec_t,s0)

--- a/policy/modules/apps/chromium.te
+++ b/policy/modules/apps/chromium.te
@@ -253,16 +253,6 @@ optional_policy(`
 	dpkg_read_db(chromium_t)
 ')
 
-ifdef(`use_alsa',`
-	optional_policy(`
-		alsa_domain(chromium_t, chromium_tmpfs_t)
-	')
-
-	optional_policy(`
-		pulseaudio_domtrans(chromium_t)
-	')
-')
-
 ########################################
 #
 # chromium_renderer local policy

--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -210,7 +210,8 @@ HOME_ROOT/lost\+found/.*	<<none>>
 /usr/lost\+found	-d	gen_context(system_u:object_r:lost_found_t,mls_systemhigh)
 /usr/lost\+found/.*		<<none>>
 
-/usr/share/doc(/.*)?/README.*	gen_context(system_u:object_r:usr_t,s0)
+/usr/share/doc(/.*)?/README.*		gen_context(system_u:object_r:usr_t,s0)
+/usr/share/docbook2X/xslt/man(/.*)?	gen_context(system_u:object_r:usr_t,s0)
 
 /usr/tmp		-d	gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
 /usr/tmp/.*			<<none>>

--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -261,6 +261,7 @@ ifndef(`distro_redhat',`
 
 /var/spool(/.*)?		gen_context(system_u:object_r:var_spool_t,s0)
 /var/spool/postfix/etc(/.*)?	gen_context(system_u:object_r:etc_t,s0)
+/var/spool/postfix/pid	-d	gen_context(system_u:object_r:var_run_t,s0)
 
 /var/tmp		-d	gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
 /var/tmp		-l	gen_context(system_u:object_r:tmp_t,s0)

--- a/policy/modules/services/consolesetup.if
+++ b/policy/modules/services/consolesetup.if
@@ -12,7 +12,7 @@
 #
 interface(`consolesetup_domtrans', `
     gen_require(`
-        type consolesetup_t, consolesetup_conf_t, consolesetup_exec_t, consolesetup_runtime_t;
+        type consolesetup_t, consolesetup_exec_t;
     ')
 
     corecmd_search_bin($1)

--- a/policy/modules/services/samba.if
+++ b/policy/modules/services/samba.if
@@ -657,11 +657,11 @@ interface(`samba_read_winbind_pid',`
 #
 interface(`samba_stream_connect_winbind',`
 	gen_require(`
-		type samba_var_t, winbind_t, winbind_runtime_t, smbd_runtime_t;
+		type samba_var_t, winbind_t, winbind_runtime_t, samba_runtime_t;
 	')
 
 	files_search_pids($1)
-	stream_connect_pattern($1, { smbd_runtime_t samba_var_t winbind_runtime_t }, winbind_runtime_t, winbind_t)
+	stream_connect_pattern($1, { samba_runtime_t samba_var_t winbind_runtime_t }, winbind_runtime_t, winbind_t)
 ')
 
 ########################################

--- a/policy/modules/services/tpm2.if
+++ b/policy/modules/services/tpm2.if
@@ -35,9 +35,6 @@ interface(`tpm2_domtrans',`
 		type tpm2_t, tpm2_exec_t;
 	')
 
-	allow tpm2_t $1:fd use;
-	allow tpm2_t $1:fifo_file rw_file_perms;
-
 	corecmd_search_bin($1)
 	domtrans_pattern($1, tpm2_exec_t, tpm2_t)
 ')
@@ -162,6 +159,6 @@ interface(`tpm2_rw_abrmd_pipes',`
 	')
 
 	allow $1 tpm2_abrmd_t:fd use;
-	allow $1 tpm2_abrmd_t:fifo_file rw_file_perms;
+	allow $1 tpm2_abrmd_t:fifo_file rw_fifo_file_perms;
 ')
 

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -3384,6 +3384,26 @@ interface(`init_reload_all_units',`
 
 ########################################
 ## <summary>
+##	Manage systemd unit dirs and the files in them
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_manage_all_unit_files',`
+	gen_require(`
+		attribute systemdunit;
+	')
+
+	manage_dirs_pattern($1, systemdunit, systemdunit)
+	manage_files_pattern($1, systemdunit, systemdunit)
+	manage_lnk_files_pattern($1, systemdunit, systemdunit)
+')
+
+########################################
+## <summary>
 ##      Allow unconfined access to send instructions to init
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -402,6 +402,7 @@ ifdef(`init_systemd',`
 	# for network namespaces
 	fs_read_nsfs_files(init_t)
 
+	init_manage_all_unit_files(init_t)
 	init_read_script_state(init_t)
 
 	miscfiles_watch_localization(init_t)
@@ -446,7 +447,6 @@ ifdef(`init_systemd',`
 	systemd_relabelto_tmpfiles_conf_files(init_t)
 	systemd_relabelto_journal_dirs(init_t)
 	systemd_relabelto_journal_files(init_t)
-	systemd_manage_all_units(init_t)
 	systemd_rw_networkd_netlink_route_sockets(init_t)
 
 	term_create_devpts_dirs(init_t)

--- a/policy/modules/system/libraries.fc
+++ b/policy/modules/system/libraries.fc
@@ -43,6 +43,10 @@ ifdef(`distro_redhat',`
 /opt/(.*/)?jre.*/.+\.so(\.[^/]*)*	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /opt/(.*/)?jre/.+\.jar			--	gen_context(system_u:object_r:lib_t,s0)
 
+/opt/google/chrome/libudev\.so\.0		gen_context(system_u:object_r:lib_t,s0)
+/opt/google/chrome-beta/libudev\.so\.0		gen_context(system_u:object_r:lib_t,s0)
+/opt/google/chrome-unstable/libudev\.so\.0	gen_context(system_u:object_r:lib_t,s0)
+
 /opt/openoffice4/program/.+\.so(\.[^/]*)*	--	gen_context(system_u:object_r:lib_t,s0)
 
 /opt/(.*/)?/RealPlayer/.+\.so(\.[^/]*)* --	gen_context(system_u:object_r:textrel_shlib_t,s0)

--- a/policy/modules/system/logging.fc
+++ b/policy/modules/system/logging.fc
@@ -89,7 +89,6 @@ ifdef(`distro_redhat',`
 
 /var/spool/audit(/.*)?		gen_context(system_u:object_r:audit_spool_t,mls_systemhigh)
 /var/spool/bacula/log(/.*)? 	gen_context(system_u:object_r:var_log_t,s0)
-/var/spool/postfix/pid	-d	gen_context(system_u:object_r:var_run_t,s0)
 /var/spool/plymouth/boot\.log	gen_context(system_u:object_r:var_log_t,mls_systemhigh)
 /var/spool/rsyslog(/.*)? 	gen_context(system_u:object_r:var_log_t,s0)
 

--- a/policy/modules/system/miscfiles.fc
+++ b/policy/modules/system/miscfiles.fc
@@ -47,8 +47,6 @@ ifdef(`distro_redhat',`
 
 /usr/local/share/fonts(/.*)?	gen_context(system_u:object_r:fonts_t,s0)
 
-/usr/share/docbook2X/xslt/man(/.*)?	gen_context(system_u:object_r:usr_t,s0)
-
 /usr/share/fonts(/.*)?		gen_context(system_u:object_r:fonts_t,s0)
 /usr/share/ghostscript/fonts(/.*)? gen_context(system_u:object_r:fonts_t,s0)
 /usr/share/texmf[^/]*/fonts(/.*)? gen_context(system_u:object_r:fonts_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -524,7 +524,7 @@ interface(`systemd_manage_passwd_runtime_symlinks',`
 
 ########################################
 ## <summary>
-##      manage systemd unit dirs and the files in them
+##      manage systemd unit dirs and the files in them  (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##      <summary>
@@ -533,13 +533,8 @@ interface(`systemd_manage_passwd_runtime_symlinks',`
 ## </param>
 #
 interface(`systemd_manage_all_units',`
-	gen_require(`
-		attribute systemdunit;
-	')
-
-	manage_dirs_pattern($1, systemdunit, systemdunit)
-	manage_files_pattern($1, systemdunit, systemdunit)
-	manage_lnk_files_pattern($1, systemdunit, systemdunit)
+	refpolicywarn(`$0() has been deprecated, use init_manage_all_unit_files() instead.')
+	init_manage_all_unit_files($1)
 ')
 
 ########################################

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -2,6 +2,22 @@
 
 ########################################
 ## <summary>
+##	Unconfined stub interface.  No access allowed.
+## </summary>
+## <param name="domain" unused="true">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_stub',`
+	gen_require(`
+		type unconfined_t;
+	')
+')
+
+########################################
+## <summary>
 ##	Make the specified domain unconfined.
 ## </summary>
 ## <param name="domain">
@@ -12,12 +28,13 @@
 #
 interface(`unconfined_domain_noaudit',`
 	gen_require(`
-		type unconfined_t;
 		class dbus all_dbus_perms;
 		class nscd all_nscd_perms;
 		class passwd all_passwd_perms;
 		class service all_service_perms;
 	')
+
+	unconfined_stub($1)
 
 	# Use most Linux capabilities
 	allow $1 self:{ capability cap_userns } { chown dac_override dac_read_search fowner fsetid kill setgid setuid setpcap linux_immutable net_bind_service net_broadcast net_admin net_raw ipc_lock ipc_owner sys_rawio sys_chroot sys_ptrace sys_pacct sys_admin sys_boot sys_nice sys_resource sys_time sys_tty_config mknod lease audit_write audit_control setfcap };


### PR DESCRIPTION
* samba: fix wrong interface context smbd_runtime_t
* chromium: drop dead conditional block
* example: use module name matching file name
* consolesetup: drop unused requires
* unconfined: clarify unconfined_t stub usage in unconfined_domain_noaudit()
* portage: drop bizarre conditional TODO blocks
* init/systemd: move systemd_manage_all_units to init_manage_all_units
* tpm2: small fixes
* xserver: declare all callers of template xserver_common_x_domain_template as template
* files/logging: move var_run_t filecontext to defining module
* files/miscfiles: move usr_t filecontext to defining module
* chromium/libraries: move lib_t filecontext to defining module
