### PR TITLE
Fix autorelabel

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -8,10 +8,10 @@
 /afs			-d	gen_context(system_u:object_r:mnt_t,s0)
 /initrd\.img.*		-l	gen_context(system_u:object_r:boot_t,s0)
 /vmlinuz.*		-l	gen_context(system_u:object_r:boot_t,s0)
+/\.autorelabel		--	gen_context(system_u:object_r:etc_runtime_t,s0)
 
 ifdef(`distro_redhat',`
 /\.autofsck		--	gen_context(system_u:object_r:etc_runtime_t,s0)
-/\.autorelabel		--	gen_context(system_u:object_r:etc_runtime_t,s0)
 /\.suspended		--	gen_context(system_u:object_r:etc_runtime_t,s0)
 /fastboot 		--	gen_context(system_u:object_r:etc_runtime_t,s0)
 /forcefsck 		--	gen_context(system_u:object_r:etc_runtime_t,s0)

--- a/policy/modules/kernel/terminal.if
+++ b/policy/modules/kernel/terminal.if
@@ -401,6 +401,24 @@ interface(`term_create_console_dev',`
 
 ########################################
 ## <summary>
+##  Watch reads on the console character device.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`term_watch_reads_console_dev', `
+	gen_require(`
+		type console_device_t;
+	')
+
+	allow $1 console_device_t:chr_file { watch watch_reads };
+')
+
+########################################
+## <summary>
 ##	Get the attributes of a pty filesystem
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -431,6 +431,9 @@ ifdef(`init_systemd',`
 	storage_getattr_removable_dev(init_t)
 
 	term_relabel_pty_dirs(init_t)
+	# for autorelabel
+	term_setattr_console(init_t)
+	term_watch_reads_console_dev(init_t)
 
 	auth_manage_var_auth(init_t)
 	auth_relabel_login_records(init_t)

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -520,6 +520,8 @@ term_use_all_terms(semanage_t)
 # Running genhomedircon requires this for finding all users
 auth_use_nsswitch(semanage_t)
 
+init_use_fds(semanage_t)
+
 logging_send_syslog_msg(semanage_t)
 
 miscfiles_read_localization(semanage_t)
@@ -633,6 +635,7 @@ selinux_compute_user_contexts(setfiles_t)
 term_use_all_ttys(setfiles_t)
 term_use_all_ptys(setfiles_t)
 term_use_unallocated_ttys(setfiles_t)
+term_use_console(setfiles_t)
 
 # this is to satisfy the assertion:
 auth_relabelto_shadow(setfiles_t)

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -26,6 +26,7 @@
 /usr/lib/systemd/system-generators/systemd-efi-boot-generator	--	gen_context(system_u:object_r:systemd_efi_generator_exec_t,s0)
 /usr/lib/systemd/system-generators/systemd-fstab-generator		--	gen_context(system_u:object_r:systemd_fstab_generator_exec_t,s0)
 /usr/lib/systemd/system-generators/systemd-gpt-auto-generator	--	gen_context(system_u:object_r:systemd_gpt_generator_exec_t,s0)
+/usr/lib/systemd/system-generators/selinux-autorelabel-generator\.sh		--	gen_context(system_u:object_r:systemd_selinux_autorelabel_generator_exec_t,s0)
 /usr/lib/systemd/system-generators/systemd-sysv-generator		--	gen_context(system_u:object_r:systemd_sysv_generator_exec_t,s0)
 
 /usr/lib/systemd/systemd-activate	--	gen_context(system_u:object_r:systemd_activate_exec_t,s0)

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -29,6 +29,7 @@
 /usr/lib/systemd/system-generators/selinux-autorelabel-generator\.sh		--	gen_context(system_u:object_r:systemd_selinux_autorelabel_generator_exec_t,s0)
 /usr/lib/systemd/system-generators/systemd-sysv-generator		--	gen_context(system_u:object_r:systemd_sysv_generator_exec_t,s0)
 
+/usr/lib/systemd/selinux-autorelabel	--	gen_context(system_u:object_r:systemd_selinux_autorelabel_exec_t,s0)
 /usr/lib/systemd/systemd-activate	--	gen_context(system_u:object_r:systemd_activate_exec_t,s0)
 /usr/lib/systemd/systemd-backlight	--	gen_context(system_u:object_r:systemd_backlight_exec_t,s0)
 /usr/lib/systemd/systemd-binfmt		--	gen_context(system_u:object_r:systemd_binfmt_exec_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -300,6 +300,8 @@ fs_register_binary_executable_type(systemd_binfmt_t)
 # generic generator local policy
 #
 
+allow systemd_generator_type self:process setfscreate;
+
 corecmd_search_bin(systemd_generator_type)
 
 dev_read_sysfs(systemd_generator_type)
@@ -321,6 +323,8 @@ init_write_pid_files(systemd_generator_type)
 kernel_use_fds(systemd_generator_type)
 kernel_read_system_state(systemd_generator_type)
 kernel_read_kernel_sysctls(systemd_generator_type)
+
+seutil_libselinux_linked(systemd_generator_type)
 
 #######################################
 #

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -388,6 +388,9 @@ optional_policy(`
 corecmd_exec_bin(systemd_selinux_autorelabel_generator_t)
 corecmd_exec_shell(systemd_selinux_autorelabel_generator_t)
 
+# for /.autorelabel
+files_read_etc_runtime_files(systemd_selinux_autorelabel_generator_t)
+
 #######################################
 #
 # sysv generator local policy

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -219,6 +219,18 @@ init_unit_file(systemd_rfkill_unit_t)
 type systemd_rfkill_var_lib_t;
 files_type(systemd_rfkill_var_lib_t)
 
+type systemd_selinux_autorelabel_t;
+type systemd_selinux_autorelabel_exec_t;
+init_system_domain(systemd_selinux_autorelabel_t, systemd_selinux_autorelabel_exec_t)
+
+ifdef(`enable_mcs', `
+	init_ranged_system_domain(systemd_selinux_autorelabel_t, systemd_selinux_autorelabel_exec_t, mcs_systemhigh)
+')
+
+ifdef(`enable_mls', `
+	init_ranged_system_domain(systemd_selinux_autorelabel_t, systemd_selinux_autorelabel_exec_t, mls_systemhigh)
+')
+
 type systemd_sessions_t;
 type systemd_sessions_exec_t;
 init_system_domain(systemd_sessions_t, systemd_sessions_exec_t)
@@ -1156,6 +1168,44 @@ optional_policy(`
 	dbus_system_bus_client(systemd_resolved_t)
 	dbus_watch_system_bus_runtime_dirs(systemd_resolved_t)
 	dbus_watch_system_bus_runtime_named_sockets(systemd_resolved_t)
+')
+
+#########################################
+#
+# systemd selinux-autorelabel local policy
+#
+
+allow systemd_selinux_autorelabel_t self:fifo_file rw_fifo_file_perms;
+allow systemd_selinux_autorelabel_t self:process getsched;
+
+corecmd_exec_bin(systemd_selinux_autorelabel_t)
+corecmd_exec_shell(systemd_selinux_autorelabel_t)
+
+files_read_etc_files(systemd_selinux_autorelabel_t)
+files_purge_tmp(systemd_selinux_autorelabel_t)
+# for /.autorelabel
+files_read_etc_runtime_files(systemd_selinux_autorelabel_t)
+files_delete_boot_flag(systemd_selinux_autorelabel_t)
+
+kernel_read_system_state(systemd_selinux_autorelabel_t)
+
+term_use_console(systemd_selinux_autorelabel_t)
+
+init_use_fds(systemd_selinux_autorelabel_t)
+# for triggering reboot
+init_stream_connect(systemd_selinux_autorelabel_t)
+init_reboot_system(systemd_selinux_autorelabel_t)
+init_read_state(systemd_selinux_autorelabel_t)
+
+miscfiles_read_localization(systemd_selinux_autorelabel_t)
+
+seutil_read_config(systemd_selinux_autorelabel_t)
+seutil_domtrans_setfiles(systemd_selinux_autorelabel_t)
+# for genhomedircon
+seutil_domtrans_semanage(systemd_selinux_autorelabel_t)
+
+optional_policy(`
+	quota_domtrans(systemd_selinux_autorelabel_t)
 ')
 
 #########################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -82,6 +82,10 @@ type systemd_lvm2_generator_t;
 type systemd_lvm2_generator_exec_t;
 systemd_unit_generator(systemd_lvm2_generator_t, systemd_lvm2_generator_exec_t)
 
+type systemd_selinux_autorelabel_generator_t;
+type systemd_selinux_autorelabel_generator_exec_t;
+systemd_unit_generator(systemd_selinux_autorelabel_generator_t, systemd_selinux_autorelabel_generator_exec_t)
+
 type systemd_sysv_generator_t;
 type systemd_sysv_generator_exec_t;
 systemd_unit_generator(systemd_sysv_generator_t, systemd_sysv_generator_exec_t)
@@ -324,6 +328,8 @@ kernel_use_fds(systemd_generator_type)
 kernel_read_system_state(systemd_generator_type)
 kernel_read_kernel_sysctls(systemd_generator_type)
 
+miscfiles_read_localization(systemd_generator_type)
+
 seutil_libselinux_linked(systemd_generator_type)
 
 #######################################
@@ -373,6 +379,14 @@ optional_policy(`
 	lvm_read_config(systemd_lvm2_generator_t)
 	miscfiles_read_localization(systemd_lvm2_generator_t)
 ')
+
+#######################################
+#
+# selinux-autorelabel-generator.sh local policy
+#
+
+corecmd_exec_bin(systemd_selinux_autorelabel_generator_t)
+corecmd_exec_shell(systemd_selinux_autorelabel_generator_t)
 
 #######################################
 #


### PR DESCRIPTION
The systemd autolabel generator was broken (likely by #197). This adds the required access to allow it to function correctly.
Alternativeley the generator could be targeted seperately.

This PR also adds a policy for the autorelabel service.
Since it runs `genhomedircon` it needs to transition to `semanage_t` however this access probably shouldn't be given to `initrc_t`.
It also ensures that `restorecon` is run with `SystemHigh` so even if selinux is in enforcing mode with MCS or MLS enabled everything will be relabeled properly.