### PR TITLE
Corosync & pacemaker changes to work in enforcing

### DIFF
--- a/policy/modules/services/corosync.fc
+++ b/policy/modules/services/corosync.fc
@@ -6,7 +6,14 @@
 /usr/sbin/corosync	--	gen_context(system_u:object_r:corosync_exec_t,s0)
 /usr/sbin/corosync-notifyd	--	gen_context(system_u:object_r:corosync_exec_t,s0)
 
+ifdef(`distro_redhat',`
+/usr/share/corosync/corosync			--	gen_context(system_u:object_r:corosync_exec_t,s0)
+/usr/share/corosync/corosync-notifyd	--	gen_context(system_u:object_r:corosync_exec_t,s0)
+')
+
 /var/lib/corosync(/.*)?	gen_context(system_u:object_r:corosync_var_lib_t,s0)
+
+/var/lock/subsys/corosync	--	gen_context(system_u:object_r:corosync_lock_t,s0)
 
 /var/log/cluster/corosync\.log.*	--	gen_context(system_u:object_r:corosync_var_log_t,s0)
 

--- a/policy/modules/services/corosync.if
+++ b/policy/modules/services/corosync.if
@@ -99,6 +99,25 @@ interface(`corosync_stream_connect',`
 
 ######################################
 ## <summary>
+##	Memmap, read and write corosync tmpfs files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`corosync_mmap_rw_tmpfs',`
+	gen_require(`
+		type corosync_tmpfs_t;
+	')
+
+	fs_search_tmpfs($1)
+	mmap_rw_files_pattern($1, corosync_tmpfs_t, corosync_tmpfs_t)
+')
+
+######################################
+## <summary>
 ##	Read and write corosync tmpfs files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/corosync.te
+++ b/policy/modules/services/corosync.te
@@ -13,6 +13,9 @@ domain_obj_id_change_exemption(corosync_t)
 type corosync_initrc_exec_t;
 init_script_file(corosync_initrc_exec_t)
 
+type corosync_lock_t;
+files_lock_file(corosync_lock_t)
+
 type corosync_runtime_t alias corosync_var_run_t;
 files_runtime_file(corosync_runtime_t)
 
@@ -43,6 +46,9 @@ allow corosync_t self:shm create_shm_perms;
 allow corosync_t self:unix_dgram_socket sendto;
 allow corosync_t self:unix_stream_socket { accept connectto listen };
 
+manage_files_pattern(corosync_t, corosync_lock_t, corosync_lock_t)
+files_lock_filetrans(corosync_t, corosync_lock_t, file)
+
 manage_dirs_pattern(corosync_t, corosync_tmp_t, corosync_tmp_t)
 manage_files_pattern(corosync_t, corosync_tmp_t, corosync_tmp_t)
 relabel_files_pattern(corosync_t, corosync_tmp_t, corosync_tmp_t)
@@ -50,6 +56,7 @@ files_tmp_filetrans(corosync_t, corosync_tmp_t, { dir file })
 
 manage_dirs_pattern(corosync_t, corosync_tmpfs_t, corosync_tmpfs_t)
 manage_files_pattern(corosync_t, corosync_tmpfs_t, corosync_tmpfs_t)
+mmap_read_files_pattern(corosync_t, corosync_tmpfs_t, corosync_tmpfs_t)
 fs_tmpfs_filetrans(corosync_t, corosync_tmpfs_t, { dir file })
 
 manage_files_pattern(corosync_t, corosync_var_lib_t, corosync_var_lib_t)

--- a/policy/modules/services/pacemaker.fc
+++ b/policy/modules/services/pacemaker.fc
@@ -9,3 +9,4 @@
 /var/lib/pengine(/.*)?	gen_context(system_u:object_r:pacemaker_var_lib_t,s0)
 
 /run/crm(/.*)?	gen_context(system_u:object_r:pacemaker_runtime_t,s0)
+/run/resource-agents(/.*)?		gen_context(system_u:object_r:pacemaker_runtime_t,s0)

--- a/policy/modules/services/pacemaker.te
+++ b/policy/modules/services/pacemaker.te
@@ -121,6 +121,7 @@ tunable_policy(`pacemaker_startstop_all_services',`
 
 optional_policy(`
 	corosync_read_log(pacemaker_t)
+	corosync_mmap_rw_tmpfs(pacemaker_t)
 	corosync_stream_connect(pacemaker_t)
 ')
 

--- a/policy/modules/services/pacemaker.te
+++ b/policy/modules/services/pacemaker.te
@@ -5,6 +5,13 @@ policy_module(pacemaker, 1.6.0)
 # Declarations
 #
 
+## <desc>
+## <p>
+## Allow pacemaker to start/stop services
+## </p>
+## </desc>
+gen_tunable(pacemaker_startstop_all_services, false)
+
 type pacemaker_t;
 type pacemaker_exec_t;
 init_daemon_domain(pacemaker_t, pacemaker_exec_t)
@@ -17,6 +24,9 @@ logging_log_file(pacemaker_log_t)
 
 type pacemaker_runtime_t alias pacemaker_var_run_t;
 files_runtime_file(pacemaker_runtime_t)
+
+type pacemaker_runtime_unit_t;
+init_unit_file(pacemaker_runtime_unit_t)
 
 type pacemaker_tmp_t;
 files_tmp_file(pacemaker_tmp_t)
@@ -61,6 +71,10 @@ manage_dirs_pattern(pacemaker_t, pacemaker_runtime_t, pacemaker_runtime_t)
 manage_files_pattern(pacemaker_t, pacemaker_runtime_t, pacemaker_runtime_t)
 files_runtime_filetrans(pacemaker_t, pacemaker_runtime_t, { dir file })
 
+manage_dirs_pattern(pacemaker_t, pacemaker_runtime_unit_t, pacemaker_runtime_unit_t)
+manage_files_pattern(pacemaker_t, pacemaker_runtime_unit_t, pacemaker_runtime_unit_t)
+init_runtime_filetrans(pacemaker_t, pacemaker_runtime_unit_t, { dir file })
+
 kernel_getattr_core_if(pacemaker_t)
 kernel_read_all_sysctls(pacemaker_t)
 kernel_read_messages(pacemaker_t)
@@ -94,6 +108,16 @@ libs_exec_lib_files(pacemaker_t)
 logging_send_syslog_msg(pacemaker_t)
 
 miscfiles_read_localization(pacemaker_t)
+
+ifdef(`init_systemd',`
+	init_get_all_units_status(pacemaker_t)
+	init_reload(pacemaker_t)
+')
+
+tunable_policy(`pacemaker_startstop_all_services',`
+	init_start_all_units(pacemaker_t)
+	init_stop_all_units(pacemaker_t)
+')
 
 optional_policy(`
 	corosync_read_log(pacemaker_t)

--- a/policy/modules/services/pacemaker.te
+++ b/policy/modules/services/pacemaker.te
@@ -12,6 +12,9 @@ init_daemon_domain(pacemaker_t, pacemaker_exec_t)
 type pacemaker_initrc_exec_t;
 init_script_file(pacemaker_initrc_exec_t)
 
+type pacemaker_log_t;
+logging_log_file(pacemaker_log_t)
+
 type pacemaker_runtime_t alias pacemaker_var_run_t;
 files_runtime_file(pacemaker_runtime_t)
 
@@ -29,15 +32,23 @@ files_type(pacemaker_var_lib_t)
 # Local policy
 #
 
-allow pacemaker_t self:capability { chown dac_override fowner fsetid kill setuid };
-allow pacemaker_t self:process { setrlimit signal setpgid };
+allow pacemaker_t self:capability { chown dac_override fowner fsetid kill net_raw setgid setuid };
+allow pacemaker_t self:process { getsched getcap setcap setpgid setrlimit setsched signal signull };
 allow pacemaker_t self:fifo_file rw_fifo_file_perms;
+allow pacemaker_t self:packet_socket { bind create getattr read write };
 allow pacemaker_t self:unix_stream_socket { connectto accept listen };
+
+create_files_pattern(pacemaker_t, pacemaker_log_t, pacemaker_log_t)
+append_files_pattern(pacemaker_t, pacemaker_log_t, pacemaker_log_t)
+setattr_files_pattern(pacemaker_t, pacemaker_log_t, pacemaker_log_t)
+read_files_pattern(pacemaker_t, pacemaker_log_t, pacemaker_log_t)
+logging_log_filetrans(pacemaker_t, pacemaker_log_t, file)
 
 manage_dirs_pattern(pacemaker_t, pacemaker_tmp_t, pacemaker_tmp_t)
 manage_files_pattern(pacemaker_t, pacemaker_tmp_t, pacemaker_tmp_t)
 files_tmp_filetrans(pacemaker_t, pacemaker_tmp_t, { file dir })
 
+mmap_rw_files_pattern(pacemaker_t, pacemaker_tmpfs_t, pacemaker_tmpfs_t)
 manage_dirs_pattern(pacemaker_t, pacemaker_tmpfs_t, pacemaker_tmpfs_t)
 manage_files_pattern(pacemaker_t, pacemaker_tmpfs_t, pacemaker_tmpfs_t)
 fs_tmpfs_filetrans(pacemaker_t, pacemaker_tmpfs_t, { dir file })
@@ -60,6 +71,8 @@ kernel_read_system_state(pacemaker_t)
 corecmd_exec_bin(pacemaker_t)
 corecmd_exec_shell(pacemaker_t)
 
+corenet_udp_bind_generic_node(pacemaker_t)
+
 dev_getattr_mtrr_dev(pacemaker_t)
 dev_read_rand(pacemaker_t)
 dev_read_urand(pacemaker_t)
@@ -68,10 +81,15 @@ domain_read_all_domains_state(pacemaker_t)
 domain_use_interactive_fds(pacemaker_t)
 
 files_read_kernel_symbol_table(pacemaker_t)
+files_read_usr_files(pacemaker_t)
 
 fs_getattr_all_fs(pacemaker_t)
 
 auth_use_nsswitch(pacemaker_t)
+
+init_dbus_chat(pacemaker_t)
+
+libs_exec_lib_files(pacemaker_t)
 
 logging_send_syslog_msg(pacemaker_t)
 
@@ -80,4 +98,16 @@ miscfiles_read_localization(pacemaker_t)
 optional_policy(`
 	corosync_read_log(pacemaker_t)
 	corosync_stream_connect(pacemaker_t)
+')
+
+optional_policy(`
+	dbus_system_bus_client(pacemaker_t)
+')
+
+optional_policy(`
+	netutils_exec(pacemaker_t)
+')
+
+optional_policy(`
+	sysnet_domtrans_ifconfig(pacemaker_t)
 ')


### PR DESCRIPTION
Sorry for so many related patches.  But I think it will be easier to review and comment on and to see why some of things are being proposed.

I'm happy to squash into a single commit once everything is ready to be merged.

I think the controversial pieces are going to be the proposed interface init_filetrans_unit which is to dynamically create directories/files in systemd_unit_t directories with a filetrans to a new type (intended for /run/systemd/system/ ) so the domain creating unit files (pacemaker in this case) don't need to have full read/write access to all systemd_unit_t files.

 The other one is the new interface corosync_mmap_rw_tmpfs which is to map/read/write corosync tmpfs file.  I thought it was better than changing the existing corosync_rw_tmpfs interface.  Though thinking about it now, it might be more standard to just add a new interface to grant map permission only.  

Signed-off-by: Dave Sugar <dsugar@tresys.com>