### PR TITLE
travis-ci: add interface db build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@
 language: python
 python: 3.5
 
-matrix:
-  fast_finish: true
-
 env:
   - TYPE=standard DISTRO=redhat MONOLITHIC=y SYSTEMD=y WERROR=y
   - TYPE=standard DISTRO=redhat MONOLITHIC=n SYSTEMD=y WERROR=y
@@ -35,12 +32,13 @@ env:
   - TYPE=mls DISTRO=debian MONOLITHIC=y SYSTEMD=y WERROR=y APPS_OFF=unconfined
   - TYPE=mls DISTRO=gentoo MONOLITHIC=y SYSTEMD=n WERROR=y APPS_OFF=unconfined
 
-matrix:
+jobs:
+  fast_finish: true
   include:
   - python: 3.7
     env: LINT=true TYPE=standard
 
-sudo: false
+os: linux
 dist: bionic
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ addons:
     - libaudit-dev
     - libbz2-dev
     - libpcre3-dev
+    - libpython3.5-dev
     - swig
     - libxml2-utils
 
@@ -89,8 +90,11 @@ install:
         # Drop sandbox to break libcap-ng dependence
         sed -i -e 's/ sandbox//' selinux-src/policycoreutils/Makefile
 
+        # Take PYTHONPATH and PYTHONHOME into account in sepolgen-ifgen
+        sed -i -e 's@#!/usr/bin/python3 -Es@#!/usr/bin/python3@' selinux-src/python/audit2allow/sepolgen-ifgen
+
         # Compile and install SELinux toolchain into ~/selinux
-        make OPT_SUBDIRS=semodule-utils -C selinux-src install
+        make OPT_SUBDIRS="python semodule-utils" -C selinux-src install install-pywrap
         echo "${SELINUX_USERSPACE_VERSION}" > "${TRAVIS_BUILD_DIR}/selinux/travis.version"
       fi
 
@@ -115,3 +119,4 @@ script:
   - make DESTDIR=${HOME}/tmp install-src
   - make DESTDIR=${HOME}/tmp install-docs
   - make DESTDIR=${HOME}/tmp install-appconfig
+  - make DESTDIR=${HOME}/tmp build-interface-db


### PR DESCRIPTION
Check that sepolgen-ifgen (creates the database for audit2allow -R) works on the policy.

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>


Note: This needs a manual travis-ci cache clean-up, as sepolgen-ifgen from the SELinux sub-directory python is required.