### PR TITLE
Remove systemd-analyze domain and executable type

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -5,7 +5,6 @@
 
 /run/log/journal(/.*)?				gen_context(system_u:object_r:systemd_journal_t,s0)
 
-/usr/bin/systemd-analyze		--	gen_context(system_u:object_r:systemd_analyze_exec_t,s0)
 /usr/bin/systemd-cgtop			--	gen_context(system_u:object_r:systemd_cgtop_exec_t,s0)
 /usr/bin/systemd-coredump		--	gen_context(system_u:object_r:systemd_coredump_exec_t,s0)
 /usr/bin/systemd-detect-virt		--	gen_context(system_u:object_r:systemd_detect_virt_exec_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -24,7 +24,7 @@ template(`systemd_role_template',`
 	gen_require(`
 		attribute systemd_user_session_type, systemd_log_parse_env_type;
 		type systemd_user_runtime_t, systemd_user_runtime_notify_t;
-		type systemd_run_exec_t, systemd_analyze_exec_t;
+		type systemd_run_exec_t;
 	')
 
 	#################################
@@ -63,7 +63,7 @@ template(`systemd_role_template',`
 	# systemctl --user
 	stream_connect_pattern($3, systemd_user_runtime_t, systemd_user_runtime_t, $1_systemd_t)
 
-	can_exec($3, { systemd_run_exec_t systemd_analyze_exec_t })
+	can_exec($3, systemd_run_exec_t)
 
 	dbus_system_bus_client($1_systemd_t)
 ')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -39,10 +39,6 @@ type systemd_activate_t;
 type systemd_activate_exec_t;
 init_system_domain(systemd_activate_t, systemd_activate_exec_t)
 
-type systemd_analyze_t;
-type systemd_analyze_exec_t;
-init_daemon_domain(systemd_analyze_t, systemd_analyze_exec_t)
-
 type systemd_backlight_t;
 type systemd_backlight_exec_t;
 init_system_domain(systemd_backlight_t, systemd_backlight_exec_t)


### PR DESCRIPTION
The systemd-analyze domain has no unique permissions, and general usage seems to be to simply run in the caller domain.  Running in the caller domain makes sense because the access required is generally the access to read the information that systemd-analyze reads.  If the calling domain should be able to read the information it makes sense to grant it directly.

Signed-off-by: Daniel Burgener <dburgener@linux.microsoft.com>