### PR TITLE
postfixpolicyd: split multi-class rule

### DIFF
--- a/policy/modules/services/postfixpolicyd.te
+++ b/policy/modules/services/postfixpolicyd.te
@@ -37,7 +37,8 @@ allow postfix_policyd_t postfix_policyd_conf_t:lnk_file read_lnk_file_perms;
 manage_files_pattern(postfix_policyd_t, postfix_policyd_runtime_t, postfix_policyd_runtime_t)
 files_runtime_filetrans(postfix_policyd_t, postfix_policyd_runtime_t, file)
 
-allow postfix_policyd_t postfix_policyd_tmp_t:{ file sock_file } manage_file_perms;
+allow postfix_policyd_t postfix_policyd_tmp_t:file manage_file_perms;
+allow postfix_policyd_t postfix_policyd_tmp_t:sock_file manage_sock_file_perms;
 files_tmp_filetrans(postfix_policyd_t, postfix_policyd_tmp_t, { file sock_file })
 
 kernel_search_network_sysctl(postfix_policyd_t)


### PR DESCRIPTION
The rule uses the permission manage_file_perms on the classes file and
sock_file.  This won't result in a change in the actual policy
generated, but if the definitions of macros are changed going forward,
the mismatches could cause issues.

Found by SELint