### PR TITLE
udev updates

### DIFF
--- a/policy/modules/admin/acct.te
+++ b/policy/modules/admin/acct.te
@@ -78,6 +78,3 @@ optional_policy(`
 	seutil_sigchld_newrole(acct_t)
 ')
 
-optional_policy(`
-	udev_read_db(acct_t)
-')

--- a/policy/modules/admin/dmesg.te
+++ b/policy/modules/admin/dmesg.te
@@ -55,6 +55,3 @@ optional_policy(`
 	seutil_sigchld_newrole(dmesg_t)
 ')
 
-optional_policy(`
-	udev_read_db(dmesg_t)
-')

--- a/policy/modules/admin/kudzu.te
+++ b/policy/modules/admin/kudzu.te
@@ -128,9 +128,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(kudzu_t)
-')
-
-optional_policy(`
 	unconfined_domtrans(kudzu_t)
 ')

--- a/policy/modules/admin/mrtg.te
+++ b/policy/modules/admin/mrtg.te
@@ -145,6 +145,3 @@ optional_policy(`
 	snmp_read_snmp_var_lib_files(mrtg_t)
 ')
 
-optional_policy(`
-	udev_read_db(mrtg_t)
-')

--- a/policy/modules/admin/quota.te
+++ b/policy/modules/admin/quota.te
@@ -97,10 +97,6 @@ optional_policy(`
 	seutil_sigchld_newrole(quota_t)
 ')
 
-optional_policy(`
-	udev_read_db(quota_t)
-')
-
 #######################################
 #
 # Nld local policy

--- a/policy/modules/admin/sxid.te
+++ b/policy/modules/admin/sxid.te
@@ -93,6 +93,3 @@ optional_policy(`
 	seutil_sigchld_newrole(sxid_t)
 ')
 
-optional_policy(`
-	udev_read_db(sxid_t)
-')

--- a/policy/modules/admin/updfstab.te
+++ b/policy/modules/admin/updfstab.te
@@ -111,6 +111,3 @@ optional_policy(`
 	seutil_sigchld_newrole(updfstab_t)
 ')
 
-optional_policy(`
-	udev_read_db(updfstab_t)
-')

--- a/policy/modules/apps/chromium.te
+++ b/policy/modules/apps/chromium.te
@@ -196,7 +196,6 @@ tunable_policy(`chromium_bind_tcp_unreserved_ports',`
 
 tunable_policy(`chromium_rw_usb_dev',`
 	dev_rw_generic_usb_dev(chromium_t)
-	udev_read_db(chromium_t)
 ')
 
 tunable_policy(`chromium_read_system_info',`

--- a/policy/modules/apps/games.te
+++ b/policy/modules/apps/games.te
@@ -84,10 +84,6 @@ optional_policy(`
 	seutil_sigchld_newrole(games_srv_t)
 ')
 
-optional_policy(`
-	udev_read_db(games_srv_t)
-')
-
 ########################################
 #
 # Client local policy

--- a/policy/modules/apps/mozilla.te
+++ b/policy/modules/apps/mozilla.te
@@ -584,10 +584,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(mozilla_plugin_t)
-')
-
-optional_policy(`
 	xserver_read_user_xauth(mozilla_plugin_t)
 	xserver_read_xdm_runtime_files(mozilla_plugin_t)
 	xserver_stream_connect(mozilla_plugin_t)

--- a/policy/modules/apps/pulseaudio.te
+++ b/policy/modules/apps/pulseaudio.te
@@ -234,7 +234,6 @@ optional_policy(`
 optional_policy(`
 	udev_read_runtime_files(pulseaudio_t)
 	udev_read_state(pulseaudio_t)
-	udev_read_db(pulseaudio_t)
 ')
 
 optional_policy(`

--- a/policy/modules/apps/uml.te
+++ b/policy/modules/apps/uml.te
@@ -166,6 +166,3 @@ optional_policy(`
 	seutil_sigchld_newrole(uml_switch_t)
 ')
 
-optional_policy(`
-	udev_read_db(uml_switch_t)
-')

--- a/policy/modules/apps/vmware.te
+++ b/policy/modules/apps/vmware.te
@@ -157,10 +157,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(vmware_host_t)
-')
-
-optional_policy(`
 	xserver_read_tmp_files(vmware_host_t)
 	xserver_read_xdm_runtime_files(vmware_host_t)
 ')

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1160,7 +1160,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udevadm_run(sysadm_t, sysadm_r)
+	udev_run_udevadm(sysadm_t, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/services/acpi.te
+++ b/policy/modules/services/acpi.te
@@ -232,7 +232,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(acpid_t)
 	udev_read_state(acpid_t)
 ')
 

--- a/policy/modules/services/apache.te
+++ b/policy/modules/services/apache.te
@@ -894,10 +894,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(httpd_t)
-')
-
-optional_policy(`
 	yam_read_content(httpd_t)
 ')
 

--- a/policy/modules/services/arpwatch.te
+++ b/policy/modules/services/arpwatch.te
@@ -85,6 +85,3 @@ optional_policy(`
 	seutil_sigchld_newrole(arpwatch_t)
 ')
 
-optional_policy(`
-	udev_read_db(arpwatch_t)
-')

--- a/policy/modules/services/asterisk.te
+++ b/policy/modules/services/asterisk.te
@@ -185,6 +185,3 @@ optional_policy(`
 	snmp_tcp_connect(asterisk_t)
 ')
 
-optional_policy(`
-	udev_read_db(asterisk_t)
-')

--- a/policy/modules/services/automount.te
+++ b/policy/modules/services/automount.te
@@ -163,6 +163,3 @@ optional_policy(`
 	seutil_sigchld_newrole(automount_t)
 ')
 
-optional_policy(`
-	udev_read_db(automount_t)
-')

--- a/policy/modules/services/avahi.te
+++ b/policy/modules/services/avahi.te
@@ -110,6 +110,3 @@ optional_policy(`
 	seutil_sigchld_newrole(avahi_t)
 ')
 
-optional_policy(`
-	udev_read_db(avahi_t)
-')

--- a/policy/modules/services/bind.te
+++ b/policy/modules/services/bind.te
@@ -206,10 +206,6 @@ optional_policy(`
 	seutil_sigchld_newrole(named_t)
 ')
 
-optional_policy(`
-	udev_read_db(named_t)
-')
-
 ########################################
 #
 # NDC local policy

--- a/policy/modules/services/bluetooth.te
+++ b/policy/modules/services/bluetooth.te
@@ -157,10 +157,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(bluetooth_t)
-')
-
-optional_policy(`
 	ppp_domtrans(bluetooth_t)
 ')
 

--- a/policy/modules/services/canna.te
+++ b/policy/modules/services/canna.te
@@ -89,6 +89,3 @@ optional_policy(`
 	seutil_sigchld_newrole(canna_t)
 ')
 
-optional_policy(`
-	udev_read_db(canna_t)
-')

--- a/policy/modules/services/cipe.te
+++ b/policy/modules/services/cipe.te
@@ -65,6 +65,3 @@ optional_policy(`
 	seutil_sigchld_newrole(ciped_t)
 ')
 
-optional_policy(`
-	udev_read_db(ciped_t)
-')

--- a/policy/modules/services/colord.te
+++ b/policy/modules/services/colord.te
@@ -132,7 +132,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(colord_t)
 	udev_read_runtime_files(colord_t)
 ')
 

--- a/policy/modules/services/consolekit.te
+++ b/policy/modules/services/consolekit.te
@@ -164,7 +164,6 @@ optional_policy(`
 
 optional_policy(`
 	udev_domtrans(consolekit_t)
-	udev_read_db(consolekit_t)
 	udev_read_runtime_files(consolekit_t)
 	udev_signal(consolekit_t)
 ')

--- a/policy/modules/services/courier.te
+++ b/policy/modules/services/courier.te
@@ -75,10 +75,6 @@ optional_policy(`
 	seutil_sigchld_newrole(courier_domain)
 ')
 
-optional_policy(`
-	udev_read_db(courier_domain)
-')
-
 ########################################
 #
 # Authdaemon local policy

--- a/policy/modules/services/cpucontrol.te
+++ b/policy/modules/services/cpucontrol.te
@@ -54,10 +54,6 @@ optional_policy(`
 	seutil_sigchld_newrole(cpucontrol_domain)
 ')
 
-optional_policy(`
-	udev_read_db(cpucontrol_domain)
-')
-
 ########################################
 #
 # Loader local policy

--- a/policy/modules/services/cron.te
+++ b/policy/modules/services/cron.te
@@ -441,10 +441,6 @@ optional_policy(`
 	init_manage_script_service(system_cronjob_t)
 ')
 
-optional_policy(`
-	udev_read_db(crond_t)
-')
-
 ########################################
 #
 # System local policy

--- a/policy/modules/services/cups.te
+++ b/policy/modules/services/cups.te
@@ -342,10 +342,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(cupsd_t)
-')
-
-optional_policy(`
 	virt_rw_all_image_chr_files(cupsd_t)
 ')
 
@@ -480,10 +476,6 @@ optional_policy(`
 
 optional_policy(`
 	seutil_sigchld_newrole(cupsd_config_t)
-')
-
-optional_policy(`
-	udev_read_db(cupsd_config_t)
 ')
 
 optional_policy(`
@@ -718,7 +710,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(hplip_t)
 	udev_read_runtime_files(hplip_t)
 ')
 
@@ -781,6 +772,3 @@ optional_policy(`
 	seutil_sigchld_newrole(ptal_t)
 ')
 
-optional_policy(`
-	udev_read_db(ptal_t)
-')

--- a/policy/modules/services/cyrus.te
+++ b/policy/modules/services/cyrus.te
@@ -138,6 +138,3 @@ optional_policy(`
 	snmp_stream_connect(cyrus_t)
 ')
 
-optional_policy(`
-	udev_read_db(cyrus_t)
-')

--- a/policy/modules/services/dante.te
+++ b/policy/modules/services/dante.te
@@ -72,6 +72,3 @@ optional_policy(`
 	seutil_sigchld_newrole(dante_t)
 ')
 
-optional_policy(`
-	udev_read_db(dante_t)
-')

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -207,10 +207,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(system_dbusd_t)
-')
-
-optional_policy(`
 	unconfined_dbus_send(system_dbusd_t)
 ')
 

--- a/policy/modules/services/dcc.te
+++ b/policy/modules/services/dcc.te
@@ -234,10 +234,6 @@ optional_policy(`
 	seutil_sigchld_newrole(dccd_t)
 ')
 
-optional_policy(`
-	udev_read_db(dccd_t)
-')
-
 ########################################
 #
 # Spamassassin and general MTA persistent client local policy
@@ -287,10 +283,6 @@ userdom_dontaudit_search_user_home_dirs(dccifd_t)
 
 optional_policy(`
 	seutil_sigchld_newrole(dccifd_t)
-')
-
-optional_policy(`
-	udev_read_db(dccifd_t)
 ')
 
 ########################################
@@ -344,6 +336,3 @@ optional_policy(`
 	seutil_sigchld_newrole(dccm_t)
 ')
 
-optional_policy(`
-	udev_read_db(dccm_t)
-')

--- a/policy/modules/services/ddclient.te
+++ b/policy/modules/services/ddclient.te
@@ -110,6 +110,3 @@ optional_policy(`
 	seutil_sigchld_newrole(ddclient_t)
 ')
 
-optional_policy(`
-	udev_read_db(ddclient_t)
-')

--- a/policy/modules/services/devicekit.te
+++ b/policy/modules/services/devicekit.te
@@ -57,10 +57,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(devicekit_t)
-')
-
-optional_policy(`
 	xserver_dbus_chat_xdm(devicekit_power_t)
 ')
 
@@ -202,7 +198,6 @@ optional_policy(`
 
 optional_policy(`
 	udev_domtrans(devicekit_disk_t)
-	udev_read_db(devicekit_disk_t)
 	udev_read_runtime_files(devicekit_disk_t)
 ')
 
@@ -363,7 +358,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(devicekit_power_t)
 	udev_manage_runtime_files(devicekit_power_t)
 ')
 

--- a/policy/modules/services/devicekit.te
+++ b/policy/modules/services/devicekit.te
@@ -197,7 +197,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_domtrans(devicekit_disk_t)
+	udev_domtrans_udevadm(devicekit_disk_t)
 	udev_read_runtime_files(devicekit_disk_t)
 ')
 

--- a/policy/modules/services/dhcp.te
+++ b/policy/modules/services/dhcp.te
@@ -127,6 +127,3 @@ optional_policy(`
 	seutil_sigchld_newrole(dhcpd_t)
 ')
 
-optional_policy(`
-	udev_read_db(dhcpd_t)
-')

--- a/policy/modules/services/dictd.te
+++ b/policy/modules/services/dictd.te
@@ -79,6 +79,3 @@ optional_policy(`
 	seutil_sigchld_newrole(dictd_t)
 ')
 
-optional_policy(`
-	udev_read_db(dictd_t)
-')

--- a/policy/modules/services/distcc.te
+++ b/policy/modules/services/distcc.te
@@ -81,6 +81,3 @@ optional_policy(`
 	seutil_sigchld_newrole(distccd_t)
 ')
 
-optional_policy(`
-	udev_read_db(distccd_t)
-')

--- a/policy/modules/services/dnsmasq.te
+++ b/policy/modules/services/dnsmasq.te
@@ -124,10 +124,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dnsmasq_t)
-')
-
-optional_policy(`
 	virt_manage_lib_files(dnsmasq_t)
 	virt_read_runtime_files(dnsmasq_t)
 	virt_runtime_filetrans(dnsmasq_t, dnsmasq_runtime_t, { dir file })

--- a/policy/modules/services/dovecot.te
+++ b/policy/modules/services/dovecot.te
@@ -233,10 +233,6 @@ optional_policy(`
 	squid_dontaudit_search_cache(dovecot_t)
 ')
 
-optional_policy(`
-	udev_read_db(dovecot_t)
-')
-
 ########################################
 #
 # Auth local policy

--- a/policy/modules/services/entropyd.te
+++ b/policy/modules/services/entropyd.te
@@ -87,6 +87,3 @@ optional_policy(`
 	seutil_sigchld_newrole(entropyd_t)
 ')
 
-optional_policy(`
-	udev_read_db(entropyd_t)
-')

--- a/policy/modules/services/fetchmail.te
+++ b/policy/modules/services/fetchmail.te
@@ -107,6 +107,3 @@ optional_policy(`
 	seutil_sigchld_newrole(fetchmail_t)
 ')
 
-optional_policy(`
-	udev_read_db(fetchmail_t)
-')

--- a/policy/modules/services/finger.te
+++ b/policy/modules/services/finger.te
@@ -97,6 +97,3 @@ optional_policy(`
 	tcpd_wrapped_domain(fingerd_t, fingerd_exec_t)
 ')
 
-optional_policy(`
-	udev_read_db(fingerd_t)
-')

--- a/policy/modules/services/ftp.te
+++ b/policy/modules/services/ftp.te
@@ -405,10 +405,6 @@ optional_policy(`
 	seutil_sigchld_newrole(ftpd_t)
 ')
 
-optional_policy(`
-	udev_read_db(ftpd_t)
-')
-
 ########################################
 #
 # Ctl local policy

--- a/policy/modules/services/gatekeeper.te
+++ b/policy/modules/services/gatekeeper.te
@@ -96,6 +96,3 @@ optional_policy(`
 	seutil_sigchld_newrole(gatekeeper_t)
 ')
 
-optional_policy(`
-	udev_read_db(gatekeeper_t)
-')

--- a/policy/modules/services/gpm.te
+++ b/policy/modules/services/gpm.te
@@ -78,6 +78,3 @@ optional_policy(`
 	seutil_sigchld_newrole(gpm_t)
 ')
 
-optional_policy(`
-	udev_read_db(gpm_t)
-')

--- a/policy/modules/services/hal.te
+++ b/policy/modules/services/hal.te
@@ -314,7 +314,6 @@ optional_policy(`
 
 optional_policy(`
 	udev_domtrans(hald_t)
-	udev_read_db(hald_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/howl.te
+++ b/policy/modules/services/howl.te
@@ -71,6 +71,3 @@ optional_policy(`
 	seutil_sigchld_newrole(howl_t)
 ')
 
-optional_policy(`
-	udev_read_db(howl_t)
-')

--- a/policy/modules/services/i18n_input.te
+++ b/policy/modules/services/i18n_input.te
@@ -119,6 +119,3 @@ optional_policy(`
 	seutil_sigchld_newrole(i18n_input_t)
 ')
 
-optional_policy(`
-	udev_read_db(i18n_input_t)
-')

--- a/policy/modules/services/imaze.te
+++ b/policy/modules/services/imaze.te
@@ -77,6 +77,3 @@ optional_policy(`
 	seutil_sigchld_newrole(imazesrv_t)
 ')
 
-optional_policy(`
-	udev_read_db(imazesrv_t)
-')

--- a/policy/modules/services/inetd.te
+++ b/policy/modules/services/inetd.te
@@ -189,10 +189,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(inetd_t)
-')
-
-optional_policy(`
 	unconfined_domtrans(inetd_t)
 ')
 

--- a/policy/modules/services/inn.te
+++ b/policy/modules/services/inn.te
@@ -116,6 +116,3 @@ optional_policy(`
 	seutil_sigchld_newrole(innd_t)
 ')
 
-optional_policy(`
-	udev_read_db(innd_t)
-')

--- a/policy/modules/services/ircd.te
+++ b/policy/modules/services/ircd.te
@@ -82,6 +82,3 @@ optional_policy(`
 	seutil_sigchld_newrole(ircd_t)
 ')
 
-optional_policy(`
-	udev_read_db(ircd_t)
-')

--- a/policy/modules/services/irqbalance.te
+++ b/policy/modules/services/irqbalance.te
@@ -57,6 +57,3 @@ miscfiles_read_localization(irqbalance_t)
 userdom_dontaudit_use_unpriv_user_fds(irqbalance_t)
 userdom_dontaudit_search_user_home_dirs(irqbalance_t)
 
-optional_policy(`
-	udev_read_db(irqbalance_t)
-')

--- a/policy/modules/services/jabber.te
+++ b/policy/modules/services/jabber.te
@@ -119,10 +119,6 @@ sysnet_read_config(jabberd_t)
 userdom_dontaudit_use_unpriv_user_fds(jabberd_t)
 userdom_dontaudit_search_user_home_dirs(jabberd_t)
 
-optional_policy(`
-	udev_read_db(jabberd_t)
-')
-
 ########################################
 #
 # Router local policy

--- a/policy/modules/services/kerberos.te
+++ b/policy/modules/services/kerberos.te
@@ -162,10 +162,6 @@ optional_policy(`
 	seutil_sigchld_newrole(kadmind_t)
 ')
 
-optional_policy(`
-	udev_read_db(kadmind_t)
-')
-
 ########################################
 #
 # Krb5kdc local policy
@@ -263,10 +259,6 @@ optional_policy(`
 
 optional_policy(`
 	seutil_sigchld_newrole(krb5kdc_t)
-')
-
-optional_policy(`
-	udev_read_db(krb5kdc_t)
 ')
 
 ########################################

--- a/policy/modules/services/ldap.te
+++ b/policy/modules/services/ldap.te
@@ -147,6 +147,3 @@ optional_policy(`
 	seutil_sigchld_newrole(slapd_t)
 ')
 
-optional_policy(`
-	udev_read_db(slapd_t)
-')

--- a/policy/modules/services/lpd.te
+++ b/policy/modules/services/lpd.te
@@ -195,10 +195,6 @@ optional_policy(`
 	seutil_sigchld_newrole(lpd_t)
 ')
 
-optional_policy(`
-	udev_read_db(lpd_t)
-')
-
 ##############################
 #
 # Lpr local policy

--- a/policy/modules/services/modemmanager.te
+++ b/policy/modules/services/modemmanager.te
@@ -55,6 +55,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(modemmanager_t)
 	udev_manage_runtime_files(modemmanager_t)
 ')

--- a/policy/modules/services/monop.te
+++ b/policy/modules/services/monop.te
@@ -77,6 +77,3 @@ optional_policy(`
 	seutil_sigchld_newrole(monopd_t)
 ')
 
-optional_policy(`
-	udev_read_db(monopd_t)
-')

--- a/policy/modules/services/mpd.te
+++ b/policy/modules/services/mpd.te
@@ -194,10 +194,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(mpd_t)
-')
-
-optional_policy(`
 	xserver_stream_connect(mpd_t)
 	xserver_read_xdm_runtime_files(mpd_t)
 ')

--- a/policy/modules/services/munin.te
+++ b/policy/modules/services/munin.te
@@ -228,10 +228,6 @@ optional_policy(`
 	seutil_sigchld_newrole(munin_t)
 ')
 
-optional_policy(`
-	udev_read_db(munin_t)
-')
-
 ###################################
 #
 # Disk local policy

--- a/policy/modules/services/mysql.te
+++ b/policy/modules/services/mysql.te
@@ -150,10 +150,6 @@ optional_policy(`
 	seutil_sigchld_newrole(mysqld_t)
 ')
 
-optional_policy(`
-	udev_read_db(mysqld_t)
-')
-
 #######################################
 #
 # Safe local policy

--- a/policy/modules/services/nagios.te
+++ b/policy/modules/services/nagios.te
@@ -170,10 +170,6 @@ optional_policy(`
 	seutil_sigchld_newrole(nagios_t)
 ')
 
-optional_policy(`
-	udev_read_db(nagios_t)
-')
-
 ########################################
 #
 # CGI local policy
@@ -279,10 +275,6 @@ optional_policy(`
 
 optional_policy(`
 	tcpd_wrapped_domain(nrpe_t, nrpe_exec_t)
-')
-
-optional_policy(`
-	udev_read_db(nrpe_t)
 ')
 
 #####################################

--- a/policy/modules/services/nessus.te
+++ b/policy/modules/services/nessus.te
@@ -102,6 +102,3 @@ optional_policy(`
 	seutil_sigchld_newrole(nessusd_t)
 ')
 
-optional_policy(`
-	udev_read_db(nessusd_t)
-')

--- a/policy/modules/services/networkmanager.te
+++ b/policy/modules/services/networkmanager.te
@@ -358,7 +358,6 @@ optional_policy(`
 
 optional_policy(`
 	udev_exec(NetworkManager_t)
-	udev_read_db(NetworkManager_t)
 	udev_read_runtime_files(NetworkManager_t)
 ')
 

--- a/policy/modules/services/nis.te
+++ b/policy/modules/services/nis.te
@@ -139,10 +139,6 @@ optional_policy(`
 	seutil_sigchld_newrole(ypbind_t)
 ')
 
-optional_policy(`
-	udev_read_db(ypbind_t)
-')
-
 ########################################
 #
 # yppasswdd local policy
@@ -222,10 +218,6 @@ optional_policy(`
 	seutil_sigchld_newrole(yppasswdd_t)
 ')
 
-optional_policy(`
-	udev_read_db(yppasswdd_t)
-')
-
 ########################################
 #
 # ypserv local policy
@@ -296,10 +288,6 @@ userdom_dontaudit_search_user_home_dirs(ypserv_t)
 
 optional_policy(`
 	seutil_sigchld_newrole(ypserv_t)
-')
-
-optional_policy(`
-	udev_read_db(ypserv_t)
 ')
 
 ########################################

--- a/policy/modules/services/nscd.te
+++ b/policy/modules/services/nscd.te
@@ -132,10 +132,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(nscd_t)
-')
-
-optional_policy(`
 	xen_dontaudit_rw_unix_stream_sockets(nscd_t)
 	xen_append_log(nscd_t)
 ')

--- a/policy/modules/services/nsd.te
+++ b/policy/modules/services/nsd.te
@@ -97,10 +97,6 @@ optional_policy(`
 	seutil_sigchld_newrole(nsd_t)
 ')
 
-optional_policy(`
-	udev_read_db(nsd_t)
-')
-
 ########################################
 #
 # Cron local policy

--- a/policy/modules/services/ntop.te
+++ b/policy/modules/services/ntop.te
@@ -101,6 +101,3 @@ optional_policy(`
 	seutil_sigchld_newrole(ntop_t)
 ')
 
-optional_policy(`
-	udev_read_db(ntop_t)
-')

--- a/policy/modules/services/ntp.te
+++ b/policy/modules/services/ntp.te
@@ -206,6 +206,3 @@ optional_policy(`
 	seutil_sigchld_newrole(ntpd_t)
 ')
 
-optional_policy(`
-	udev_read_db(ntpd_t)
-')

--- a/policy/modules/services/oav.te
+++ b/policy/modules/services/oav.te
@@ -120,6 +120,3 @@ optional_policy(`
 	seutil_sigchld_newrole(scannerdaemon_t)
 ')
 
-optional_policy(`
-	udev_read_db(scannerdaemon_t)
-')

--- a/policy/modules/services/openct.te
+++ b/policy/modules/services/openct.te
@@ -62,6 +62,3 @@ optional_policy(`
 	seutil_sigchld_newrole(openct_t)
 ')
 
-optional_policy(`
-	udev_read_db(openct_t)
-')

--- a/policy/modules/services/pcscd.te
+++ b/policy/modules/services/pcscd.te
@@ -87,6 +87,3 @@ optional_policy(`
 	rpm_use_script_fds(pcscd_t)
 ')
 
-optional_policy(`
-	udev_read_db(pcscd_t)
-')

--- a/policy/modules/services/pegasus.te
+++ b/policy/modules/services/pegasus.te
@@ -174,10 +174,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(pegasus_t)
-')
-
-optional_policy(`
 	unconfined_signull(pegasus_t)
 ')
 

--- a/policy/modules/services/perdition.te
+++ b/policy/modules/services/perdition.te
@@ -77,6 +77,3 @@ optional_policy(`
 	seutil_sigchld_newrole(perdition_t)
 ')
 
-optional_policy(`
-	udev_read_db(perdition_t)
-')

--- a/policy/modules/services/portmap.te
+++ b/policy/modules/services/portmap.te
@@ -88,10 +88,6 @@ optional_policy(`
 	seutil_sigchld_newrole(portmap_t)
 ')
 
-optional_policy(`
-	udev_read_db(portmap_t)
-')
-
 ########################################
 #
 # Helper local policy

--- a/policy/modules/services/portslave.te
+++ b/policy/modules/services/portslave.te
@@ -103,6 +103,3 @@ optional_policy(`
 	seutil_sigchld_newrole(portslave_t)
 ')
 
-optional_policy(`
-	udev_read_db(portslave_t)
-')

--- a/policy/modules/services/postfix.te
+++ b/policy/modules/services/postfix.te
@@ -163,10 +163,6 @@ miscfiles_read_generic_tls_privkey(postfix_domain)
 
 userdom_dontaudit_use_unpriv_user_fds(postfix_domain)
 
-optional_policy(`
-	udev_read_db(postfix_domain)
-')
-
 ########################################
 #
 # Common postfix server domain local policy

--- a/policy/modules/services/postgresql.te
+++ b/policy/modules/services/postgresql.te
@@ -384,10 +384,6 @@ optional_policy(`
 	seutil_sigchld_newrole(postgresql_t)
 ')
 
-optional_policy(`
-	udev_read_db(postgresql_t)
-')
-
 ########################################
 #
 # Ranged Trusted Procedure Domain

--- a/policy/modules/services/postgrey.te
+++ b/policy/modules/services/postgrey.te
@@ -103,6 +103,3 @@ optional_policy(`
 	seutil_sigchld_newrole(postgrey_t)
 ')
 
-optional_policy(`
-	udev_read_db(postgrey_t)
-')

--- a/policy/modules/services/ppp.te
+++ b/policy/modules/services/ppp.te
@@ -212,10 +212,6 @@ optional_policy(`
 	seutil_sigchld_newrole(pppd_t)
 ')
 
-optional_policy(`
-	udev_read_db(pppd_t)
-')
-
 ########################################
 #
 # PPTP local policy
@@ -309,10 +305,6 @@ optional_policy(`
 
 optional_policy(`
 	seutil_sigchld_newrole(pptp_t)
-')
-
-optional_policy(`
-	udev_read_db(pptp_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/privoxy.te
+++ b/policy/modules/services/privoxy.te
@@ -103,6 +103,3 @@ optional_policy(`
 	seutil_sigchld_newrole(privoxy_t)
 ')
 
-optional_policy(`
-	udev_read_db(privoxy_t)
-')

--- a/policy/modules/services/pxe.te
+++ b/policy/modules/services/pxe.te
@@ -64,6 +64,3 @@ optional_policy(`
 	seutil_sigchld_newrole(pxe_t)
 ')
 
-optional_policy(`
-	udev_read_db(pxe_t)
-')

--- a/policy/modules/services/radius.te
+++ b/policy/modules/services/radius.te
@@ -137,6 +137,3 @@ optional_policy(`
 	seutil_sigchld_newrole(radiusd_t)
 ')
 
-optional_policy(`
-	udev_read_db(radiusd_t)
-')

--- a/policy/modules/services/radvd.te
+++ b/policy/modules/services/radvd.te
@@ -71,6 +71,3 @@ optional_policy(`
 	seutil_sigchld_newrole(radvd_t)
 ')
 
-optional_policy(`
-	udev_read_db(radvd_t)
-')

--- a/policy/modules/services/rdisc.te
+++ b/policy/modules/services/rdisc.te
@@ -51,6 +51,3 @@ optional_policy(`
 	seutil_sigchld_newrole(rdisc_t)
 ')
 
-optional_policy(`
-	udev_read_db(rdisc_t)
-')

--- a/policy/modules/services/resmgr.te
+++ b/policy/modules/services/resmgr.te
@@ -62,6 +62,3 @@ optional_policy(`
 	seutil_sigchld_newrole(resmgrd_t)
 ')
 
-optional_policy(`
-	udev_read_db(resmgrd_t)
-')

--- a/policy/modules/services/rgmanager.te
+++ b/policy/modules/services/rgmanager.te
@@ -191,10 +191,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(rgmanager_t)
-')
-
-optional_policy(`
 	virt_stream_connect(rgmanager_t)
 ')
 

--- a/policy/modules/services/rhcs.te
+++ b/policy/modules/services/rhcs.te
@@ -317,6 +317,3 @@ optional_policy(`
 	netutils_domtrans_ping(qdiskd_t)
 ')
 
-optional_policy(`
-	udev_read_db(qdiskd_t)
-')

--- a/policy/modules/services/rhgb.te
+++ b/policy/modules/services/rhgb.te
@@ -120,6 +120,3 @@ optional_policy(`
 	seutil_sigchld_newrole(rhgb_t)
 ')
 
-optional_policy(`
-	udev_read_db(rhgb_t)
-')

--- a/policy/modules/services/roundup.te
+++ b/policy/modules/services/roundup.te
@@ -81,6 +81,3 @@ optional_policy(`
 	seutil_sigchld_newrole(roundup_t)
 ')
 
-optional_policy(`
-	udev_read_db(roundup_t)
-')

--- a/policy/modules/services/rpc.te
+++ b/policy/modules/services/rpc.te
@@ -133,10 +133,6 @@ optional_policy(`
 	seutil_sigchld_newrole(rpc_domain)
 ')
 
-optional_policy(`
-	udev_read_db(rpc_domain)
-')
-
 ########################################
 #
 # Local policy

--- a/policy/modules/services/samba.te
+++ b/policy/modules/services/samba.te
@@ -501,10 +501,6 @@ optional_policy(`
 	seutil_sigchld_newrole(smbd_t)
 ')
 
-optional_policy(`
-	udev_read_db(smbd_t)
-')
-
 ########################################
 #
 # Nmbd Local policy
@@ -603,10 +599,6 @@ tunable_policy(`samba_export_all_rw',`
 
 optional_policy(`
 	seutil_sigchld_newrole(nmbd_t)
-')
-
-optional_policy(`
-	udev_read_db(nmbd_t)
 ')
 
 ########################################
@@ -945,10 +937,6 @@ optional_policy(`
 
 optional_policy(`
 	seutil_sigchld_newrole(winbind_t)
-')
-
-optional_policy(`
-	udev_read_db(winbind_t)
 ')
 
 ########################################

--- a/policy/modules/services/sasl.te
+++ b/policy/modules/services/sasl.te
@@ -109,6 +109,3 @@ optional_policy(`
 	seutil_sigchld_newrole(saslauthd_t)
 ')
 
-optional_policy(`
-	udev_read_db(saslauthd_t)
-')

--- a/policy/modules/services/sendmail.te
+++ b/policy/modules/services/sendmail.te
@@ -194,10 +194,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(sendmail_t)
-')
-
-optional_policy(`
 	uucp_domtrans_uux(sendmail_t)
 ')
 

--- a/policy/modules/services/slrnpull.te
+++ b/policy/modules/services/slrnpull.te
@@ -65,6 +65,3 @@ optional_policy(`
 	seutil_sigchld_newrole(slrnpull_t)
 ')
 
-optional_policy(`
-	udev_read_db(slrnpull_t)
-')

--- a/policy/modules/services/smartmon.te
+++ b/policy/modules/services/smartmon.te
@@ -120,6 +120,3 @@ optional_policy(`
 	seutil_sigchld_newrole(fsdaemon_t)
 ')
 
-optional_policy(`
-	udev_read_db(fsdaemon_t)
-')

--- a/policy/modules/services/snmp.te
+++ b/policy/modules/services/snmp.te
@@ -163,10 +163,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(snmpd_t)
-')
-
-optional_policy(`
 	virt_stream_connect(snmpd_t)
 ')
 

--- a/policy/modules/services/snort.te
+++ b/policy/modules/services/snort.te
@@ -107,6 +107,3 @@ optional_policy(`
 	seutil_sigchld_newrole(snort_t)
 ')
 
-optional_policy(`
-	udev_read_db(snort_t)
-')

--- a/policy/modules/services/soundserver.te
+++ b/policy/modules/services/soundserver.te
@@ -102,6 +102,3 @@ optional_policy(`
 	seutil_sigchld_newrole(soundd_t)
 ')
 
-optional_policy(`
-	udev_read_db(soundd_t)
-')

--- a/policy/modules/services/spamassassin.te
+++ b/policy/modules/services/spamassassin.te
@@ -467,10 +467,6 @@ optional_policy(`
 	mta_send_mail(spamd_t)
 ')
 
-optional_policy(`
-	udev_read_db(spamd_t)
-')
-
 ########################################
 #
 # Update local policy

--- a/policy/modules/services/speedtouch.te
+++ b/policy/modules/services/speedtouch.te
@@ -56,6 +56,3 @@ optional_policy(`
 	seutil_sigchld_newrole(speedmgmt_t)
 ')
 
-optional_policy(`
-	udev_read_db(speedmgmt_t)
-')

--- a/policy/modules/services/squid.te
+++ b/policy/modules/services/squid.te
@@ -232,6 +232,3 @@ optional_policy(`
 	seutil_sigchld_newrole(squid_t)
 ')
 
-optional_policy(`
-	udev_read_db(squid_t)
-')

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -362,6 +362,3 @@ optional_policy(`
 	seutil_sigchld_newrole(ssh_keygen_t)
 ')
 
-optional_policy(`
-	udev_read_db(ssh_keygen_t)
-')

--- a/policy/modules/services/stunnel.te
+++ b/policy/modules/services/stunnel.te
@@ -95,6 +95,3 @@ optional_policy(`
 	seutil_sigchld_newrole(stunnel_t)
 ')
 
-optional_policy(`
-	udev_read_db(stunnel_t)
-')

--- a/policy/modules/services/tftp.te
+++ b/policy/modules/services/tftp.te
@@ -133,6 +133,3 @@ optional_policy(`
 	seutil_sigchld_newrole(tftpd_t)
 ')
 
-optional_policy(`
-	udev_read_db(tftpd_t)
-')

--- a/policy/modules/services/timidity.te
+++ b/policy/modules/services/timidity.te
@@ -67,6 +67,3 @@ optional_policy(`
 	seutil_sigchld_newrole(timidity_t)
 ')
 
-optional_policy(`
-	udev_read_db(timidity_t)
-')

--- a/policy/modules/services/transproxy.te
+++ b/policy/modules/services/transproxy.te
@@ -62,6 +62,3 @@ optional_policy(`
 	seutil_sigchld_newrole(transproxy_t)
 ')
 
-optional_policy(`
-	udev_read_db(transproxy_t)
-')

--- a/policy/modules/services/uptime.te
+++ b/policy/modules/services/uptime.te
@@ -68,6 +68,3 @@ optional_policy(`
 	seutil_sigchld_newrole(uptimed_t)
 ')
 
-optional_policy(`
-	udev_read_db(uptimed_t)
-')

--- a/policy/modules/services/uwimap.te
+++ b/policy/modules/services/uwimap.te
@@ -100,6 +100,3 @@ optional_policy(`
 	tcpd_wrapped_domain(imapd_t, imapd_exec_t)
 ')
 
-optional_policy(`
-	udev_read_db(imapd_t)
-')

--- a/policy/modules/services/virt.te
+++ b/policy/modules/services/virt.te
@@ -818,7 +818,6 @@ optional_policy(`
 
 optional_policy(`
 	udev_domtrans(virtd_t)
-	udev_read_db(virtd_t)
 	udev_read_runtime_files(virtd_t)
 ')
 

--- a/policy/modules/services/watchdog.te
+++ b/policy/modules/services/watchdog.te
@@ -95,6 +95,3 @@ optional_policy(`
 	seutil_sigchld_newrole(watchdog_t)
 ')
 
-optional_policy(`
-	udev_read_db(watchdog_t)
-')

--- a/policy/modules/services/xfs.te
+++ b/policy/modules/services/xfs.te
@@ -79,6 +79,3 @@ optional_policy(`
 	seutil_sigchld_newrole(xfs_t)
 ')
 
-optional_policy(`
-	udev_read_db(xfs_t)
-')

--- a/policy/modules/services/xprint.te
+++ b/policy/modules/services/xprint.te
@@ -74,6 +74,3 @@ optional_policy(`
 	seutil_sigchld_newrole(xprint_t)
 ')
 
-optional_policy(`
-	udev_read_db(xprint_t)
-')

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -591,10 +591,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(xdm_t)
-')
-
-optional_policy(`
 	unconfined_domain(xdm_t)
 	unconfined_domtrans(xdm_t)
 ')
@@ -818,7 +814,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(xserver_t)
 	udev_read_runtime_files(xserver_t)
 ')
 

--- a/policy/modules/services/zebra.te
+++ b/policy/modules/services/zebra.te
@@ -132,6 +132,3 @@ optional_policy(`
 	seutil_sigchld_newrole(zebra_t)
 ')
 
-optional_policy(`
-	udev_read_db(zebra_t)
-')

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -324,10 +324,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(pam_console_t)
-')
-
-optional_policy(`
 	xserver_read_xdm_runtime_files(pam_console_t)
 	xserver_dontaudit_write_log(pam_console_t)
 ')

--- a/policy/modules/system/clock.te
+++ b/policy/modules/system/clock.te
@@ -73,9 +73,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(hwclock_t)
-')
-
-optional_policy(`
 	userdom_dontaudit_use_unpriv_user_fds(hwclock_t)
 ')

--- a/policy/modules/system/fstools.te
+++ b/policy/modules/system/fstools.te
@@ -212,8 +212,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(fsadm_t)
-
 	# Xen causes losetup to run with a presumably accidentally inherited
 	# file handle for /run/xen-hotplug/block
 	udev_dontaudit_rw_runtime_files(fsadm_t)

--- a/policy/modules/system/getty.te
+++ b/policy/modules/system/getty.te
@@ -128,6 +128,3 @@ optional_policy(`
 	rhgb_dontaudit_use_ptys(getty_t)
 ')
 
-optional_policy(`
-	udev_read_db(getty_t)
-')

--- a/policy/modules/system/hotplug.te
+++ b/policy/modules/system/hotplug.te
@@ -188,7 +188,6 @@ optional_policy(`
 optional_policy(`
 	udev_domtrans(hotplug_t)
 	udev_helper_domtrans(hotplug_t)
-	udev_read_db(hotplug_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -485,8 +485,6 @@ ifdef(`init_systemd',`
 	# for systemd to read udev status
 	udev_read_runtime_files(init_t)
 
-	udev_relabelto_db_sockets(init_t)
-
 	tunable_policy(`init_mounton_non_security',`
 		files_mounton_non_security(init_t)
 	')
@@ -577,11 +575,6 @@ optional_policy(`
 
 optional_policy(`
 	sssd_stream_connect(init_t)
-')
-
-optional_policy(`
-	udev_read_db(init_t)
-	udev_relabelto_db(init_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -189,10 +189,6 @@ optional_policy(`
 	seutil_sigchld_newrole(ipsec_t)
 ')
 
-optional_policy(`
-	udev_read_db(ipsec_t)
-')
-
 ########################################
 #
 # ipsec_mgmt Local policy

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -145,7 +145,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(iptables_t)
 	# this is for iptables_t to inherit a file handle from xen vif-bridge
 	udev_manage_runtime_files(iptables_t)
 ')

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -236,10 +236,6 @@ optional_policy(`
 	systemd_status_power_units(auditd_t)
 ')
 
-optional_policy(`
-	udev_read_db(auditd_t)
-')
-
 ########################################
 #
 # audit dispatcher local policy
@@ -361,10 +357,6 @@ ifdef(`distro_ubuntu',`
 	optional_policy(`
 		unconfined_domain(klogd_t)
 	')
-')
-
-optional_policy(`
-	udev_read_db(klogd_t)
 ')
 
 optional_policy(`
@@ -601,10 +593,6 @@ optional_policy(`
 
 optional_policy(`
 	seutil_sigchld_newrole(syslogd_t)
-')
-
-optional_policy(`
-	udev_read_db(syslogd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/lvm.te
+++ b/policy/modules/system/lvm.te
@@ -153,10 +153,6 @@ optional_policy(`
 	ricci_dontaudit_use_modcluster_fds(clvmd_t)
 ')
 
-optional_policy(`
-	udev_read_db(clvmd_t)
-')
-
 ########################################
 #
 # LVM Local policy
@@ -373,7 +369,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(lvm_t)
 	udev_read_runtime_files(lvm_t)
 ')
 

--- a/policy/modules/system/pcmcia.te
+++ b/policy/modules/system/pcmcia.te
@@ -116,6 +116,3 @@ optional_policy(`
 	sysnet_sigstop_dhcpc(cardmgr_t)
 ')
 
-optional_policy(`
-	udev_read_db(cardmgr_t)
-')

--- a/policy/modules/system/raid.te
+++ b/policy/modules/system/raid.te
@@ -104,6 +104,3 @@ optional_policy(`
 	seutil_sigchld_newrole(mdadm_t)
 ')
 
-optional_policy(`
-	udev_read_db(mdadm_t)
-')

--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -257,10 +257,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(dhcpc_t)
-')
-
-optional_policy(`
 	userdom_use_all_users_fds(dhcpc_t)
 ')
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -639,7 +639,6 @@ systemd_log_parse_environment(systemd_logind_t)
 systemd_start_power_units(systemd_logind_t)
 
 udev_list_runtime(systemd_logind_t)
-udev_read_db(systemd_logind_t)
 udev_read_runtime_files(systemd_logind_t)
 
 userdom_delete_all_user_runtime_dirs(systemd_logind_t)
@@ -849,7 +848,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	udev_read_db(systemd_networkd_t)
 	udev_read_runtime_files(systemd_networkd_t)
 ')
 

--- a/policy/modules/system/udev.fc
+++ b/policy/modules/system/udev.fc
@@ -1,7 +1,3 @@
-/dev/\.udev(/.*)? --	gen_context(system_u:object_r:udev_tbl_t,s0)
-/dev/\.udevdb	--	gen_context(system_u:object_r:udev_tbl_t,s0)
-/dev/udev\.tbl	--	gen_context(system_u:object_r:udev_tbl_t,s0)
-
 /etc/dev\.d/.+	--	gen_context(system_u:object_r:udev_helper_exec_t,s0)
 
 /etc/hotplug\.d/default/udev.* -- gen_context(system_u:object_r:udev_helper_exec_t,s0)

--- a/policy/modules/system/udev.fc
+++ b/policy/modules/system/udev.fc
@@ -6,7 +6,7 @@
 /etc/udev/scripts/.+ --	gen_context(system_u:object_r:udev_helper_exec_t,s0)
 
 /usr/bin/udev		--	gen_context(system_u:object_r:udev_exec_t,s0)
-/usr/bin/udevadm	--	gen_context(system_u:object_r:udevadm_exec_t,s0)
+/usr/bin/udevadm	--	gen_context(system_u:object_r:udev_exec_t,s0)
 /usr/bin/udevd		--	gen_context(system_u:object_r:udev_exec_t,s0)
 /usr/bin/udevinfo	--	gen_context(system_u:object_r:udev_exec_t,s0)
 /usr/bin/udevsend	--	gen_context(system_u:object_r:udev_exec_t,s0)
@@ -18,7 +18,7 @@ ifdef(`distro_debian',`
 ')
 
 /usr/sbin/udev		--	gen_context(system_u:object_r:udev_exec_t,s0)
-/usr/sbin/udevadm	--	gen_context(system_u:object_r:udevadm_exec_t,s0)
+/usr/sbin/udevadm	--	gen_context(system_u:object_r:udev_exec_t,s0)
 /usr/sbin/udevd		--	gen_context(system_u:object_r:udev_exec_t,s0)
 /usr/sbin/udevsend	--	gen_context(system_u:object_r:udev_exec_t,s0)
 /usr/sbin/udevstart	--	gen_context(system_u:object_r:udev_exec_t,s0)

--- a/policy/modules/system/udev.if
+++ b/policy/modules/system/udev.if
@@ -204,7 +204,7 @@ interface(`udev_manage_rules_files',`
 
 ########################################
 ## <summary>
-##	Do not audit search of udev database directories.
+##	Do not audit search of udev database directories.  (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -213,20 +213,16 @@ interface(`udev_manage_rules_files',`
 ## </param>
 #
 interface(`udev_dontaudit_search_db',`
-	gen_require(`
-		type udev_tbl_t;
-	')
-
-	dontaudit $1 udev_tbl_t:dir search_dir_perms;
+	refpolicywarn(`$0($*) has been deprecated.')
 ')
 
 ########################################
 ## <summary>
-##	Read the udev device table.
+##	Read the udev device table.  (Deprecated)
 ## </summary>
 ## <desc>
 ##	<p>
-##	Allow the specified domain to read the udev device table.
+##	Allow the specified domain to read the udev device table.  (Deprecated)
 ##	</p>
 ## </desc>
 ## <param name="domain">
@@ -237,25 +233,12 @@ interface(`udev_dontaudit_search_db',`
 ## <infoflow type="read" weight="10"/>
 #
 interface(`udev_read_db',`
-	gen_require(`
-		type udev_tbl_t;
-	')
-
-	allow $1 udev_tbl_t:dir list_dir_perms;
-
-	read_files_pattern($1, udev_tbl_t, udev_tbl_t)
-	read_lnk_files_pattern($1, udev_tbl_t, udev_tbl_t)
-
-	dev_list_all_dev_nodes($1)
-
-	files_search_etc($1)
-
-	udev_search_runtime($1)
+	refpolicywarn(`$0($*) has been deprecated.')
 ')
 
 ########################################
 ## <summary>
-##	Allow process to modify list of devices.
+##	Allow process to modify list of devices.  (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -264,17 +247,12 @@ interface(`udev_read_db',`
 ## </param>
 #
 interface(`udev_rw_db',`
-	gen_require(`
-		type udev_tbl_t;
-	')
-
-	dev_list_all_dev_nodes($1)
-	allow $1 udev_tbl_t:file rw_file_perms;
+	refpolicywarn(`$0($*) has been deprecated.')
 ')
 
 ########################################
 ## <summary>
-##      Allow process to relabelto udev database
+##      Allow process to relabelto udev database  (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##      <summary>
@@ -283,18 +261,12 @@ interface(`udev_rw_db',`
 ## </param>
 #
 interface(`udev_relabelto_db',`
-	gen_require(`
-		type udev_runtime_t;
-	')
-
-	files_search_runtime($1)
-	allow $1 udev_runtime_t:file relabelto_file_perms;
-	allow $1 udev_runtime_t:lnk_file relabelto_lnk_file_perms;
+	refpolicywarn(`$0($*) has been deprecated.')
 ')
 
 ########################################
 ## <summary>
-##	Allow process to relabelto sockets in /run/udev
+##	Allow process to relabelto sockets in /run/udev  (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -303,11 +275,7 @@ interface(`udev_relabelto_db',`
 ## </param>
 #
 interface(`udev_relabelto_db_sockets',`
-	gen_require(`
-		type udev_runtime_t;
-	')
-
-	allow $1 udev_runtime_t:sock_file relabelto_sock_file_perms;
+	refpolicywarn(`$0($*) has been deprecated.')
 ')
 
 ########################################

--- a/policy/modules/system/udev.if
+++ b/policy/modules/system/udev.if
@@ -514,12 +514,49 @@ interface(`udev_manage_runtime_files',`
 ##	</summary>
 ## </param>
 #
-interface(`udevadm_domtrans',`
+interface(`udev_domtrans_udevadm',`
 	gen_require(`
-		type udevadm_t, udevadm_exec_t;
+		type udevadm_t, udev_exec_t;
 	')
 
-	domtrans_pattern($1, udevadm_exec_t, udevadm_t)
+	domtrans_pattern($1, udev_exec_t, udevadm_t)
+')
+
+########################################
+## <summary>
+##	Execute udev admin in the udevadm domain.  (Deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`udevadm_domtrans',`
+	refpolicywarn(`$0($*) has been deprecated, use udev_domtrans_udevadm() instead.')
+	udev_domtrans_udevadm($1)
+')
+
+########################################
+## <summary>
+##	Execute udevadm in the udevadm domain, and
+##	allow the specified role the udevadm domain.  (Deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`udevadm_run',`
+	refpolicywarn(`$0($*) has been deprecated, use udev_run_udevadm() instead.')
+	udev_run_udevadm($1, $2)
 ')
 
 ########################################
@@ -539,13 +576,28 @@ interface(`udevadm_domtrans',`
 ## </param>
 ## <rolecap/>
 #
-interface(`udevadm_run',`
+interface(`udev_run_udevadm',`
 	gen_require(`
 		attribute_role udevadm_roles;
 	')
 
-	udevadm_domtrans($1)
+	udev_domtrans_udevadm($1)
 	roleattribute $2 udevadm_roles;
+')
+
+########################################
+## <summary>
+##	Execute udevadm in the caller domain.  (Deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`udevadm_exec',`
+	refpolicywarn(`$0($*) has been deprecated, use udev_exec_udevadm() instead.')
+	udev_exec_udevadm($1)
 ')
 
 ########################################
@@ -558,10 +610,10 @@ interface(`udevadm_run',`
 ##	</summary>
 ## </param>
 #
-interface(`udevadm_exec',`
+interface(`udev_exec_udevadm',`
 	gen_require(`
-		type udevadm_exec_t;
+		type udev_exec_t;
 	')
 
-	can_exec($1, udevadm_exec_t)
+	can_exec($1, udev_exec_t)
 ')

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -28,12 +28,9 @@ files_config_file(udev_etc_t)
 type udev_rules_t;
 files_type(udev_rules_t)
 
-type udev_runtime_t alias udev_var_run_t;
+type udev_runtime_t alias { udev_tbl_t udev_var_run_t };
 files_runtime_file(udev_runtime_t)
 init_daemon_runtime_file(udev_runtime_t, dir, "udev")
-
-type udev_tbl_t alias udev_tdb_t;
-files_type(udev_tbl_t)
 
 ifdef(`enable_mcs',`
 	kernel_ranged_domtrans_to(udev_t, udev_exec_t, s0 - mcs_systemhigh)
@@ -73,9 +70,6 @@ can_exec(udev_t, udev_helper_exec_t)
 
 # read udev config
 allow udev_t udev_etc_t:file read_file_perms;
-
-allow udev_t udev_tbl_t:file manage_file_perms;
-dev_filetrans(udev_t, udev_tbl_t, file)
 
 list_dirs_pattern(udev_t, udev_rules_t, udev_rules_t)
 manage_files_pattern(udev_t, udev_rules_t, udev_rules_t)
@@ -402,11 +396,8 @@ delete_files_pattern(udevadm_t, udev_runtime_t, udev_runtime_t)
 delete_lnk_files_pattern(udevadm_t, udev_runtime_t, udev_runtime_t)
 list_dirs_pattern(udevadm_t, udev_runtime_t, udev_runtime_t)
 read_files_pattern(udevadm_t, udev_runtime_t, udev_runtime_t)
+read_lnk_files_pattern(udevadm_t, udev_runtime_t, udev_runtime_t)
 allow udevadm_t udev_runtime_t:dir watch;
-
-list_dirs_pattern(udevadm_t, udev_tbl_t, udev_tbl_t)
-read_files_pattern(udevadm_t, udev_tbl_t, udev_tbl_t)
-read_lnk_files_pattern(udevadm_t, udev_tbl_t, udev_tbl_t)
 
 dev_rw_sysfs(udevadm_t)
 dev_read_urand(udevadm_t)

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -7,7 +7,7 @@ policy_module(udev, 1.28.1)
 attribute_role udevadm_roles;
 
 type udev_t;
-type udev_exec_t;
+type udev_exec_t alias udevadm_exec_t;
 type udev_helper_exec_t;
 kernel_domtrans_to(udev_t, udev_exec_t)
 domain_obj_id_change_exemption(udev_t)
@@ -17,9 +17,7 @@ init_daemon_domain(udev_t, udev_exec_t)
 init_named_socket_activation(udev_t, udev_runtime_t)
 
 type udevadm_t;
-type udevadm_exec_t;
-init_system_domain(udevadm_t, udevadm_exec_t)
-application_domain(udevadm_t, udevadm_exec_t)
+application_domain(udevadm_t, udev_exec_t)
 role udevadm_roles types udevadm_t;
 
 type udev_etc_t alias etc_udev_t;


### PR DESCRIPTION
### devicekit: Udisks uses udevadm, it does not exec udev.

### udev: Systemd 246 merged udev and udevadm executables.

Drop init_system_domain() for udevadm to break type transition conflicts.
Also fix interface naming issues for udevadm interfaces.

Fixes #292

### udev: Drop udev_tbl_t.

This usage under /dev/.udev has been unused for a very long time and
replaced by functionality in /run/udev.  Since these have separate types,
take this opportunity to revoke these likely unnecessary rules.

Fixes #221

Derived from Laurent Bigonville's work in #230
