### PR TITLE
userdomain.if: Marked usbguard user modify tunable as optional

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1216,8 +1216,10 @@ template(`userdom_unpriv_user_template', `
 	')
 
 	# Allow controlling usbguard
-	tunable_policy(`usbguard_user_modify_rule_files',`
-		usbguard_stream_connect($1_t)
+	optional_policy(`
+		tunable_policy(`usbguard_user_modify_rule_files',`
+			usbguard_stream_connect($1_t)
+		')
 	')
 ')
 


### PR DESCRIPTION
...so usbguard may be excluded.

Thanks to Dominick Grift for helping me pin-point this.

Signed-off-by: Jonathan Davies <jpds@protonmail.com>