### PR TITLE
Move all apache_content calls out of optional blocks

### DIFF
--- a/policy/modules/apps/lightsquid.te
+++ b/policy/modules/apps/lightsquid.te
@@ -39,13 +39,11 @@ miscfiles_read_localization(lightsquid_t)
 squid_read_config(lightsquid_t)
 squid_read_log(lightsquid_t)
 
-optional_policy(`
-	apache_content_template(lightsquid)
+apache_content_template(lightsquid)
 
-	list_dirs_pattern(httpd_lightsquid_script_t, lightsquid_rw_content_t, lightsquid_rw_content_t)
-	read_files_pattern(httpd_lightsquid_script_t, lightsquid_rw_content_t, lightsquid_rw_content_t)
-	read_lnk_files_pattern(httpd_lightsquid_script_t, lightsquid_rw_content_t, lightsquid_rw_content_t)
-')
+list_dirs_pattern(httpd_lightsquid_script_t, lightsquid_rw_content_t, lightsquid_rw_content_t)
+read_files_pattern(httpd_lightsquid_script_t, lightsquid_rw_content_t, lightsquid_rw_content_t)
+read_lnk_files_pattern(httpd_lightsquid_script_t, lightsquid_rw_content_t, lightsquid_rw_content_t)
 
 optional_policy(`
 	cron_system_entry(lightsquid_t, lightsquid_exec_t)

--- a/policy/modules/apps/webalizer.te
+++ b/policy/modules/apps/webalizer.te
@@ -75,12 +75,10 @@ userdom_use_user_terminals(webalizer_t)
 userdom_use_unpriv_users_fds(webalizer_t)
 userdom_dontaudit_search_user_home_content(webalizer_t)
 
-optional_policy(`
-	apache_read_log(webalizer_t)
-	apache_content_template(webalizer)
-	manage_dirs_pattern(webalizer_t, httpd_webalizer_content_t, httpd_webalizer_content_t)
-	manage_files_pattern(webalizer_t, httpd_webalizer_content_t, httpd_webalizer_content_t)
-')
+apache_read_log(webalizer_t)
+apache_content_template(webalizer)
+manage_dirs_pattern(webalizer_t, httpd_webalizer_content_t, httpd_webalizer_content_t)
+manage_files_pattern(webalizer_t, httpd_webalizer_content_t, httpd_webalizer_content_t)
 
 optional_policy(`
 	cron_system_entry(webalizer_t, webalizer_exec_t)

--- a/policy/modules/services/apcupsd.te
+++ b/policy/modules/services/apcupsd.te
@@ -106,19 +106,17 @@ optional_policy(`
 # CGI local policy
 #
 
-optional_policy(`
-	apache_content_template(apcupsd_cgi)
+apache_content_template(apcupsd_cgi)
 
-	allow httpd_apcupsd_cgi_script_t self:tcp_socket create_stream_socket_perms;
-	allow httpd_apcupsd_cgi_script_t self:udp_socket create_socket_perms;
+allow httpd_apcupsd_cgi_script_t self:tcp_socket create_stream_socket_perms;
+allow httpd_apcupsd_cgi_script_t self:udp_socket create_socket_perms;
 
-	corenet_all_recvfrom_netlabel(httpd_apcupsd_cgi_script_t)
-	corenet_tcp_sendrecv_generic_if(httpd_apcupsd_cgi_script_t)
-	corenet_tcp_sendrecv_generic_node(httpd_apcupsd_cgi_script_t)
-	corenet_sendrecv_apcupsd_client_packets(httpd_apcupsd_cgi_script_t)
-	corenet_tcp_connect_apcupsd_port(httpd_apcupsd_cgi_script_t)
-	corenet_udp_sendrecv_generic_if(httpd_apcupsd_cgi_script_t)
-	corenet_udp_sendrecv_generic_node(httpd_apcupsd_cgi_script_t)
+corenet_all_recvfrom_netlabel(httpd_apcupsd_cgi_script_t)
+corenet_tcp_sendrecv_generic_if(httpd_apcupsd_cgi_script_t)
+corenet_tcp_sendrecv_generic_node(httpd_apcupsd_cgi_script_t)
+corenet_sendrecv_apcupsd_client_packets(httpd_apcupsd_cgi_script_t)
+corenet_tcp_connect_apcupsd_port(httpd_apcupsd_cgi_script_t)
+corenet_udp_sendrecv_generic_if(httpd_apcupsd_cgi_script_t)
+corenet_udp_sendrecv_generic_node(httpd_apcupsd_cgi_script_t)
 
-	sysnet_dns_name_resolve(httpd_apcupsd_cgi_script_t)
-')
+sysnet_dns_name_resolve(httpd_apcupsd_cgi_script_t)

--- a/policy/modules/services/cvs.te
+++ b/policy/modules/services/cvs.te
@@ -114,10 +114,8 @@ optional_policy(`
 # CVSWeb local policy
 #
 
-optional_policy(`
-	apache_content_template(cvs)
+apache_content_template(cvs)
 
-	read_files_pattern(httpd_cvs_script_t, cvs_data_t, cvs_data_t)
-	manage_dirs_pattern(httpd_cvs_script_t, cvs_tmp_t, cvs_tmp_t)
-	manage_files_pattern(httpd_cvs_script_t, cvs_tmp_t, cvs_tmp_t)
-')
+read_files_pattern(httpd_cvs_script_t, cvs_data_t, cvs_data_t)
+manage_dirs_pattern(httpd_cvs_script_t, cvs_tmp_t, cvs_tmp_t)
+manage_files_pattern(httpd_cvs_script_t, cvs_tmp_t, cvs_tmp_t)

--- a/policy/modules/services/dspam.te
+++ b/policy/modules/services/dspam.te
@@ -64,13 +64,11 @@ logging_send_syslog_msg(dspam_t)
 
 miscfiles_read_localization(dspam_t)
 
-optional_policy(`
-	apache_content_template(dspam)
+apache_content_template(dspam)
 
-	list_dirs_pattern(dspam_t, httpd_dspam_content_t, httpd_dspam_content_t)
-	manage_dirs_pattern(dspam_t, httpd_dspam_rw_content_t, httpd_dspam_rw_content_t)
-	manage_files_pattern(dspam_t, httpd_dspam_rw_content_t, httpd_dspam_rw_content_t)
-')
+list_dirs_pattern(dspam_t, httpd_dspam_content_t, httpd_dspam_content_t)
+manage_dirs_pattern(dspam_t, httpd_dspam_rw_content_t, httpd_dspam_rw_content_t)
+manage_files_pattern(dspam_t, httpd_dspam_rw_content_t, httpd_dspam_rw_content_t)
 
 optional_policy(`
 	mysql_stream_connect(dspam_t)

--- a/policy/modules/services/munin.te
+++ b/policy/modules/services/munin.te
@@ -173,13 +173,11 @@ sysnet_exec_ifconfig(munin_t)
 userdom_dontaudit_use_unpriv_user_fds(munin_t)
 userdom_dontaudit_search_user_home_dirs(munin_t)
 
-optional_policy(`
-	apache_content_template(munin)
+apache_content_template(munin)
 
-	manage_dirs_pattern(munin_t, httpd_munin_content_t, httpd_munin_content_t)
-	manage_files_pattern(munin_t, httpd_munin_content_t, httpd_munin_content_t)
-	apache_search_sys_content(munin_t)
-')
+manage_dirs_pattern(munin_t, httpd_munin_content_t, httpd_munin_content_t)
+manage_files_pattern(munin_t, httpd_munin_content_t, httpd_munin_content_t)
+apache_search_sys_content(munin_t)
 
 optional_policy(`
 	cron_system_entry(munin_t, munin_exec_t)

--- a/policy/modules/services/nagios.te
+++ b/policy/modules/services/nagios.te
@@ -178,34 +178,32 @@ optional_policy(`
 #
 # CGI local policy
 #
-optional_policy(`
-	apache_content_template(nagios)
+apache_content_template(nagios)
 
-	allow httpd_nagios_script_t self:process signal_perms;
+allow httpd_nagios_script_t self:process signal_perms;
 
-	read_files_pattern(httpd_nagios_script_t, nagios_t, nagios_t)
-	read_lnk_files_pattern(httpd_nagios_script_t, nagios_t, nagios_t)
+read_files_pattern(httpd_nagios_script_t, nagios_t, nagios_t)
+read_lnk_files_pattern(httpd_nagios_script_t, nagios_t, nagios_t)
 
-	allow httpd_nagios_script_t nagios_etc_t:dir list_dir_perms;
-	allow httpd_nagios_script_t nagios_etc_t:file read_file_perms;
-	allow httpd_nagios_script_t nagios_etc_t:lnk_file read_lnk_file_perms;
+allow httpd_nagios_script_t nagios_etc_t:dir list_dir_perms;
+allow httpd_nagios_script_t nagios_etc_t:file read_file_perms;
+allow httpd_nagios_script_t nagios_etc_t:lnk_file read_lnk_file_perms;
 
-	files_search_spool(httpd_nagios_script_t)
-	rw_fifo_files_pattern(httpd_nagios_script_t, nagios_spool_t, nagios_spool_t)
+files_search_spool(httpd_nagios_script_t)
+rw_fifo_files_pattern(httpd_nagios_script_t, nagios_spool_t, nagios_spool_t)
 
-	allow httpd_nagios_script_t nagios_log_t:dir list_dir_perms;
-	read_files_pattern(httpd_nagios_script_t, nagios_etc_t, nagios_log_t)
-	read_lnk_files_pattern(httpd_nagios_script_t, nagios_etc_t, nagios_log_t)
+allow httpd_nagios_script_t nagios_log_t:dir list_dir_perms;
+read_files_pattern(httpd_nagios_script_t, nagios_etc_t, nagios_log_t)
+read_lnk_files_pattern(httpd_nagios_script_t, nagios_etc_t, nagios_log_t)
 
-	kernel_read_system_state(httpd_nagios_script_t)
+kernel_read_system_state(httpd_nagios_script_t)
 
-	domain_dontaudit_read_all_domains_state(httpd_nagios_script_t)
+domain_dontaudit_read_all_domains_state(httpd_nagios_script_t)
 
-	files_read_etc_runtime_files(httpd_nagios_script_t)
-	files_read_kernel_symbol_table(httpd_nagios_script_t)
+files_read_etc_runtime_files(httpd_nagios_script_t)
+files_read_kernel_symbol_table(httpd_nagios_script_t)
 
-	logging_send_syslog_msg(httpd_nagios_script_t)
-')
+logging_send_syslog_msg(httpd_nagios_script_t)
 
 ########################################
 #

--- a/policy/modules/services/nut.te
+++ b/policy/modules/services/nut.te
@@ -147,12 +147,10 @@ init_sigchld(nut_upsdrvctl_t)
 # Cgi local policy
 #
 
-optional_policy(`
-	apache_content_template(nutups_cgi)
+apache_content_template(nutups_cgi)
 
-	allow httpd_nutups_cgi_script_t nut_conf_t:dir list_dir_perms;
-	allow httpd_nutups_cgi_script_t nut_conf_t:file read_file_perms;
-	allow httpd_nutups_cgi_script_t nut_conf_t:lnk_file read_lnk_file_perms;
+allow httpd_nutups_cgi_script_t nut_conf_t:dir list_dir_perms;
+allow httpd_nutups_cgi_script_t nut_conf_t:file read_file_perms;
+allow httpd_nutups_cgi_script_t nut_conf_t:lnk_file read_lnk_file_perms;
 
-	sysnet_dns_name_resolve(httpd_nutups_cgi_script_t)
-')
+sysnet_dns_name_resolve(httpd_nutups_cgi_script_t)

--- a/policy/modules/services/prelude.te
+++ b/policy/modules/services/prelude.te
@@ -268,29 +268,27 @@ optional_policy(`
 # Cgi Declarations
 #
 
+apache_content_template(prewikka)
+
+can_exec(httpd_prewikka_script_t, httpd_prewikka_script_exec_t)
+
+files_search_tmp(httpd_prewikka_script_t)
+
+kernel_read_sysctl(httpd_prewikka_script_t)
+kernel_search_network_sysctl(httpd_prewikka_script_t)
+
+auth_use_nsswitch(httpd_prewikka_script_t)
+
+logging_send_syslog_msg(httpd_prewikka_script_t)
+
+apache_search_sys_content(httpd_prewikka_script_t)
+
 optional_policy(`
-	apache_content_template(prewikka)
+    mysql_stream_connect(httpd_prewikka_script_t)
+    mysql_tcp_connect(httpd_prewikka_script_t)
+')
 
-	can_exec(httpd_prewikka_script_t, httpd_prewikka_script_exec_t)
-
-	files_search_tmp(httpd_prewikka_script_t)
-
-	kernel_read_sysctl(httpd_prewikka_script_t)
-	kernel_search_network_sysctl(httpd_prewikka_script_t)
-
-	auth_use_nsswitch(httpd_prewikka_script_t)
-
-	logging_send_syslog_msg(httpd_prewikka_script_t)
-
-	apache_search_sys_content(httpd_prewikka_script_t)
-
-	optional_policy(`
-		mysql_stream_connect(httpd_prewikka_script_t)
-		mysql_tcp_connect(httpd_prewikka_script_t)
-	')
-
-	optional_policy(`
-		postgresql_stream_connect(httpd_prewikka_script_t)
-		postgresql_tcp_connect(httpd_prewikka_script_t)
-	')
+optional_policy(`
+    postgresql_stream_connect(httpd_prewikka_script_t)
+    postgresql_tcp_connect(httpd_prewikka_script_t)
 ')

--- a/policy/modules/services/smokeping.te
+++ b/policy/modules/services/smokeping.te
@@ -60,19 +60,17 @@ optional_policy(`
 # Cgi local policy
 #
 
-optional_policy(`
-	apache_content_template(smokeping_cgi)
+apache_content_template(smokeping_cgi)
 
-	manage_dirs_pattern(httpd_smokeping_cgi_script_t, smokeping_var_lib_t, smokeping_var_lib_t)
-	manage_files_pattern(httpd_smokeping_cgi_script_t, smokeping_var_lib_t, smokeping_var_lib_t)
+manage_dirs_pattern(httpd_smokeping_cgi_script_t, smokeping_var_lib_t, smokeping_var_lib_t)
+manage_files_pattern(httpd_smokeping_cgi_script_t, smokeping_var_lib_t, smokeping_var_lib_t)
 
-	getattr_files_pattern(httpd_smokeping_cgi_script_t, smokeping_runtime_t, smokeping_runtime_t)
+getattr_files_pattern(httpd_smokeping_cgi_script_t, smokeping_runtime_t, smokeping_runtime_t)
 
-	files_read_etc_files(httpd_smokeping_cgi_script_t)
-	files_search_tmp(httpd_smokeping_cgi_script_t)
-	files_search_var_lib(httpd_smokeping_cgi_script_t)
+files_read_etc_files(httpd_smokeping_cgi_script_t)
+files_search_tmp(httpd_smokeping_cgi_script_t)
+files_search_var_lib(httpd_smokeping_cgi_script_t)
 
-	sysnet_dns_name_resolve(httpd_smokeping_cgi_script_t)
+sysnet_dns_name_resolve(httpd_smokeping_cgi_script_t)
 
-	netutils_domtrans_ping(httpd_smokeping_cgi_script_t)
-')
+netutils_domtrans_ping(httpd_smokeping_cgi_script_t)

--- a/policy/modules/services/squid.te
+++ b/policy/modules/services/squid.te
@@ -196,20 +196,18 @@ tunable_policy(`squid_use_tproxy',`
 	corenet_tcp_bind_netport_port(squid_t)
 ')
 
-optional_policy(`
-	apache_content_template(squid)
+apache_content_template(squid)
 
-	corenet_all_recvfrom_netlabel(httpd_squid_script_t)
-	corenet_tcp_sendrecv_generic_if(httpd_squid_script_t)
-	corenet_tcp_sendrecv_generic_node(httpd_squid_script_t)
+corenet_all_recvfrom_netlabel(httpd_squid_script_t)
+corenet_tcp_sendrecv_generic_if(httpd_squid_script_t)
+corenet_tcp_sendrecv_generic_node(httpd_squid_script_t)
 
-	corenet_sendrecv_http_cache_client_packets(httpd_squid_script_t)
-	corenet_tcp_connect_http_cache_port(httpd_squid_script_t)
+corenet_sendrecv_http_cache_client_packets(httpd_squid_script_t)
+corenet_tcp_connect_http_cache_port(httpd_squid_script_t)
 
-	sysnet_dns_name_resolve(httpd_squid_script_t)
+sysnet_dns_name_resolve(httpd_squid_script_t)
 
-	squid_read_config(httpd_squid_script_t)
-')
+squid_read_config(httpd_squid_script_t)
 
 optional_policy(`
 	cron_system_entry(squid_t, squid_exec_t)


### PR DESCRIPTION
 Move all apache_content calls out of optional blocks                                                                                                                                                      
                                                                                                                                                                                                           
 Declaring derived domains inside optional blocks doesn't work well.                                                                                                                                       
 In this case it can lead to `httpd_webalizer_content_t` being a part of                                                                                                                                   
 `file_type`, but despite the rule `role system_r types file_type`,                                                                                                                                        
 `httpd_webalizer_content_t` won't be a part of `system_r`.                                                                                                                                                
                                                                                                                                                                                                           
 This was really fun to figure out.                                                                                                                                                                        
                                                                                                                                                                                                           
 Signed-off-by: bauen1 <j2468h@gmail.com>                                                                                                                                                                  


This has the side effect of creating a hard dependency from some modules on the apache module, but the workaround of adding a seperate module, e.g. `lightsquid_apache` won't scale.