### PR TITLE
selinux: add selinux_get_all_booleans() interface

### DIFF
--- a/policy/modules/kernel/selinux.if
+++ b/policy/modules/kernel/selinux.if
@@ -446,6 +446,30 @@ interface(`selinux_set_all_booleans',`
 
 ########################################
 ## <summary>
+##  Allow caller to get the state of all Booleans to
+##  view conditional portions of the policy.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+## <rolecap/>
+#
+interface(`selinux_get_all_booleans',`
+	gen_require(`
+		type security_t;
+		attribute boolean_type;
+	')
+
+	dev_search_sysfs($1)
+
+	allow $1 security_t:dir list_dir_perms;
+	allow $1 boolean_type:file read_file_perms;
+')
+
+########################################
+## <summary>
 ##	Allow caller to set SELinux access vector cache parameters.
 ## </summary>
 ## <desc>


### PR DESCRIPTION
Allow the caller to read the state of selinuxfs booleans.

Signed-off-by: Peter Morrow <pemorrow@linux.microsoft.com>