### PR TITLE
Allow systemd-modules-load to search kernel keys

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -512,6 +512,7 @@ if( ! secure_mode_insmod ) {
 	# gt: there seems to be no trace of the above, at
 	# least in kernel versions greater than 2.6.37...
 	allow can_load_kernmodule self:capability sys_nice;
+	kernel_search_key(can_load_kernmodule)
 	kernel_setsched(can_load_kernmodule)
 }
 

--- a/policy/modules/system/modutils.te
+++ b/policy/modules/system/modutils.te
@@ -60,7 +60,6 @@ kernel_write_proc_files(kmod_t)
 kernel_mount_debugfs(kmod_t)
 kernel_mount_kvmfs(kmod_t)
 kernel_read_debugfs(kmod_t)
-kernel_search_key(kmod_t)
 # Rules for /proc/sys/kernel/tainted
 kernel_read_kernel_sysctls(kmod_t)
 kernel_rw_kernel_sysctl(kmod_t)


### PR DESCRIPTION
I was seeing the following errors from systemd-modules-load without this search permission.

Dec  7 14:36:19 systemd-modules-load: Failed to insert 'nf_conntrack_ftp': Required key not available
Dec  7 14:36:19 kernel: Request for unknown module key 'Red Hat Enterprise Linux kernel signing key: 3ffb026dadef6e0bc404752a7e7c29095a68eab7' err -13
Dec  7 14:36:19 systemd: systemd-modules-load.service: main process exited, code=exited, status=1/FAILURE
Dec  7 14:36:19 audispd: node=loacalhost type=PROCTITLE msg=audit(1607351779.441:3259): proctitle="/usr/lib/systemd/systemd-modules-load"
Dec  7 14:36:19 systemd: Failed to start Load Kernel Modules.

This is the denial:

Dec  7 15:56:52 audispd: node=localhost type=AVC msg=audit(1607356612.877:3815): avc:  denied { search } for  pid=11715 comm="systemd-modules" scontext=system_u:system_r:systemd_modules_load_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=key permissive=1

Signed-off-by: Dave Sugar <dsugar@tresys.com>