### PR TITLE
Label /usr/libexec/packagekitd as apt_exec_t on debian

### DIFF
--- a/policy/modules/admin/apt.fc
+++ b/policy/modules/admin/apt.fc
@@ -9,6 +9,7 @@
 ifndef(`distro_redhat',`
 /usr/sbin/synaptic	--	gen_context(system_u:object_r:apt_exec_t,s0)
 /usr/lib/packagekit/packagekitd	--	gen_context(system_u:object_r:apt_exec_t,s0)
+/usr/libexec/packagekitd	--	gen_context(system_u:object_r:apt_exec_t,s0)
 /var/cache/PackageKit(/.*)?	gen_context(system_u:object_r:apt_var_cache_t,s0)
 /var/lib/PackageKit(/.*)?	gen_context(system_u:object_r:apt_var_lib_t,s0)
 ')

--- a/policy/modules/admin/rpm.fc
+++ b/policy/modules/admin/rpm.fc
@@ -23,7 +23,6 @@
 /usr/lib/systemd/system/[^/]*dnf-makecache.*	--	gen_context(system_u:object_r:rpm_unit_t,s0)
 /usr/lib/systemd/system/[^/]*yum-makecache.*	--	gen_context(system_u:object_r:rpm_unit_t,s0)
 
-/usr/libexec/packagekitd	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/libexec/yumDBUSBackend\.py	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 
 /usr/sbin/bcfg2	--	gen_context(system_u:object_r:rpm_exec_t,s0)
@@ -39,6 +38,7 @@
 
 ifdef(`distro_redhat',`
 /usr/sbin/synaptic	--	gen_context(system_u:object_r:rpm_exec_t,s0)
+/usr/libexec/packagekitd	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 /var/cache/PackageKit(/.*)?	gen_context(system_u:object_r:rpm_var_cache_t,s0)
 /var/lib/PackageKit(/.*)?	gen_context(system_u:object_r:rpm_var_lib_t,s0)
 ')


### PR DESCRIPTION
The daemon has now moved from /usr/lib/packagekit/packagekitd to
/usr/libexec/packagekitd

Signed-off-by: Laurent Bigonville <bigon@bigon.be>