### PR TITLE
access_vectors: Add new capabilities to cap2

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -132,7 +132,7 @@ common x_device
 #
 common cap
 {
-	# The capabilities are defined in include/linux/capability.h
+	# The capabilities are defined in include/uapi/linux/capability.h
 	# Capabilities >= 32 are defined in the cap2 common.
 	# Care should be taken to ensure that these are consistent with
 	# those definitions. (Order matters)
@@ -179,6 +179,9 @@ common cap2
 	wake_alarm
 	block_suspend
 	audit_read
+	perfmon
+	bpf
+	checkpoint_restore
 }
 
 #


### PR DESCRIPTION
Updated location of capability definitions to point to current location within kernel source code.

CAP_BPF and CAP_PERFMON mainlined in: cb8e59cc87201af93dfbb6c3dccc8fcad72a09c2, original commit: a17b53c4a4b55ec322c132b6670743612229ee9c
CAP_CHECKPOINT_RESTORE mainlined in: 74858abbb1032222f922487fd1a24513bbed80f9, original commit: 124ea650d3072b005457faed69909221c2905a1f

The missing capabilities were noticed on archlinux with kernel 5.8.14-arch1-1.