### PR TITLE
Add selinux-policy for systemd-pstore service

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -4501,6 +4501,32 @@ interface(`dev_read_sysfs',`
 
 ########################################
 ## <summary>
+##	Write to hardware state information.
+## </summary>
+## <desc>
+##	<p>
+##	Allow the specified domain to write to the sysfs
+##	filesystem.
+##	</p>
+## </desc>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <infoflow type="read" weight="10"/>
+#
+interface(`dev_write_sysfs',`
+	gen_require(`
+		type sysfs_t;
+	')
+
+	list_dirs_pattern($1, sysfs_t, sysfs_t)
+	write_files_pattern($1, sysfs_t, sysfs_t)
+')
+
+########################################
+## <summary>
 ##	Allow caller to modify hardware state information.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -3870,6 +3870,64 @@ interface(`fs_relabel_pstore_dirs',`
 
 ########################################
 ## <summary>
+##	List the directories
+##	of a pstore filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_list_pstore_dirs',`
+	gen_require(`
+		type pstore_t;
+	')
+
+	allow $1 pstore_t:dir list_dir_perms;
+	dev_search_sysfs($1)
+')
+
+########################################
+## <summary>
+##	Read pstore_t files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_read_pstore_files',`
+	gen_require(`
+		type pstore_t;
+	')
+
+	allow $1 pstore_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Delete the files
+##	of a pstore filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_delete_pstore_files',`
+	gen_require(`
+		type pstore_t;
+	')
+
+	delete_files_pattern($1, pstore_t, pstore_t)
+	dev_search_sysfs($1)
+')
+
+########################################
+## <summary>
 ##	Allow the type to associate to ramfs filesystems.
 ## </summary>
 ## <param name="type">

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -35,6 +35,7 @@
 /usr/lib/systemd/systemd-machined	--	gen_context(system_u:object_r:systemd_machined_exec_t,s0)
 /usr/lib/systemd/systemd-modules-load	--	gen_context(system_u:object_r:systemd_modules_load_exec_t,s0)
 /usr/lib/systemd/systemd-networkd	--	gen_context(system_u:object_r:systemd_networkd_exec_t,s0)
+/usr/lib/systemd/systemd-pstore		--	gen_context(system_u:object_r:systemd_pstore_exec_t,s0)
 /usr/lib/systemd/systemd-resolved	--	gen_context(system_u:object_r:systemd_resolved_exec_t,s0)
 /usr/lib/systemd/systemd-rfkill		--	gen_context(system_u:object_r:systemd_rfkill_exec_t,s0)
 /usr/lib/systemd/systemd-update-done	--	gen_context(system_u:object_r:systemd_update_done_exec_t,s0)
@@ -59,6 +60,7 @@
 /var/lib/systemd/backlight(/.*)?	gen_context(system_u:object_r:systemd_backlight_var_lib_t,s0)
 /var/lib/systemd/coredump(/.*)?	gen_context(system_u:object_r:systemd_coredump_var_lib_t,s0)
 /var/lib/systemd/linger(/.*)?	gen_context(system_u:object_r:systemd_logind_var_lib_t,s0)
+/var/lib/systemd/pstore(/.*)?	gen_context(system_u:object_r:systemd_pstore_var_lib_t,s0)
 /var/lib/systemd/rfkill(/.*)?	gen_context(system_u:object_r:systemd_rfkill_var_lib_t,s0)
 
 /run/\.nologin[^/]*	--	gen_context(system_u:object_r:systemd_sessions_runtime_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -168,6 +168,13 @@ files_runtime_file(systemd_nspawn_runtime_t)
 type systemd_nspawn_tmp_t;
 files_tmp_file(systemd_nspawn_tmp_t)
 
+type systemd_pstore_t;
+type systemd_pstore_exec_t;
+init_system_domain(systemd_pstore_t, systemd_pstore_exec_t)
+
+type systemd_pstore_var_lib_t;
+files_type(systemd_pstore_var_lib_t)
+
 type systemd_resolved_t;
 type systemd_resolved_exec_t;
 init_system_domain(systemd_resolved_t, systemd_resolved_exec_t)
@@ -1168,6 +1175,9 @@ allow systemd_tmpfiles_t self:process { setfscreate getcap };
 allow systemd_tmpfiles_t systemd_coredump_var_lib_t:dir { manage_dir_perms relabel_dir_perms };
 allow systemd_tmpfiles_t systemd_coredump_var_lib_t:file manage_file_perms;
 
+allow systemd_tmpfiles_t systemd_pstore_var_lib_t:dir { manage_dir_perms relabel_dir_perms };
+allow systemd_tmpfiles_t systemd_pstore_var_lib_t:file manage_file_perms;
+
 allow systemd_tmpfiles_t systemd_sessions_runtime_t:file { manage_file_perms relabel_file_perms };
 
 manage_dirs_pattern(systemd_tmpfiles_t, systemd_journal_t, systemd_journal_t)
@@ -1187,6 +1197,10 @@ dev_manage_all_dev_nodes(systemd_tmpfiles_t)
 dev_read_urand(systemd_tmpfiles_t)
 dev_relabel_all_sysfs(systemd_tmpfiles_t)
 dev_setattr_all_sysfs(systemd_tmpfiles_t)
+# Allow systemd-tmpfiles to enable pstore kernel parameters over sysfs
+# /sys/module/printk/parameters/always_kmsg_dump
+# /sys/module/kernel/parameters/crash_kexec_post_notifiers
+dev_write_sysfs(systemd_tmpfiles_t)
 
 files_create_lock_dirs(systemd_tmpfiles_t)
 files_manage_all_runtime_dirs(systemd_tmpfiles_t)
@@ -1411,3 +1425,26 @@ userdom_mounton_user_runtime_dirs(systemd_user_runtime_dir_t)
 userdom_relabelto_user_runtime_dirs(systemd_user_runtime_dir_t)
 
 dbus_system_bus_client(systemd_user_runtime_dir_t)
+
+#########################################
+#
+# systemd-pstore local policy
+#
+
+dontaudit systemd_pstore_t self:capability net_admin;
+
+manage_files_pattern(systemd_pstore_t, systemd_pstore_var_lib_t, systemd_pstore_var_lib_t)
+
+files_read_etc_files(systemd_pstore_t)
+files_search_var_lib(systemd_pstore_t)
+
+fs_list_pstore_dirs(systemd_pstore_t)
+fs_read_pstore_files(systemd_pstore_t)
+fs_delete_pstore_files(systemd_pstore_t)
+
+init_search_run(systemd_pstore_t)
+init_list_var_lib_dirs(systemd_pstore_t)
+
+kernel_read_system_state(systemd_pstore_t)
+
+logging_send_syslog_msg(systemd_pstore_t)


### PR DESCRIPTION
systemd-pstore is a service to archive contents of pstore.

Signed-off-by: Deepak Rawat <drawat.floss@gmail.com>