### PR TITLE
init: allow systemd to map the SELinux status page

### DIFF
--- a/policy/modules/admin/rpm.te
+++ b/policy/modules/admin/rpm.te
@@ -181,7 +181,7 @@ selinux_compute_access_vector(rpm_t)
 selinux_compute_create_context(rpm_t)
 selinux_compute_relabel_context(rpm_t)
 selinux_compute_user_contexts(rpm_t)
-selinux_map_security_files(rpm_t)
+selinux_use_status_page(rpm_t)
 
 storage_raw_write_fixed_disk(rpm_t)
 storage_raw_read_fixed_disk(rpm_t)

--- a/policy/modules/kernel/selinux.if
+++ b/policy/modules/kernel/selinux.if
@@ -637,7 +637,28 @@ interface(`selinux_compute_user_contexts',`
 
 ########################################
 ## <summary>
-##	Allows caller to map secuirty_t files.
+##	Allows the caller to use the SELinux status page.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`selinux_use_status_page',`
+	gen_require(`
+		type security_t;
+	')
+
+	dev_search_sysfs($1)
+	allow $1 security_t:dir list_dir_perms;
+	allow $1 security_t:file mmap_read_file_perms;
+')
+
+########################################
+## <summary>
+##	Allows caller to map secuirty_t files. (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -650,6 +671,8 @@ interface(`selinux_map_security_files',`
 	gen_require(`
 		type security_t;
 	')
+
+	refpolicywarn(`$0() has been deprecated, use selinux_use_status_page() instead.')
 
 	dev_search_sysfs($1)
 	allow $1 security_t:file map;

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -439,8 +439,7 @@ ifdef(`init_systemd',`
 	selinux_compute_access_vector(init_t)
 	# for starting systemd --user in the right domain:
 	selinux_compute_user_contexts(init_t)
-	# mmap status page
-	selinux_map_security_files(init_t)
+	selinux_use_status_page(init_t)
 
 	storage_getattr_removable_dev(init_t)
 

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -439,6 +439,8 @@ ifdef(`init_systemd',`
 	selinux_compute_access_vector(init_t)
 	# for starting systemd --user in the right domain:
 	selinux_compute_user_contexts(init_t)
+	# mmap status page
+	selinux_map_security_files(init_t)
 
 	storage_getattr_removable_dev(init_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -424,8 +424,7 @@ dev_read_sysfs(systemd_hostnamed_t)
 
 files_read_etc_files(systemd_hostnamed_t)
 
-selinux_get_enforce_mode(systemd_hostnamed_t)
-selinux_map_security_files(systemd_hostnamed_t)
+selinux_use_status_page(systemd_hostnamed_t)
 
 seutil_read_file_contexts(systemd_hostnamed_t)
 
@@ -457,8 +456,7 @@ files_etc_filetrans(systemd_hw_t, systemd_hwdb_t, file)
 files_search_runtime(systemd_hw_t)
 
 selinux_get_fs_mount(systemd_hw_t)
-selinux_get_enforce_mode(systemd_hw_t)
-selinux_map_security_files(systemd_hw_t)
+selinux_use_status_page(systemd_hw_t)
 
 init_read_state(systemd_hw_t)
 
@@ -474,8 +472,7 @@ kernel_read_kernel_sysctls(systemd_locale_t)
 
 files_read_etc_files(systemd_locale_t)
 
-selinux_get_enforce_mode(systemd_locale_t)
-selinux_map_security_files(systemd_locale_t)
+selinux_use_status_page(systemd_locale_t)
 
 seutil_read_file_contexts(systemd_locale_t)
 
@@ -568,8 +565,7 @@ fs_read_efivarfs_files(systemd_logind_t)
 fs_relabelfrom_tmpfs_dirs(systemd_logind_t)
 fs_unmount_tmpfs(systemd_logind_t)
 
-selinux_get_enforce_mode(systemd_logind_t)
-selinux_map_security_files(systemd_logind_t)
+selinux_use_status_page(systemd_logind_t)
 
 storage_getattr_removable_dev(systemd_logind_t)
 storage_getattr_scsi_generic_dev(systemd_logind_t)
@@ -1089,8 +1085,7 @@ corenet_udp_bind_generic_node(systemd_resolved_t)
 corenet_udp_bind_dns_port(systemd_resolved_t)
 corenet_udp_bind_llmnr_port(systemd_resolved_t)
 
-selinux_get_enforce_mode(systemd_resolved_t)
-selinux_map_security_files(systemd_resolved_t)
+selinux_use_status_page(systemd_resolved_t)
 
 auth_use_nsswitch(systemd_resolved_t)
 
@@ -1123,9 +1118,8 @@ files_runtime_filetrans(systemd_sessions_t, systemd_sessions_runtime_t, file)
 
 kernel_read_kernel_sysctls(systemd_sessions_t)
 
-selinux_get_enforce_mode(systemd_sessions_t)
 selinux_get_fs_mount(systemd_sessions_t)
-selinux_map_security_files(systemd_sessions_t)
+selinux_use_status_page(systemd_sessions_t)
 
 seutil_read_config(systemd_sessions_t)
 seutil_read_default_contexts(systemd_sessions_t)
@@ -1147,8 +1141,7 @@ files_manage_etc_files(systemd_sysusers_t)
 
 kernel_read_kernel_sysctls(systemd_sysusers_t)
 
-selinux_get_enforce_mode(systemd_sysusers_t)
-selinux_map_security_files(systemd_sysusers_t)
+selinux_use_status_page(systemd_sysusers_t)
 
 auth_manage_shadow(systemd_sysusers_t)
 auth_etc_filetrans_shadow(systemd_sysusers_t)
@@ -1218,8 +1211,7 @@ fs_list_tmpfs(systemd_tmpfiles_t)
 fs_relabelfrom_tmpfs_dirs(systemd_tmpfiles_t)
 
 selinux_get_fs_mount(systemd_tmpfiles_t)
-selinux_get_enforce_mode(systemd_tmpfiles_t)
-selinux_map_security_files(systemd_tmpfiles_t)
+selinux_use_status_page(systemd_tmpfiles_t)
 
 auth_append_lastlog(systemd_tmpfiles_t)
 auth_manage_faillog(systemd_tmpfiles_t)
@@ -1304,8 +1296,7 @@ files_var_filetrans(systemd_update_done_t, systemd_update_run_t, file)
 
 kernel_read_kernel_sysctls(systemd_update_done_t)
 
-selinux_get_enforce_mode(systemd_update_done_t)
-selinux_map_security_files(systemd_update_done_t)
+selinux_use_status_page(systemd_update_done_t)
 
 seutil_read_file_contexts(systemd_update_done_t)
 
@@ -1400,8 +1391,7 @@ fs_relabelfrom_tmpfs_dirs(systemd_user_runtime_dir_t)
 
 kernel_read_kernel_sysctls(systemd_user_runtime_dir_t)
 
-selinux_get_enforce_mode(systemd_user_runtime_dir_t)
-selinux_map_security_files(systemd_user_runtime_dir_t)
+selinux_use_status_page(systemd_user_runtime_dir_t)
 
 systemd_log_parse_environment(systemd_user_runtime_dir_t)
 systemd_dbus_chat_logind(systemd_user_runtime_dir_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -424,6 +424,9 @@ dev_read_sysfs(systemd_hostnamed_t)
 
 files_read_etc_files(systemd_hostnamed_t)
 
+selinux_get_enforce_mode(systemd_hostnamed_t)
+selinux_map_security_files(systemd_hostnamed_t)
+
 seutil_read_file_contexts(systemd_hostnamed_t)
 
 sysnet_etc_filetrans_config(systemd_hostnamed_t)
@@ -454,6 +457,8 @@ files_etc_filetrans(systemd_hw_t, systemd_hwdb_t, file)
 files_search_runtime(systemd_hw_t)
 
 selinux_get_fs_mount(systemd_hw_t)
+selinux_get_enforce_mode(systemd_hw_t)
+selinux_map_security_files(systemd_hw_t)
 
 init_read_state(systemd_hw_t)
 
@@ -468,6 +473,9 @@ seutil_read_file_contexts(systemd_hw_t)
 kernel_read_kernel_sysctls(systemd_locale_t)
 
 files_read_etc_files(systemd_locale_t)
+
+selinux_get_enforce_mode(systemd_locale_t)
+selinux_map_security_files(systemd_locale_t)
 
 seutil_read_file_contexts(systemd_locale_t)
 
@@ -561,6 +569,7 @@ fs_relabelfrom_tmpfs_dirs(systemd_logind_t)
 fs_unmount_tmpfs(systemd_logind_t)
 
 selinux_get_enforce_mode(systemd_logind_t)
+selinux_map_security_files(systemd_logind_t)
 
 storage_getattr_removable_dev(systemd_logind_t)
 storage_getattr_scsi_generic_dev(systemd_logind_t)
@@ -1080,6 +1089,9 @@ corenet_udp_bind_generic_node(systemd_resolved_t)
 corenet_udp_bind_dns_port(systemd_resolved_t)
 corenet_udp_bind_llmnr_port(systemd_resolved_t)
 
+selinux_get_enforce_mode(systemd_resolved_t)
+selinux_map_security_files(systemd_resolved_t)
+
 auth_use_nsswitch(systemd_resolved_t)
 
 files_watch_root_dirs(systemd_resolved_t)
@@ -1113,6 +1125,7 @@ kernel_read_kernel_sysctls(systemd_sessions_t)
 
 selinux_get_enforce_mode(systemd_sessions_t)
 selinux_get_fs_mount(systemd_sessions_t)
+selinux_map_security_files(systemd_sessions_t)
 
 seutil_read_config(systemd_sessions_t)
 seutil_read_default_contexts(systemd_sessions_t)
@@ -1133,6 +1146,9 @@ allow systemd_sysusers_t self:unix_dgram_socket sendto;
 files_manage_etc_files(systemd_sysusers_t)
 
 kernel_read_kernel_sysctls(systemd_sysusers_t)
+
+selinux_get_enforce_mode(systemd_sysusers_t)
+selinux_map_security_files(systemd_sysusers_t)
 
 auth_manage_shadow(systemd_sysusers_t)
 auth_etc_filetrans_shadow(systemd_sysusers_t)
@@ -1202,7 +1218,8 @@ fs_list_tmpfs(systemd_tmpfiles_t)
 fs_relabelfrom_tmpfs_dirs(systemd_tmpfiles_t)
 
 selinux_get_fs_mount(systemd_tmpfiles_t)
-selinux_search_fs(systemd_tmpfiles_t)
+selinux_get_enforce_mode(systemd_tmpfiles_t)
+selinux_map_security_files(systemd_tmpfiles_t)
 
 auth_append_lastlog(systemd_tmpfiles_t)
 auth_manage_faillog(systemd_tmpfiles_t)
@@ -1286,6 +1303,9 @@ files_etc_filetrans(systemd_update_done_t, systemd_update_run_t, file)
 files_var_filetrans(systemd_update_done_t, systemd_update_run_t, file)
 
 kernel_read_kernel_sysctls(systemd_update_done_t)
+
+selinux_get_enforce_mode(systemd_update_done_t)
+selinux_map_security_files(systemd_update_done_t)
 
 seutil_read_file_contexts(systemd_update_done_t)
 
@@ -1381,6 +1401,7 @@ fs_relabelfrom_tmpfs_dirs(systemd_user_runtime_dir_t)
 kernel_read_kernel_sysctls(systemd_user_runtime_dir_t)
 
 selinux_get_enforce_mode(systemd_user_runtime_dir_t)
+selinux_map_security_files(systemd_user_runtime_dir_t)
 
 systemd_log_parse_environment(systemd_user_runtime_dir_t)
 systemd_dbus_chat_logind(systemd_user_runtime_dir_t)


### PR DESCRIPTION
systemd v247 will access the SELinux status page.

see https://github.com/systemd/systemd/pull/16821

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>