### PR TITLE
Looks like this got dropped in pull request #294

### DIFF
--- a/policy/modules/system/modutils.te
+++ b/policy/modules/system/modutils.te
@@ -44,6 +44,7 @@ allow kmod_t self:rawip_socket create_socket_perms;
 # Read module config and dependency information
 list_dirs_pattern(kmod_t, modules_conf_t, modules_conf_t)
 read_files_pattern(kmod_t, modules_conf_t, modules_conf_t)
+allow kmod_t modules_dep_t:file map;
 list_dirs_pattern(kmod_t, modules_dep_t, modules_dep_t)
 manage_files_pattern(kmod_t, modules_dep_t, modules_dep_t)
 files_kernel_modules_filetrans(kmod_t, modules_dep_t, file)


### PR DESCRIPTION
Adding map permission back, seeing the following denial:
localhost kernel: type=1400 audit(1598497795.109:57): avc:  denied  { map } for  pid=1054 comm="modprobe" path="/usr/lib/modules/3.10.0-1127.19.1.el7.x86_64/modules.dep.bin" dev="dm-0" ino=23711 scontext=system_u:system_r:kmod_t:s0 tcontext=system_u:object_r:modules_dep_t:s0 tclass=file permissive=0

Signed-off-by: Dave Sugar <dsugar100@gmail.com>