### PR TITLE
setrans: allow label translation for all domains.

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -137,6 +137,10 @@ optional_policy(`
 	libs_use_shared_libs(domain)
 ')
 
+optional_policy(`
+	setrans_translate_context(domain)
+')
+
 # xdm passes an open file descriptor to xsession-errors.log which is then audited by all confined domains.
 optional_policy(`
 	xserver_dontaudit_use_xdm_fds(domain)

--- a/policy/modules/system/setrans.if
+++ b/policy/modules/system/setrans.if
@@ -21,7 +21,7 @@ interface(`setrans_initrc_domtrans',`
 
 #######################################
 ## <summary>
-##	Allow a domain to translate contexts.  (Deprecated)
+##	Allow a domain to translate contexts.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -30,7 +30,13 @@ interface(`setrans_initrc_domtrans',`
 ## </param>
 #
 interface(`setrans_translate_context',`
-	refpolicywarn(`$0($*) has been deprecated')
+	gen_require(`
+		type setrans_t, setrans_var_run_t;
+	')
+
+	allow $1 self:unix_stream_socket create_stream_socket_perms;
+	stream_connect_pattern($1, setrans_var_run_t, setrans_var_run_t, setrans_t)
+	files_list_pids($1)
 ')
 
 ######################################


### PR DESCRIPTION
This partially reverts commit 65da822c1b5c70bd1ff7eca645f5f9fd74fa949e
Connecting to setransd is still very much necessary for any domain that
uses SELinux labels in any way.

Signed-off-by: bauen1 <j2468h@gmail.com>