### PR TITLE
Set of fixes made while using a minimal Buildroot generated system

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -155,6 +155,7 @@ ifdef(`distro_gentoo',`
 /usr/bin/sesh			--	gen_context(system_u:object_r:shell_exec_t,s0)
 /usr/bin/scponly		--	gen_context(system_u:object_r:shell_exec_t,s0)
 /usr/bin/scponlyc		--	gen_context(system_u:object_r:shell_exec_t,s0)
+/usr/bin/sh			--	gen_context(system_u:object_r:shell_exec_t,s0)
 /usr/bin/smrsh			--	gen_context(system_u:object_r:shell_exec_t,s0)
 /usr/bin/tcsh			--	gen_context(system_u:object_r:shell_exec_t,s0)
 /usr/bin/yash			--	gen_context(system_u:object_r:shell_exec_t,s0)

--- a/policy/modules/services/dbus.if
+++ b/policy/modules/services/dbus.if
@@ -143,6 +143,8 @@ interface(`dbus_system_bus_client',`
 	stream_connect_pattern($1, system_dbusd_runtime_t, system_dbusd_runtime_t, system_dbusd_t)
 
 	dbus_read_config($1)
+	dbus_list_system_bus_runtime($1)
+	dbus_read_system_bus_runtime_named_sockets($1)
 ')
 
 #######################################

--- a/policy/modules/services/dbus.if
+++ b/policy/modules/services/dbus.if
@@ -596,6 +596,24 @@ interface(`dbus_watch_system_bus_runtime_dirs',`
 
 ########################################
 ## <summary>
+##	List system bus runtime directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dbus_list_system_bus_runtime',`
+	gen_require(`
+		type system_dbusd_runtime_t;
+	')
+
+	allow $1 system_dbusd_runtime_t:dir list_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Watch system bus runtime named sockets.
 ## </summary>
 ## <param name="domain">
@@ -610,6 +628,24 @@ interface(`dbus_watch_system_bus_runtime_named_sockets',`
 	')
 
 	allow $1 system_dbusd_runtime_t:sock_file watch;
+')
+
+########################################
+## <summary>
+##	Read system bus runtime named sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dbus_read_system_bus_runtime_named_sockets',`
+	gen_require(`
+		type system_dbusd_runtime_t;
+	')
+
+	allow $1 system_dbusd_runtime_t:sock_file read;
 ')
 
 ########################################

--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -59,6 +59,7 @@ kernel_read_system_state(local_login_t)
 kernel_read_kernel_sysctls(local_login_t)
 kernel_search_key(local_login_t)
 kernel_link_key(local_login_t)
+kernel_getattr_proc(local_login_t)
 
 corecmd_list_bin(local_login_t)
 # cjp: these are probably not needed:

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -524,7 +524,7 @@ ifdef(`init_systemd',`
 	allow syslogd_t self:netlink_audit_socket connected_socket_perms;
 	allow syslogd_t self:capability2 audit_read;
 	allow syslogd_t self:capability { chown setgid setuid sys_ptrace };
-	allow syslogd_t self:netlink_audit_socket { getattr getopt read setopt write };
+	allow syslogd_t self:netlink_audit_socket { getattr getopt read setopt write nlmsg_write };
 
 	# remove /run/log/journal when switching to permanent storage
 	allow syslogd_t var_log_t:dir rmdir;

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -346,6 +346,8 @@ interface(`sysnet_read_config',`
 	')
 
 	files_search_etc($1)
+	files_search_runtime($1)
+	allow $1 net_conf_t:dir list_dir_perms;
 	allow $1 net_conf_t:file read_file_perms;
 
 	ifdef(`distro_debian',`

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -461,6 +461,7 @@ selinux_get_fs_mount(systemd_hw_t)
 selinux_use_status_page(systemd_hw_t)
 
 init_read_state(systemd_hw_t)
+init_search_runtime(systemd_hw_t)
 
 seutil_read_config(systemd_hw_t)
 seutil_read_file_contexts(systemd_hw_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -785,6 +785,7 @@ dev_write_kmsg(systemd_networkd_t)
 files_read_etc_files(systemd_networkd_t)
 files_watch_runtime_dirs(systemd_networkd_t)
 files_watch_root_dirs(systemd_networkd_t)
+fs_getattr_xattr_fs(systemd_networkd_t)
 
 auth_use_nsswitch(systemd_networkd_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1095,6 +1095,7 @@ auth_use_nsswitch(systemd_resolved_t)
 
 files_watch_root_dirs(systemd_resolved_t)
 files_watch_runtime_dirs(systemd_resolved_t)
+files_list_runtime(systemd_resolved_t)
 
 init_dgram_send(systemd_resolved_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -362,6 +362,8 @@ seutil_search_default_contexts(systemd_coredump_t)
 #
 
 allow systemd_generator_t self:fifo_file rw_fifo_file_perms;
+allow systemd_generator_t self:capability dac_override;
+allow systemd_generator_t self:process setfscreate;
 
 corecmd_getattr_bin_files(systemd_generator_t)
 

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -421,3 +421,5 @@ kernel_read_kernel_sysctls(udevadm_t)
 kernel_read_system_state(udevadm_t)
 
 seutil_read_file_contexts(udevadm_t)
+
+fs_getattr_xattr_fs(udevadm_t)


### PR DESCRIPTION
Hello,

While working on adding SELinux support in [Buildroot](https://buildroot.org) (a tool widely used to generate small or embedded Linux systems), I came across multiple denied actions when using the refpolicy. I made tests using a small image, with systemd as the init and was not able to boot properly and to go up to the login prompt. As a result, I patched the refpolicy and (most of) those changes ended up in this PR.

The reason I made this PR is I'd like more systems to be supported by the refpolicy, and this PR will at least help to start the discussion on how to do that properly. Many of the changes that were required for the Buildroot generated image seem to also be part of the [changes](https://git.yoctoproject.org/cgit/cgit.cgi/meta-selinux/tree/recipes-security/refpolicy/refpolicy) made in [Yocto/OE](https://www.yoctoproject.org/) for their images. I believe there's a real benefit to support those systems in the official refpolicy (note that Yocto is carrying 80 patches on top of the refpolicy!).

I tried to use available functions whenever possible, but might have missed some. I also chose to make all of the changes unconditional so far, but that might be something to explore as I'm not sure wether or not all of those changes should be made for everyone. That's a point where I'd like some input, as I assume the refpolicy is at least working already for some.

Note that systems generated by Buildroot or Yocto/OE aren't distributions per-say, and can't be considered as ones as those systems could end up to be quite different. Using the DISTRO mechanism do not seem to fit here. We could think of other conditional mechanisms if needed.

Thanks!