### PR TITLE
acpi.te: Allow acpid_t to shutdown the system

### DIFF
--- a/policy/modules/services/acpi.te
+++ b/policy/modules/services/acpi.te
@@ -137,7 +137,6 @@ auth_use_nsswitch(acpid_t)
 
 init_domtrans_script(acpid_t)
 init_telinit(acpid_t)
-init_write_initctl(acpid_t)
 
 libs_exec_ld_so(acpid_t)
 libs_exec_lib_files(acpid_t)

--- a/policy/modules/services/acpi.te
+++ b/policy/modules/services/acpi.te
@@ -108,6 +108,7 @@ dev_dontaudit_getattr_all_blk_files(acpid_t)
 
 files_exec_etc_files(acpid_t)
 files_read_etc_runtime_files(acpid_t)
+files_read_usr_files(acpid_t)
 files_dontaudit_getattr_all_files(acpid_t)
 files_dontaudit_getattr_all_symlinks(acpid_t)
 files_dontaudit_getattr_all_pipes(acpid_t)
@@ -135,6 +136,8 @@ domain_dontaudit_list_all_domains_state(acpid_t)
 auth_use_nsswitch(acpid_t)
 
 init_domtrans_script(acpid_t)
+init_telinit(acpid_t)
+init_write_initctl(acpid_t)
 
 libs_exec_ld_so(acpid_t)
 libs_exec_lib_files(acpid_t)
@@ -221,6 +224,12 @@ optional_policy(`
 
 optional_policy(`
 	sysnet_domtrans_ifconfig(acpid_t)
+')
+
+optional_policy(`
+	init_list_unit_dirs(acpid_t)
+	systemd_start_power_units(acpid_t)
+	systemd_status_power_units(acpid_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
acpi.te: Allow acpid_t to shutdown the system - this is required to handle shutdown calls from libvirt. Fixes #298.