### PR TITLE
Allow snmpd to read hwdata

### DIFF
--- a/policy/modules/services/snmp.te
+++ b/policy/modules/services/snmp.te
@@ -108,6 +108,7 @@ init_dontaudit_write_utmp(snmpd_t)
 
 logging_send_syslog_msg(snmpd_t)
 
+miscfiles_read_hwdata(snmpd_t)
 miscfiles_read_localization(snmpd_t)
 
 seutil_dontaudit_search_config(snmpd_t)


### PR DESCRIPTION
Oct  1 16:11:49 localhost audispd: node=virtual type=AVC msg=audit(1601568708.950:2198): avc:  denied  { getattr } for  pid=4114 comm="snmpd" path="/usr/share/hwdata/pci.ids" dev="dm-0" ino=76435 scontext=system_u:system_r:snmpd_t:s0 tcontext=system_u:object_r:hwdata_t:s0 tclass=file permissive=1
Oct  1 16:11:49 localhost audispd: node=virtual type=AVC msg=audit(1601568708.950:2197): avc:  denied  { read } for  pid=4114 comm="snmpd" name="pci.ids" dev="dm-0" ino=76435 scontext=system_u:system_r:snmpd_t:s0 tcontext=system_u:object_r:hwdata_t:s0 tclass=file permissive=1
Oct  1 16:11:49 localhost audispd: node=virtual type=AVC msg=audit(1601568708.950:2197): avc:  denied  { open } for  pid=4114 comm="snmpd" path="/usr/share/hwdata/pci.ids" dev="dm-0" ino=76435 scontext=system_u:system_r:snmpd_t:s0 tcontext=system_u:object_r:hwdata_t:s0 tclass=file permissive=1

Signed-off-by: Dave Sugar <dsugar100@gmail.com>