### PR TITLE
Use self keyword when an AV rule source type matches destination

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -263,7 +263,7 @@ kernel_mounton_proc_dirs(kernel_t)
 kernel_request_load_module(kernel_t)
 
 # Allow unlabeled network traffic
-allow unlabeled_t unlabeled_t:packet { forward_in forward_out };
+allow unlabeled_t self:packet { forward_in forward_out };
 corenet_in_generic_if(unlabeled_t)
 corenet_in_generic_node(unlabeled_t)
 

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -787,9 +787,9 @@ tunable_policy(`!xserver_object_manager',`
 	# should be xserver_unconfined(xserver_t),
 	# but typeattribute doesnt work in conditionals
 
-	allow xserver_t xserver_t:x_server { getattr setattr record debug grab manage };
+	allow xserver_t self:x_server { getattr setattr record debug grab manage };
 	allow xserver_t { x_domain root_xdrawable_t }:x_drawable { create destroy read write blend getattr setattr list_child add_child remove_child list_property get_property set_property manage override show hide send receive };
-	allow xserver_t xserver_t:x_screen { getattr setattr hide_cursor show_cursor saver_getattr saver_setattr saver_hide saver_show };
+	allow xserver_t self:x_screen { getattr setattr hide_cursor show_cursor saver_getattr saver_setattr saver_hide saver_show };
 	allow xserver_t x_domain:x_gc { create destroy getattr setattr use };
 	allow xserver_t { x_domain root_xcolormap_t }:x_colormap { create destroy read write getattr add_color remove_color install uninstall use };
 	allow xserver_t xproperty_type:x_property { create destroy read write append getattr setattr };


### PR DESCRIPTION
This is reported in a new SELint check in soon to be released selint version 1.2.0

Signed-off-by: Daniel Burgener <dburgener@linux.microsoft.com>