### PR TITLE
Confined debian fixes

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -79,10 +79,8 @@ mls_trusted_object(initctl_t)
 
 type initrc_t, init_script_domain_type, init_run_all_scripts_domain;
 type initrc_exec_t, init_script_file_type;
-domain_type(initrc_t)
-domain_entry_file(initrc_t, initrc_exec_t)
+init_domain(initrc_t, initrc_exec_t)
 init_named_socket_activation(initrc_t, init_runtime_t)
-role system_r types initrc_t;
 # should be part of the true block
 # of the below init_upstart tunable
 # but this has a typeattribute in it

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -433,6 +433,7 @@ ifdef(`init_systemd',`
 	logging_send_audit_msgs(init_t)
 	logging_relabelto_devlog_sock_files(init_t)
 	logging_relabel_generic_log_dirs(init_t)
+	logging_audit_socket_activation(init_t)
 
 	# lvm2-activation-generator checks file labels
 	seutil_read_file_contexts(init_t)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -80,6 +80,15 @@ mls_trusted_object(initctl_t)
 type initrc_t, init_script_domain_type, init_run_all_scripts_domain;
 type initrc_exec_t, init_script_file_type;
 init_domain(initrc_t, initrc_exec_t)
+
+ifdef(`enable_mcs', `
+	init_ranged_daemon_domain(initrc_t, initrc_exec_t, s0)
+')
+
+ifdef(`enable_mls', `
+	init_ranged_daemon_domain(initrc_t, initrc_exec_t, s0 - mls_systemhigh)
+')
+
 init_named_socket_activation(initrc_t, init_runtime_t)
 # should be part of the true block
 # of the below init_upstart tunable
@@ -206,9 +215,6 @@ selinux_get_fs_mount(init_t)
 selinux_set_all_booleans(init_t)
 
 term_use_all_terms(init_t)
-
-# Run init scripts.
-init_domtrans_script(init_t)
 
 libs_rw_ld_so_cache(init_t)
 

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -60,6 +60,7 @@ role system_r types init_t;
 #
 type init_runtime_t alias init_var_run_t;
 files_pid_file(init_runtime_t)
+init_mountpoint(init_runtime_t)
 
 #
 # init_var_lib_t is the type for /var/lib/systemd.

--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -486,6 +486,25 @@ interface(`logging_setattr_syslogd_tmp_files',`
 
 ########################################
 ## <summary>
+##  Allow the domain to create the audit socket
+##  for syslogd.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`logging_audit_socket_activation', `
+	gen_require(`
+		type syslogd_t;
+	')
+
+	allow $1 syslogd_t:netlink_audit_socket create_socket_perms;
+')
+
+########################################
+## <summary>
 ##	Relabel to and from syslog temporary file type.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
A number of changes necessary to allow debian (and probably other systemd based installations) to boot without the unconfined module.