### PR TITLE
corecommands.fc: Handle Gentoo python-exec binary directories.

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -378,6 +378,7 @@ ifdef(`distro_gentoo', `
 /usr/[^/-]+-[^/-]+-linux-[^/-]+/[^/]+/gcc-bin/.*(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/[^/-]+-[^/-]+-linux-[^/-]+/[^/]+/binutils-bin(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 
+/usr/lib/python-exec(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/rcscripts/addons(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/rcscripts/sh(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/rcscripts/net\.modules\.d/helpers\.d/dhclient-.* -- gen_context(system_u:object_r:bin_t,s0)


### PR DESCRIPTION
Gentoo stores Python scripts in separate directories: https://wiki.gentoo.org/wiki/Project:Python/python-exec

Signed-off-by: Jonathan Davies <jpds@protonmail.com>