### PR TITLE
Allow init to mount over the system bus

### DIFF
--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -50,6 +50,7 @@ init_named_socket_activation(system_dbusd_t, system_dbusd_runtime_t)
 type system_dbusd_runtime_t alias system_dbusd_var_run_t;
 files_runtime_file(system_dbusd_runtime_t)
 init_daemon_runtime_file(system_dbusd_runtime_t, dir, "dbus")
+init_mountpoint(system_dbusd_runtime_t)
 
 type system_dbusd_tmp_t;
 files_tmp_file(system_dbusd_tmp_t)


### PR DESCRIPTION
In portable profiles, systemd bind mounts the system bus into process
namespaces

Signed-off-by: Daniel Burgener <Daniel.Burgener@microsoft.com>