### PR TITLE
Systemd userdb

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -426,6 +426,10 @@ files_read_etc_files(nsswitch_domain)
 
 sysnet_dns_name_resolve(nsswitch_domain)
 
+ifdef(`init_systemd', `
+	systemd_stream_connect_userdb(nsswitch_domain)
+')
+
 tunable_policy(`authlogin_nsswitch_use_ldap',`
 	miscfiles_read_generic_certs(nsswitch_domain)
 	sysnet_use_ldap(nsswitch_domain)

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -925,6 +925,25 @@ interface(`init_stream_connect',`
 
 ########################################
 ## <summary>
+##	Connect to init with a unix socket.
+##  Without any additional permissions.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_unix_stream_socket_connectto',`
+	gen_require(`
+		type init_t;
+	')
+
+	allow $1 init_t:unix_stream_socket connectto;
+')
+
+########################################
+## <summary>
 ##	Inherit and use file descriptors from init.
 ## </summary>
 ## <desc>

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -469,6 +469,9 @@ ifdef(`init_systemd',`
 	systemd_relabelto_journal_dirs(init_t)
 	systemd_relabelto_journal_files(init_t)
 	systemd_rw_networkd_netlink_route_sockets(init_t)
+	systemd_manage_userdb_runtime_sock_files(init_t)
+	systemd_manage_userdb_runtime_dirs(init_t)
+	systemd_filetrans_userdb_runtime_dirs(init_t)
 
 	term_create_devpts_dirs(init_t)
 	term_create_ptmx(init_t)

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -70,6 +70,7 @@
 /run/systemd/seats(/.*)?	gen_context(system_u:object_r:systemd_sessions_runtime_t,s0)
 /run/systemd/sessions(/.*)?	gen_context(system_u:object_r:systemd_sessions_runtime_t,s0)
 /run/systemd/users(/.*)?	gen_context(system_u:object_r:systemd_logind_runtime_t,s0)
+/run/systemd/userdb(/.*)?	gen_context(system_u:object_r:systemd_userdb_runtime_t,s0)
 /run/systemd/inhibit(/.*)?	gen_context(system_u:object_r:systemd_logind_inhibit_runtime_t,s0)
 /run/systemd/nspawn(/.*)?	gen_context(system_u:object_r:systemd_nspawn_runtime_t,s0)
 /run/systemd/machines(/.*)?	gen_context(system_u:object_r:systemd_machined_runtime_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -428,6 +428,42 @@ interface(`systemd_signull_logind',`
 
 ########################################
 ## <summary>
+##  Manage systemd userdb runtime directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_manage_userdb_runtime_dirs', `
+	gen_require(`
+		type systemd_userdb_runtime_t;
+	')
+
+	manage_dirs_pattern($1, systemd_userdb_runtime_t, systemd_userdb_runtime_t)
+')
+
+########################################
+## <summary>
+##  Manage socket files under /run/systemd/userdb .
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_manage_userdb_runtime_sock_files', `
+	gen_require(`
+		type systemd_userdb_runtime_t;
+	')
+
+	manage_sock_files_pattern($1, systemd_userdb_runtime_t, systemd_userdb_runtime_t)
+')
+
+########################################
+## <summary>
 ##	Allow reading /run/systemd/machines
 ## </summary>
 ## <param name="domain">
@@ -526,6 +562,26 @@ interface(`systemd_filetrans_passwd_runtime_dirs',`
 
 	init_runtime_filetrans($1, systemd_passwd_runtime_t, dir, "ask-password-block")
 	init_runtime_filetrans($1, systemd_passwd_runtime_t, dir, "ask-password")
+')
+
+########################################
+## <summary>
+##  Transition to systemd_userdb_runtime_t when
+##  creating the userdb directory inside an init runtime
+##  directory.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`systemd_filetrans_userdb_runtime_dirs', `
+	gen_require(`
+		type systemd_userdb_runtime_t;
+	')
+
+	init_runtime_filetrans($1, systemd_userdb_runtime_t, dir, "userdb")
 ')
 
 ######################################

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -464,6 +464,27 @@ interface(`systemd_manage_userdb_runtime_sock_files', `
 
 ########################################
 ## <summary>
+##  Connect to /run/systemd/userdb/io.systemd.DynamicUser .
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_stream_connect_userdb', `
+	gen_require(`
+		type systemd_userdb_runtime_t;
+	')
+
+	init_search_runtime($1)
+	allow $1 systemd_userdb_runtime_t:dir list_dir_perms;
+	allow $1 systemd_userdb_runtime_t:sock_file write_sock_file_perms;
+	init_unix_stream_socket_connectto($1)
+')
+
+########################################
+## <summary>
 ##	Allow reading /run/systemd/machines
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -550,7 +550,6 @@ dev_setattr_video_dev(systemd_logind_t)
 
 domain_obj_id_change_exemption(systemd_logind_t)
 
-files_read_etc_files(systemd_logind_t)
 files_search_runtime(systemd_logind_t)
 
 fs_getattr_cgroup(systemd_logind_t)
@@ -574,6 +573,7 @@ term_setattr_unallocated_ttys(systemd_logind_t)
 term_use_unallocated_ttys(systemd_logind_t)
 
 auth_manage_faillog(systemd_logind_t)
+auth_use_nsswitch(systemd_logind_t)
 
 init_dbus_send_script(systemd_logind_t)
 init_get_all_units_status(systemd_logind_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -242,6 +242,9 @@ init_system_domain(systemd_user_runtime_dir_t, systemd_user_runtime_dir_exec_t)
 type systemd_user_tmpfs_t;
 userdom_user_tmpfs_file(systemd_user_tmpfs_t)
 
+type systemd_userdb_runtime_t;
+files_runtime_file(systemd_userdb_runtime_t)
+
 #
 # Unit file types
 #


### PR DESCRIPTION
This only addresses the scenario where `userdb` is disabeled, e.g. debian.
Partially Fixes #246 

`init_unix_stream_socket_connectto` is used because `init_stream_connect` was already taken and grants additional (unwanted) access that is not necessary.