### PR TITLE
init.te: Made init_run_all_scripts_domain unconditional

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -228,10 +228,10 @@ seutil_read_default_contexts(init_t)
 
 miscfiles_read_localization(init_t)
 
-ifdef(`init_systemd',`
-	# handle instances where an old labeled init script is encountered.
-	typeattribute init_t init_run_all_scripts_domain;
+# handle instances where an old labeled init script is encountered.
+typeattribute init_t init_run_all_scripts_domain;
 
+ifdef(`init_systemd',`
 	allow init_t self:unix_dgram_socket { create_socket_perms sendto };
 	allow init_t self:process { setsockcreate setfscreate setrlimit };
 	allow init_t self:process { getcap setcap getsched setsched };


### PR DESCRIPTION
 ...so it works on non-systemd systems like Gentoo.

Signed-off-by: Jonathan Davies <jpds@protonmail.com>