### PR TITLE
apache: use correct content types in apache_manage_all_user_content()

### DIFF
--- a/policy/modules/services/apache.if
+++ b/policy/modules/services/apache.if
@@ -1202,13 +1202,13 @@ interface(`apache_search_sys_scripts',`
 #
 interface(`apache_manage_all_user_content',`
 	gen_require(`
-		type httpd_user_content_t, httpd_user_content_rw_t, httpd_user_content_ra_t;
+		type httpd_user_content_t, httpd_user_rw_content_t, httpd_user_ra_content_t;
 		type httpd_user_htaccess_t, httpd_user_script_exec_t;
 	')
 
-	manage_dirs_pattern($1, { httpd_user_content_t httpd_user_content_rw_t httpd_user_content_ra_t httpd_user_script_exec_t }, { httpd_user_content_t httpd_user_content_rw_t httpd_user_content_ra_t httpd_user_script_exec_t })
-	manage_files_pattern($1, { httpd_user_content_t httpd_user_content_rw_t httpd_user_content_ra_t httpd_user_script_exec_t httpd_user_htaccess_t }, { httpd_user_content_t httpd_user_content_rw_t httpd_user_content_ra_t httpd_user_script_exec_t httpd_user_htaccess_t })
-	manage_lnk_files_pattern($1, { httpd_user_content_t httpd_user_content_rw_t httpd_user_content_ra_t httpd_user_script_exec_t }, { httpd_user_content_t httpd_user_content_rw_t httpd_user_content_ra_t httpd_user_script_exec_t })
+	manage_dirs_pattern($1, { httpd_user_content_t httpd_user_rw_content_t httpd_user_ra_content_t httpd_user_script_exec_t }, { httpd_user_content_t httpd_user_rw_content_t httpd_user_ra_content_t httpd_user_script_exec_t })
+	manage_files_pattern($1, { httpd_user_content_t httpd_user_rw_content_t httpd_user_ra_content_t httpd_user_script_exec_t httpd_user_htaccess_t }, { httpd_user_content_t httpd_user_rw_content_t httpd_user_ra_content_t httpd_user_script_exec_t httpd_user_htaccess_t })
+	manage_lnk_files_pattern($1, { httpd_user_content_t httpd_user_rw_content_t httpd_user_ra_content_t httpd_user_script_exec_t }, { httpd_user_content_t httpd_user_rw_content_t httpd_user_ra_content_t httpd_user_script_exec_t })
 ')
 
 ########################################


### PR DESCRIPTION
The content types are named httpd_user_rw_content_t and
httpd_user_ra_content_t not httpd_user_content_rw_t and
httpd_user_content_ra_t in apache_content_template()

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>