### PR TITLE
added policy for systemd-socket-proxyd

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -359,12 +359,15 @@ interface(`init_daemon_domain',`
 		init_domain($1, $2)
 
 		allow $1 init_t:unix_dgram_socket sendto;
+
+		optional_policy(`
+			systemd_connectto_socket_proxyd_unix_sockets($1)
+		')
 	')
 
 	optional_policy(`
 		nscd_use($1)
 	')
-
 ')
 
 ########################################

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -38,6 +38,7 @@
 /usr/lib/systemd/systemd-pstore		--	gen_context(system_u:object_r:systemd_pstore_exec_t,s0)
 /usr/lib/systemd/systemd-resolved	--	gen_context(system_u:object_r:systemd_resolved_exec_t,s0)
 /usr/lib/systemd/systemd-rfkill		--	gen_context(system_u:object_r:systemd_rfkill_exec_t,s0)
+/usr/lib/systemd/systemd-socket-proxyd	--	gen_context(system_u:object_r:systemd_socket_proxyd_exec_t,s0)
 /usr/lib/systemd/systemd-update-done	--	gen_context(system_u:object_r:systemd_update_done_exec_t,s0)
 /usr/lib/systemd/systemd-user-runtime-dir	--	gen_context(system_u:object_r:systemd_user_runtime_dir_exec_t,s0)
 /usr/lib/systemd/systemd-user-sessions	--	gen_context(system_u:object_r:systemd_sessions_exec_t,s0)
@@ -54,6 +55,7 @@
 /usr/lib/systemd/system/systemd-binfmt.*	--	gen_context(system_u:object_r:systemd_binfmt_unit_t,s0)
 /usr/lib/systemd/system/systemd-networkd.*		gen_context(system_u:object_r:systemd_networkd_unit_t,s0)
 /usr/lib/systemd/system/systemd-rfkill.*	--	gen_context(system_u:object_r:systemd_rfkill_unit_t,s0)
+/usr/lib/systemd/system/systemd-socket-proxyd\.service	--	gen_context(system_u:object_r:systemd_socket_proxyd_unit_file_t,s0)
 
 /var/\.updated				--	gen_context(system_u:object_r:systemd_update_run_t,s0)
 

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -888,6 +888,24 @@ interface(`systemd_status_power_units',`
 
 ########################################
 ## <summary>
+##  Allows connections to the systemd-socket-proxyd's socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_connectto_socket_proxyd_unix_sockets', `
+	gen_require(`
+		type systemd_socket_proxyd_t;
+	')
+
+	allow $1 systemd_socket_proxyd_t:unix_stream_socket connectto;
+')
+
+########################################
+## <summary>
 ##	Make the specified type usable for
 ##	systemd tmpfiles config files.
 ## </summary>

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -29,6 +29,22 @@ gen_tunable(systemd_nspawn_labeled_namespace, false)
 ## </desc>
 gen_tunable(systemd_logind_get_bootloader, false)
 
+## <desc>
+## <p>
+## Allow systemd-socket-proxyd to bind any port instead of one labelled
+## with systemd_socket_proxyd_port_t.
+## </p>
+## </desc>
+gen_tunable(systemd_socket_proxyd_bind_any, false)
+
+## <desc>
+## <p>
+## Allow systemd-socket-proxyd to connect to any port instead of
+## labelled ones.
+## </p>
+## </desc>
+gen_tunable(systemd_socket_proxyd_connect_any, false)
+
 attribute systemd_log_parse_env_type;
 attribute systemd_tmpfiles_conf_type;
 attribute systemd_user_session_type;
@@ -216,6 +232,16 @@ type systemd_sessions_runtime_t alias systemd_sessions_var_run_t;
 files_runtime_file(systemd_sessions_runtime_t)
 init_daemon_runtime_file(systemd_sessions_runtime_t, dir, "systemd_sessions")
 init_mountpoint(systemd_sessions_runtime_t)
+
+type systemd_socket_proxyd_t;
+type systemd_socket_proxyd_exec_t;
+init_daemon_domain(systemd_socket_proxyd_t, systemd_socket_proxyd_exec_t)
+
+type systemd_socket_proxyd_port_t;
+corenet_port(systemd_socket_proxyd_port_t)
+
+type systemd_socket_proxyd_unit_file_t;
+init_unit_file(systemd_socket_proxyd_unit_file_t)
 
 type systemd_sysusers_t;
 type systemd_sysusers_exec_t;
@@ -1143,6 +1169,32 @@ optional_policy(`
 	dbus_watch_system_bus_runtime_dirs(systemd_resolved_t)
 	dbus_watch_system_bus_runtime_named_sockets(systemd_resolved_t)
 ')
+
+#########################################
+#
+# Socket-proxyd local policy
+#
+
+allow systemd_socket_proxyd_t self:unix_dgram_socket { create create_socket_perms getopt setopt sendto read write };
+allow systemd_socket_proxyd_t self:tcp_socket accept;
+
+kernel_read_system_state(systemd_socket_proxyd_t)
+
+auth_use_nsswitch(systemd_socket_proxyd_t)
+sysnet_dns_name_resolve(systemd_socket_proxyd_t)
+
+tunable_policy(`systemd_socket_proxyd_bind_any',`
+ corenet_tcp_bind_all_ports(systemd_socket_proxyd_t)
+',`
+ allow systemd_socket_proxyd_t systemd_socket_proxyd_port_t:tcp_socket name_bind;
+')
+
+tunable_policy(`systemd_socket_proxyd_connect_any',`
+ corenet_tcp_connect_all_ports(systemd_socket_proxyd_t)
+',`
+ allow systemd_socket_proxyd_t systemd_socket_proxyd_port_t:tcp_socket name_connect;
+')
+
 
 #########################################
 #


### PR DESCRIPTION
People are stumbling upon a tool provided by systemd that does not work on a SELinux enabled system due to a missing policy for the tool (e.g. https://bugzilla.redhat.com/show_bug.cgi?id=1868949).  I am using the proposed rules for [3 years now](https://dmitry.khlebnikov.net/2017/01/13/nginx-a-backend-with-a-dynamic-ip-eg-aws-elb/), so decided to contribute back to a wider community :).