### PR TITLE
Move user definitions to the right place during compilation.

### DIFF
--- a/Rules.modular
+++ b/Rules.modular
@@ -154,9 +154,10 @@ endif
 	$(verbose) $(M4) $(M4PARAM) -s $^ > $@
 
 $(tmpdir)/post_te_files.conf: M4PARAM += -D self_contained_policy
-$(tmpdir)/post_te_files.conf: $(m4support) $(tmpdir)/generated_definitions.conf $(base_post_te_files)
+$(tmpdir)/post_te_files.conf: $(m4support) $(tmpdir)/generated_definitions.conf $(base_post_te_files) $(tmpdir)/all_te_files.conf
 	@test -d $(tmpdir) || mkdir -p $(tmpdir)
-	$(verbose) $(M4) $(M4PARAM) $^ > $@
+	$(verbose) $(GREP) '^[[:blank:]]*user ' $(tmpdir)/all_te_files.conf > $@ || true
+	$(verbose) $(M4) $(M4PARAM) $(m4support) $(tmpdir)/generated_definitions.conf $(base_post_te_files) >> $@
 
 # extract attributes and put them first. extract post te stuff
 # like genfscon and put last.

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -134,9 +134,10 @@ endif
 	@test -d $(tmpdir) || mkdir -p $(tmpdir)
 	$(verbose) $(M4) $(M4PARAM) -s $^ > $@
 
-$(tmpdir)/post_te_files.conf: $(m4support) $(tmpdir)/generated_definitions.conf $(post_te_files)
+$(tmpdir)/post_te_files.conf: $(m4support) $(tmpdir)/generated_definitions.conf $(post_te_files) $(tmpdir)/all_te_files.conf
 	@test -d $(tmpdir) || mkdir -p $(tmpdir)
-	$(verbose) $(M4) $(M4PARAM) $^ > $@
+	$(verbose) $(GREP) '^[[:blank:]]*user ' $(tmpdir)/all_te_files.conf > $@ || true
+	$(verbose) $(M4) $(M4PARAM) $(m4support) $(tmpdir)/generated_definitions.conf $(post_te_files) >> $@
 
 # extract attributes and put them first. extract post te stuff
 # like genfscon and put last.

--- a/support/comment_move_decl.sed
+++ b/support/comment_move_decl.sed
@@ -11,5 +11,6 @@
 /^[[:blank:]]*sid /s/^/# this line was moved by the build process: &/
 /^[[:blank:]]*bool /s/^/# this line was moved by the build process: &/
 /^[[:blank:]]*role[[:blank:]]+[a-zA-Z_]+[[:blank:]]*;/s/^/# this line was moved by the build process: &/
+/^[[:blank:]]*user [a-zA-Z_]+ roles /s/^/# this line was moved by the build process: &/
 
 :nextline


### PR DESCRIPTION
This will allow user definitions in modules to work for monolithic policies
and base module.

Signed-off-by: Chris PeBenito <chpebeni@linux.microsoft.com>