### PR TITLE
Interfaces for tpm2

### DIFF
--- a/policy/modules/services/tpm2.if
+++ b/policy/modules/services/tpm2.if
@@ -67,6 +67,43 @@ interface(`tpm2_run',`
 
 ########################################
 ## <summary>
+##	Use tpm2 file descriptors.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tpm2_use_fds',`
+	gen_require(`
+		type tpm2_t;
+	')
+
+	allow $1 tpm2_t:fd use;
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to inherit file
+##	descriptors from tpm2.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`tpm2_dontaudit_use_fds',`
+	gen_require(`
+		type tpm2_t;
+	')
+
+	dontaudit $1 tpm2_t:fd use;
+')
+
+########################################
+## <summary>
 ##   Send and receive messages from
 ##   tpm2-abrmd over dbus.
 ## </summary>
@@ -84,6 +121,32 @@ interface(`tpm2_dbus_chat_abrmd',`
 
 	allow $1 tpm2_abrmd_t:dbus send_msg;
 	allow tpm2_abrmd_t $1:dbus send_msg;
+')
+
+########################################
+## <summary>
+##	Allow tpm2 to read unnamed pipes from other process.
+## </summary>
+## <desc>
+##	<p>
+##	Allow the tpm to open and read pipes from other
+##	domain.  This is seen when piping input to one 
+##	of the tpm2_* processes.  For example:
+##	sha512sum my_file | tpm2_hmac -k 0x81001000 -g sha256 /dev/stdin
+##	</p>
+## </desc>
+## <param name="domain">
+##	<summary>
+##	Domain of pipe to be read by tpm2_t.
+##	</summary>
+## </param>
+#
+interface(`tpm2_read_pipes',`
+	gen_require(`
+		type tpm2_t;
+	')
+
+	allow tpm2_t $1:fifo_file read_fifo_file_perms;
 ')
 
 ########################################


### PR DESCRIPTION
Add interfaces tpm2_use_fds, tpm2_dontaudit_use_fds, and tpm2_read_pipes

Signed-off-by: David Sugar <dsugar@tresys.com>