### PR TITLE
Add LVM module permissions needed to open cryptsetup devices.

### DIFF
--- a/policy/modules/system/lvm.te
+++ b/policy/modules/system/lvm.te
@@ -177,6 +177,8 @@ allow lvm_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow lvm_t self:sem create_sem_perms;
 # gt: the following is for sockets in the AF_ALG namespace (userspace interface to the kernel Crypto API)
 allow lvm_t self:socket create_stream_socket_perms;
+# gt: the following allows opening cryptsetup devices
+allow lvm_t self:key { search write };
 
 allow lvm_t self:unix_stream_socket { connectto create_stream_socket_perms };
 allow lvm_t clvmd_t:unix_stream_socket { connectto rw_socket_perms };


### PR DESCRIPTION
Add LVM module permissions needed to open cryptsetup devices.
---
 policy/modules/system/lvm.te |    2 ++
 1 file changed, 2 insertions(+)