### PR TITLE
More fixes for systemd systems generated with Buildroot

### DIFF
--- a/policy/modules/services/ntp.te
+++ b/policy/modules/services/ntp.te
@@ -139,6 +139,8 @@ userdom_dontaudit_use_unpriv_user_fds(ntpd_t)
 userdom_list_user_home_dirs(ntpd_t)
 
 ifdef(`init_systemd',`
+	allow ntpd_t self:process setfscreate;
+
 	allow ntpd_t ntpd_unit_t:file read_file_perms;
 
 	dbus_system_bus_client(ntpd_t)

--- a/policy/modules/services/ntp.te
+++ b/policy/modules/services/ntp.te
@@ -143,6 +143,8 @@ ifdef(`init_systemd',`
 
 	dbus_system_bus_client(ntpd_t)
 	dbus_connect_system_bus(ntpd_t)
+	dbus_watch_system_bus_runtime_dirs(ntpd_t)
+	dbus_watch_system_bus_runtime_named_sockets(ntpd_t)
 	init_dbus_chat(ntpd_t)
 	init_get_system_status(ntpd_t)
 	init_list_unit_dirs(ntpd_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -402,6 +402,8 @@ storage_raw_read_fixed_disk(systemd_generator_t)
 
 systemd_log_parse_environment(systemd_generator_t)
 
+term_use_unallocated_ttys(systemd_generator_t)
+
 optional_policy(`
 	fstools_exec(systemd_generator_t)
 ')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -787,6 +787,7 @@ dev_write_kmsg(systemd_networkd_t)
 files_read_etc_files(systemd_networkd_t)
 files_watch_runtime_dirs(systemd_networkd_t)
 files_watch_root_dirs(systemd_networkd_t)
+files_list_runtime(systemd_networkd_t)
 fs_getattr_xattr_fs(systemd_networkd_t)
 
 auth_use_nsswitch(systemd_networkd_t)


### PR DESCRIPTION
Hello,

This PR includes more fixes needed to get a working systemd image generated with [Buildroot](https://buildroot.org/). All the fixes are related to systemd, except the last patch. Those changes should also benefit to other build systems such as OE/Yocto.

Thanks!
Antoine