### PR TITLE
sysnet: allow dhcpcd to create socket file

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -62,6 +62,7 @@ allow dhcpc_t self:packet_socket create_socket_perms;
 allow dhcpc_t self:netlink_generic_socket create_socket_perms;
 allow dhcpc_t self:netlink_route_socket create_netlink_socket_perms;
 allow dhcpc_t self:rawip_socket create_socket_perms;
+allow dhcpc_t self:unix_dgram_socket { create_socket_perms sendto };
 
 allow dhcpc_t dhcp_etc_t:dir list_dir_perms;
 read_lnk_files_pattern(dhcpc_t, dhcp_etc_t, dhcp_etc_t)
@@ -74,6 +75,7 @@ allow dhcpc_t dhcpc_state_t:file map;
 
 # create pid file
 manage_files_pattern(dhcpc_t, dhcpc_runtime_t, dhcpc_runtime_t)
+manage_sock_files_pattern(dhcpc_t, dhcpc_runtime_t, dhcpc_runtime_t)
 create_dirs_pattern(dhcpc_t, dhcpc_runtime_t, dhcpc_runtime_t)
 files_runtime_filetrans(dhcpc_t, dhcpc_runtime_t, { file dir })
 


### PR DESCRIPTION
The dhcpcd needs to create socket file under /run/dhcpcd directory.

Fixes:
AVC avc:  denied  { create } for  pid=331 comm="dhcpcd" name="eth0.sock"
scontext=system_u:system_r:dhcpc_t:s0-s15:c0.c1023
tcontext=system_u:object_r:dhcpc_runtime_t:s0 tclass=sock_file
permissive=0

AVC avc:  denied  { setattr } for  pid=331 comm="dhcpcd"
name="eth0.sock" dev="tmpfs" ino=19153
scontext=system_u:system_r:dhcpc_t:s0-s15:c0.c1023
tcontext=system_u:object_r:dhcpc_runtime_t:s0 tclass=sock_file
permissive=0

AVC avc:  denied  { sendto } for  pid=331 comm="dhcpcd"
scontext=system_u:system_r:dhcpc_t:s0-s15:c0.c1023
tcontext=system_u:system_r:dhcpc_t:s0-s15:c0.c1023
tclass=unix_dgram_socket permissive=0

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>