### PR TITLE
Mc/nsswitch usage

### DIFF
--- a/policy/modules/system/getty.te
+++ b/policy/modules/system/getty.te
@@ -84,6 +84,7 @@ term_setattr_unallocated_ttys(getty_t)
 term_setattr_console(getty_t)
 
 auth_rw_login_records(getty_t)
+auth_use_nsswitch(getty_t)
 
 init_rw_utmp(getty_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1322,6 +1322,7 @@ auth_manage_var_auth(systemd_tmpfiles_t)
 auth_relabel_lastlog(systemd_tmpfiles_t)
 auth_relabel_login_records(systemd_tmpfiles_t)
 auth_setattr_login_records(systemd_tmpfiles_t)
+auth_use_nsswitch(systemd_tmpfiles_t)
 
 init_manage_utmp(systemd_tmpfiles_t)
 init_manage_var_lib_files(systemd_tmpfiles_t)


### PR DESCRIPTION
Hello,

This PR adds the use of auth_use_nsswitch() for getty and systemd-tmpfiles, as discussed in PR #307 .

Now that PR #269 is merged, we can use auth_use_nsswitch to solve issues where getty and systemd-tmpfiles would need to access the userdb.

Any review is welcome !

Thanks to @atenart for starting this work.

Regards,

Maxime