### PR TITLE
Confined debian fixes2

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -3793,6 +3793,24 @@ interface(`dev_write_rand',`
 
 ########################################
 ## <summary>
+##  Create the random device (/dev/random).
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`dev_create_rand_dev',`
+	gen_require(`
+		type device_t, random_device_t;
+	')
+
+	create_chr_files_pattern($1, device_t, random_device_t)
+')
+
+########################################
+## <summary>
 ##	Read the realtime clock (/dev/rtc).
 ## </summary>
 ## <param name="domain">
@@ -4673,6 +4691,24 @@ interface(`dev_write_urand',`
 	')
 
 	write_chr_files_pattern($1, device_t, urandom_device_t)
+')
+
+########################################
+## <summary>
+##  Create the urandom device (/dev/urandom).
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`dev_create_urand_dev',`
+	gen_require(`
+		type device_t, urandom_device_t;
+	')
+
+	create_chr_files_pattern($1, device_t, urandom_device_t)
 ')
 
 ########################################

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -197,6 +197,10 @@ type mtrr_device_t;
 dev_node(mtrr_device_t)
 genfscon proc /mtrr gen_context(system_u:object_r:mtrr_device_t,s0)
 
+optional_policy(`
+	init_mountpoint(mtrr_device_t)
+')
+
 #
 # null_device_t is the type of /dev/null.
 #
@@ -285,7 +289,7 @@ type tpm_device_t;
 dev_node(tpm_device_t)
 
 #
-# uhid_device_t is the thpe of /dev/uhid - 
+# uhid_device_t is the type of /dev/uhid -
 # User-space I/O driver support for HID subsystem
 #
 type uhid_device_t;

--- a/policy/modules/kernel/files.te
+++ b/policy/modules/kernel/files.te
@@ -101,6 +101,10 @@ files_mountpoint(mnt_t)
 type modules_object_t;
 files_type(modules_object_t)
 
+optional_policy(`
+	init_mountpoint(modules_object_t)
+')
+
 type no_access_t;
 files_type(no_access_t)
 

--- a/policy/modules/kernel/files.te
+++ b/policy/modules/kernel/files.te
@@ -136,6 +136,10 @@ type system_map_t;
 files_type(system_map_t)
 genfscon proc /kallsyms gen_context(system_u:object_r:system_map_t,s0)
 
+optional_policy(`
+	init_mountpoint(system_map_t)
+')
+
 #
 # tmp_t is the type of the temporary directories
 #

--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -181,6 +181,10 @@ type tracefs_t;
 fs_type(tracefs_t)
 genfscon tracefs / gen_context(system_u:object_r:tracefs_t,s0)
 
+optional_policy(`
+	init_mountpoint(tracefs_t)
+')
+
 type vmblock_t;
 fs_noxattr_type(vmblock_t)
 files_mountpoint(vmblock_t)

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -95,6 +95,10 @@ type proc_kcore_t, proc_type;
 neverallow ~{ can_dump_kernel kern_unconfined } proc_kcore_t:file ~getattr;
 genfscon proc /kcore gen_context(system_u:object_r:proc_kcore_t,mls_systemhigh)
 
+optional_policy(`
+	init_mountpoint(proc_kcore_t)
+')
+
 type proc_mdstat_t, proc_type;
 genfscon proc /mdstat gen_context(system_u:object_r:proc_mdstat_t,s0)
 
@@ -118,6 +122,10 @@ genfscon proc /sys gen_context(system_u:object_r:sysctl_t,s0)
 # /proc/irq directory and files
 type sysctl_irq_t, sysctl_type;
 genfscon proc /irq gen_context(system_u:object_r:sysctl_irq_t,s0)
+
+optional_policy(`
+	init_mountpoint(sysctl_irq_t)
+')
 
 # /proc/net/rpc directory and files
 type sysctl_rpc_t, sysctl_type;

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -136,6 +136,10 @@ genfscon proc /sys/fs gen_context(system_u:object_r:sysctl_fs_t,s0)
 type sysctl_kernel_t, sysctl_type;
 genfscon proc /sys/kernel gen_context(system_u:object_r:sysctl_kernel_t,s0)
 
+optional_policy(`
+	init_mountpoint(sysctl_kernel_t)
+')
+
 # /sys/kernel/ns_last_pid file
 type sysctl_kernel_ns_last_pid_t, sysctl_type;
 genfscon proc /sys/kernel/ns_last_pid gen_context(system_u:object_r:sysctl_kernel_ns_last_pid_t,s0)

--- a/policy/modules/kernel/terminal.if
+++ b/policy/modules/kernel/terminal.if
@@ -163,6 +163,7 @@ interface(`term_create_devpts_dirs',`
 		type devpts_t;
 	')
 
+	dev_add_entry_generic_dirs($1)
 	allow $1 devpts_t:dir create_dir_perms;
 ')
 
@@ -395,7 +396,7 @@ interface(`term_create_console_dev',`
 	')
 
 	dev_add_entry_generic_dirs($1)
-	allow $1 console_device_t:chr_file create;
+	allow $1 console_device_t:chr_file create_chr_file_perms;
 	allow $1 self:capability mknod;
 ')
 

--- a/policy/modules/kernel/terminal.if
+++ b/policy/modules/kernel/terminal.if
@@ -731,6 +731,27 @@ interface(`term_dontaudit_use_generic_ptys',`
 
 #######################################
 ## <summary>
+##  Create the tty device.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`term_create_controlling_term',`
+	gen_require(`
+		type devtty_t;
+	')
+
+	dev_list_all_dev_nodes($1)
+	dev_add_entry_generic_dirs($1)
+	allow $1 devtty_t:chr_file create_chr_file_perms;
+	allow $1 self:capability mknod;
+')
+
+#######################################
+## <summary>
 ##	Set the attributes of the tty device
 ## </summary>
 ## <param name="domain">
@@ -766,6 +787,26 @@ interface(`term_use_controlling_term',`
 
 	dev_list_all_dev_nodes($1)
 	allow $1 devtty_t:chr_file { rw_term_perms lock append };
+')
+
+#######################################
+## <summary>
+##  Create the pty multiplexor (/dev/ptmx).
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`term_create_ptmx',`
+	gen_require(`
+		type ptmx_t;
+	')
+
+	dev_add_entry_generic_dirs($1)
+	allow $1 ptmx_t:chr_file create_chr_file_perms;
+	allow $1 self:capability mknod;
 ')
 
 #######################################

--- a/policy/modules/services/ntp.te
+++ b/policy/modules/services/ntp.te
@@ -12,6 +12,7 @@ files_config_file(ntp_conf_t)
 
 type ntp_drift_t;
 files_type(ntp_drift_t)
+init_mountpoint(ntp_drift_t)
 
 type ntpd_t;
 type ntpd_exec_t;
@@ -33,6 +34,7 @@ logging_log_file(ntpd_log_t)
 
 type ntpd_pid_t;
 files_pid_file(ntpd_pid_t)
+init_mountpoint(ntpd_pid_t)
 
 type ntpd_tmp_t;
 files_tmp_file(ntpd_tmp_t)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -332,6 +332,11 @@ ifdef(`init_systemd',`
 	dev_manage_sysfs_dirs(init_t)
 	dev_relabel_sysfs_dirs(init_t)
 	dev_read_usbfs(initrc_t)
+	# sandbox
+	dev_create_null_dev(init_t)
+	dev_create_zero_dev(init_t)
+	dev_create_rand_dev(init_t)
+	dev_create_urand_dev(init_t)
 	# systemd writes to /dev/watchdog on shutdown
 	dev_write_watchdog(init_t)
 
@@ -458,6 +463,8 @@ ifdef(`init_systemd',`
 	systemd_rw_networkd_netlink_route_sockets(init_t)
 
 	term_create_devpts_dirs(init_t)
+	term_create_ptmx(init_t)
+	term_create_controlling_term(init_t)
 
 	# udevd is a "systemd kobject uevent socket activated daemon"
 	udev_create_kobject_uevent_sockets(init_t)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -408,6 +408,7 @@ ifdef(`init_systemd',`
 	fs_relabel_tmpfs_dirs(init_t)
 	fs_relabel_tmpfs_files(init_t)
 	fs_relabelfrom_tmpfs_sockets(init_t)
+	fs_manage_tmpfs_symlinks(init_t)
 	# mount-setup
 	fs_unmount_autofs(init_t)
 	fs_getattr_pstore_dirs(init_t)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -447,6 +447,7 @@ ifdef(`init_systemd',`
 	logging_relabelto_devlog_sock_files(init_t)
 	logging_relabel_generic_log_dirs(init_t)
 	logging_audit_socket_activation(init_t)
+	logging_use_syslogd_fd(init_t)
 
 	# lvm2-activation-generator checks file labels
 	seutil_read_file_contexts(init_t)

--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -689,6 +689,25 @@ interface(`logging_send_syslog_msg',`
 
 ########################################
 ## <summary>
+##  Allow domain to use a file descriptor
+##  from syslogd.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`logging_use_syslogd_fd', `
+	gen_require(`
+		type syslogd_t;
+	')
+
+	allow $1 syslogd_t:fd use;
+')
+
+########################################
+## <summary>
 ##	Allow domain to relabelto devlog sock_files
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -137,13 +137,16 @@ init_named_socket_activation(systemd_logind_t, systemd_logind_runtime_t)
 
 type systemd_logind_inhibit_runtime_t alias systemd_logind_inhibit_var_run_t;
 files_pid_file(systemd_logind_inhibit_runtime_t)
+init_mountpoint(systemd_logind_inhibit_runtime_t)
 
 type systemd_logind_runtime_t alias systemd_logind_var_run_t;
 files_pid_file(systemd_logind_runtime_t)
 init_daemon_pid_file(systemd_logind_runtime_t, dir, "systemd_logind")
+init_mountpoint(systemd_logind_runtime_t)
 
 type systemd_logind_var_lib_t;
 files_type(systemd_logind_var_lib_t)
+init_mountpoint(systemd_logind_var_lib_t)
 
 type systemd_machined_t;
 type systemd_machined_exec_t;
@@ -222,6 +225,7 @@ init_system_domain(systemd_sessions_t, systemd_sessions_exec_t)
 type systemd_sessions_runtime_t alias systemd_sessions_var_run_t;
 files_pid_file(systemd_sessions_runtime_t)
 init_daemon_pid_file(systemd_sessions_runtime_t, dir, "systemd_sessions")
+init_mountpoint(systemd_sessions_runtime_t)
 
 type systemd_tmpfiles_t;
 type systemd_tmpfiles_exec_t;


### PR DESCRIPTION
Without the `unconfined` module present, systemd will fail to boot due to various sandboxing options, e.g. ProtectKernelModules=yes (in https://github.com/systemd/systemd/blob/master/units/systemd-logind.service.in#L43).
A few other things also prevent a successful boot and have been fixed.

These changes should allow a minimal debian unstable install to boot successfully without the `unconfined` module.