### PR TITLE
can_exec(): move from misc_macros to misc_patterns

### DIFF
--- a/policy/support/misc_macros.spt
+++ b/policy/support/misc_macros.spt
@@ -64,12 +64,6 @@ define(`gen_context',`$1`'ifdef(`enable_mls',`:$2')`'ifdef(`enable_mcs',`:s0`'if
 
 ########################################
 #
-# can_exec(domain,executable)
-#
-define(`can_exec',`allow $1 $2:file { mmap_exec_file_perms ioctl lock execute_no_trans };')
-
-########################################
-#
 # gen_bool(name,default_value)
 #
 define(`gen_bool',`

--- a/policy/support/misc_patterns.spt
+++ b/policy/support/misc_patterns.spt
@@ -111,3 +111,12 @@ define(`admin_process_pattern',`
 
 	allow $1 $2:process { ptrace signal_perms };
 ')
+
+#
+# File execution pattern
+#
+# Parameters:
+# 1. source domain
+# 2. executable file type
+#
+define(`can_exec',`allow $1 $2:file { mmap_exec_file_perms ioctl lock execute_no_trans };')


### PR DESCRIPTION
The file misc_macros.spt is due heavy usage of the m4 language
hard to parse for third party tools.
Move the macro can_exec() to misc_patterns.spt, which contains
only interface like define blocks.