### PR TITLE
Also label polkit-agent-helper-1 when installed directly in /usr/libexec

### DIFF
--- a/policy/modules/services/policykit.fc
+++ b/policy/modules/services/policykit.fc
@@ -11,6 +11,7 @@
 # Systemd unit file
 /usr/lib/systemd/system/[^/]*polkit.*	--	gen_context(system_u:object_r:policykit_unit_t,s0)
 
+/usr/libexec/polkit-agent-helper-1	--	gen_context(system_u:object_r:policykit_auth_exec_t,s0)
 /usr/libexec/polkit-read-auth-helper	--	gen_context(system_u:object_r:policykit_auth_exec_t,s0)
 /usr/libexec/polkit-grant-helper.*	--	gen_context(system_u:object_r:policykit_grant_exec_t,s0)
 /usr/libexec/polkit-resolve-exe-helper.*	--	gen_context(system_u:object_r:policykit_resolve_exec_t,s0)


### PR DESCRIPTION
Debian now installs that executable directly in /usr/libexec for the
version 0.105

Signed-off-by: Laurent Bigonville <bigon@bigon.be>