### PR TITLE
application: applications can be executed from ssh without pty

### DIFF
--- a/policy/modules/system/application.te
+++ b/policy/modules/system/application.te
@@ -13,6 +13,10 @@ optional_policy(`
 optional_policy(`
 	ssh_sigchld(application_domain_type)
 	ssh_rw_stream_sockets(application_domain_type)
+
+	ifndef(`distro_redhat', `
+		ssh_rw_pipes(application_domain_type)
+	')
 ')
 
 optional_policy(`


### PR DESCRIPTION
For example ansible uses `ssh localhost sudo id` to become root.
This doesn't appear to be necessary in redhat due to https://src.fedoraproject.org/rpms/openssh/blob/master/f/openssh-6.6p1-privsep-selinux.patch

Signed-off-by: bauen1 <j2468h@gmail.com>