### PR TITLE
systemd-sysusers: add policy

### DIFF
--- a/policy/modules/admin/dpkg.te
+++ b/policy/modules/admin/dpkg.te
@@ -334,6 +334,7 @@ optional_policy(`
 optional_policy(`
 	systemd_read_logind_state(dpkg_script_t)
 	systemd_dbus_chat_logind(dpkg_script_t)
+	systemd_run_sysusers(dpkg_script_t, dpkg_roles)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -13,6 +13,7 @@
 /usr/bin/systemd-nspawn			--	gen_context(system_u:object_r:systemd_nspawn_exec_t,s0)
 /usr/bin/systemd-run			--	gen_context(system_u:object_r:systemd_run_exec_t,s0)
 /usr/bin/systemd-stdio-bridge		--	gen_context(system_u:object_r:systemd_stdio_bridge_exec_t,s0)
+/usr/bin/systemd-sysusers		--	gen_context(system_u:object_r:systemd_sysusers_exec_t,s0)
 /usr/bin/systemd-tmpfiles		--	gen_context(system_u:object_r:systemd_tmpfiles_exec_t,s0)
 /usr/bin/systemd-tty-ask-password-agent	--	gen_context(system_u:object_r:systemd_passwd_agent_exec_t,s0)
 /usr/bin/systemd-notify			--	gen_context(system_u:object_r:systemd_notify_exec_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1126,3 +1126,48 @@ interface(`systemd_write_all_user_keys',`
 
 	allow $1 systemd_user_session_type:key write;
 ')
+
+########################################
+## <summary>
+##  Execute systemd-sysusers in the
+##  systemd sysusers domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_domtrans_sysusers', `
+	gen_require(`
+		type systemd_sysusers_t, systemd_sysusers_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, systemd_sysusers_exec_t, systemd_sysusers_t)
+')
+
+########################################
+## <summary>
+##  Run systemd-sysusers with a domain transition.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##  <summary>
+##  Role allowed access.
+##  </summary>
+## </param>
+## <rolecap/>
+#
+interface(`systemd_run_sysusers', `
+	gen_require(`
+		attribute_role systemd_sysusers_roles;
+	')
+
+	systemd_domtrans_sysusers($1)
+	roleattribute $2 systemd_sysusers_roles;
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -223,6 +223,10 @@ type systemd_sessions_runtime_t alias systemd_sessions_var_run_t;
 files_pid_file(systemd_sessions_runtime_t)
 init_daemon_pid_file(systemd_sessions_runtime_t, dir, "systemd_sessions")
 
+type systemd_sysusers_t;
+type systemd_sysusers_exec_t;
+init_system_domain(systemd_sysusers_t, systemd_sysusers_exec_t)
+
 type systemd_tmpfiles_t;
 type systemd_tmpfiles_exec_t;
 init_daemon_domain(systemd_tmpfiles_t, systemd_tmpfiles_exec_t)
@@ -1157,6 +1161,29 @@ seutil_read_default_contexts(systemd_sessions_t)
 seutil_read_file_contexts(systemd_sessions_t)
 
 systemd_log_parse_environment(systemd_sessions_t)
+
+
+#########################################
+#
+# Sysusers local policy
+#
+
+allow systemd_sysusers_t self:capability { chown fsetid };
+allow systemd_sysusers_t self:process setfscreate;
+allow systemd_sysusers_t self:unix_dgram_socket sendto;
+
+files_manage_etc_files(systemd_sysusers_t)
+
+kernel_read_kernel_sysctls(systemd_sysusers_t)
+
+auth_manage_shadow(systemd_sysusers_t)
+auth_etc_filetrans_shadow(systemd_sysusers_t)
+auth_use_nsswitch(systemd_sysusers_t)
+
+seutil_libselinux_linked(systemd_sysusers_t)
+seutil_read_file_contexts(systemd_sysusers_t)
+
+systemd_log_parse_environment(systemd_sysusers_t)
 
 #########################################
 #

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -34,6 +34,8 @@ attribute systemd_log_parse_env_type;
 attribute systemd_tmpfiles_conf_type;
 attribute systemd_user_session_type;
 
+attribute_role systemd_sysusers_roles;
+
 type systemd_activate_t;
 type systemd_activate_exec_t;
 init_system_domain(systemd_activate_t, systemd_activate_exec_t)
@@ -226,6 +228,7 @@ init_daemon_pid_file(systemd_sessions_runtime_t, dir, "systemd_sessions")
 type systemd_sysusers_t;
 type systemd_sysusers_exec_t;
 init_system_domain(systemd_sysusers_t, systemd_sysusers_exec_t)
+role systemd_sysusers_roles types systemd_sysusers_t;
 
 type systemd_tmpfiles_t;
 type systemd_tmpfiles_exec_t;


### PR DESCRIPTION
Running a system without the unconfined module, this is another service that needs additional privileges (modifying /etc/shadow and friends).
This is blocked by #246 but open for comments.