### PR TITLE
Systemd generator

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -2148,11 +2148,11 @@ interface(`init_exec_script_files',`
 #
 interface(`init_getattr_all_script_files',`
 	gen_require(`
-		attribute init_script_file_type;
+		attribute init_script_file_type, systemdunit;
 	')
 
 	files_list_etc($1)
-	allow $1 init_script_file_type:file getattr;
+	allow $1 { init_script_file_type systemdunit }:file getattr;
 ')
 
 ########################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -380,6 +380,7 @@ files_list_usr(systemd_generator_t)
 fs_list_efivars(systemd_generator_t)
 fs_getattr_xattr_fs(systemd_generator_t)
 
+init_getattr_all_script_files(systemd_generator_t)
 init_create_pid_files(systemd_generator_t)
 init_manage_pid_dirs(systemd_generator_t)
 init_manage_pid_symlinks(systemd_generator_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -363,7 +363,8 @@ seutil_search_default_contexts(systemd_coredump_t)
 
 allow systemd_generator_t self:fifo_file rw_fifo_file_perms;
 
-corecmd_getattr_bin_files(systemd_generator_t)
+corecmd_exec_bin(systemd_generator_t)
+corecmd_shell_entry_type(systemd_generator_t)
 
 dev_read_sysfs(systemd_generator_t)
 dev_write_kmsg(systemd_generator_t)


### PR DESCRIPTION
Several fixes for the systemd generator

I expanded `init_getattr_all_script_files` interface to allow getting the attributes of the systemd unit files in addition of the initscripts, please tell me if you want a new one