### PR TITLE
travis: resolve Linter tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@
 language: python
 python: 3.5
 
-matrix:
-  fast_finish: true
-
 env:
   - TYPE=standard DISTRO=redhat MONOLITHIC=y SYSTEMD=y WERROR=y
   - TYPE=standard DISTRO=redhat MONOLITHIC=n SYSTEMD=y WERROR=y
@@ -35,12 +32,13 @@ env:
   - TYPE=mls DISTRO=debian MONOLITHIC=y SYSTEMD=y WERROR=y APPS_OFF=unconfined
   - TYPE=mls DISTRO=gentoo MONOLITHIC=y SYSTEMD=n WERROR=y APPS_OFF=unconfined
 
-matrix:
+jobs:
+  fast_finish: true
   include:
   - python: 3.7
     env: LINT=true TYPE=standard
 
-sudo: false
+os: linux
 dist: bionic
 
 cache:


### PR DESCRIPTION
root: duplicate key: matrix
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing os, using the default linux
root: key matrix is an alias for jobs, using jobs

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>