### PR TITLE
Makefile: remove obsolete .SUFFIXES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -658,5 +658,3 @@ endif
 endif
 
 .PHONY: install-src install-appconfig install-headers generate xml conf html bare tags
-.SUFFIXES:
-.SUFFIXES: .c


### PR DESCRIPTION
With the removal of fc_sort there are no more .c files in the repository.

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>