### PR TITLE
add policy for pcs_snmp_agent

### DIFF
--- a/policy/modules/services/corosync.fc
+++ b/policy/modules/services/corosync.fc
@@ -2,9 +2,11 @@
 
 /usr/bin/corosync	--	gen_context(system_u:object_r:corosync_exec_t,s0)
 /usr/bin/corosync-notifyd	--	gen_context(system_u:object_r:corosync_exec_t,s0)
+/usr/bin/corosync-cmapctl      --      gen_context(system_u:object_r:corosync_exec_t,s0)
 
 /usr/sbin/corosync	--	gen_context(system_u:object_r:corosync_exec_t,s0)
 /usr/sbin/corosync-notifyd	--	gen_context(system_u:object_r:corosync_exec_t,s0)
+/usr/sbin/corosync-cmapctl      --      gen_context(system_u:object_r:corosync_exec_t,s0)
 
 ifdef(`distro_redhat',`
 /usr/share/corosync/corosync			--	gen_context(system_u:object_r:corosync_exec_t,s0)

--- a/policy/modules/services/corosync.if
+++ b/policy/modules/services/corosync.if
@@ -135,6 +135,24 @@ interface(`corosync_rw_tmpfs',`
 	rw_files_pattern($1, corosync_tmpfs_t, corosync_tmpfs_t)
 ')
 
+########################################
+## <summary>
+##	Read process state of corosync.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`corosync_read_state',`
+	gen_require(`
+		type corosync_t;
+	')
+
+	ps_process_pattern($1, corosync_t)
+')
+
 ######################################
 ## <summary>
 ##	All of the rules required to

--- a/policy/modules/services/pacemaker.fc
+++ b/policy/modules/services/pacemaker.fc
@@ -10,3 +10,6 @@
 
 /run/crm(/.*)?	gen_context(system_u:object_r:pacemaker_runtime_t,s0)
 /run/resource-agents(/.*)?		gen_context(system_u:object_r:pacemaker_runtime_t,s0)
+
+/usr/lib/pcs/pcs_snmp_agent     --      gen_context(system_u:object_r:pcs_snmp_agent_exec_t,s0)
+

--- a/policy/modules/services/pacemaker.te
+++ b/policy/modules/services/pacemaker.te
@@ -37,9 +37,16 @@ files_tmpfs_file(pacemaker_tmpfs_t)
 type pacemaker_var_lib_t;
 files_type(pacemaker_var_lib_t)
 
+type pcs_snmp_agent_t;
+type pcs_snmp_agent_exec_t;
+init_daemon_domain(pcs_snmp_agent_t, pcs_snmp_agent_exec_t)
+
+type pcs_snmp_agent_log_t;
+logging_log_file(pcs_snmp_agent_log_t)
+
 ########################################
 #
-# Local policy
+# Pacemaker policy
 #
 
 allow pacemaker_t self:capability { chown dac_override fowner fsetid kill net_raw setgid setuid };
@@ -136,3 +143,66 @@ optional_policy(`
 optional_policy(`
 	sysnet_domtrans_ifconfig(pacemaker_t)
 ')
+
+########################################
+#
+# pcs_snmp_agent policy
+#
+
+allow pcs_snmp_agent_t self:capability { dac_override sys_resource };
+allow pcs_snmp_agent_t self:fifo_file { rw_inherited_fifo_file_perms };
+allow pcs_snmp_agent_t self:process { execmem setsched getsched setrlimit };
+allow pcs_snmp_agent_t self:unix_stream_socket { create_socket_perms };
+
+create_files_pattern(pcs_snmp_agent_t, pcs_snmp_agent_log_t, pcs_snmp_agent_log_t)
+append_files_pattern(pcs_snmp_agent_t, pcs_snmp_agent_log_t, pcs_snmp_agent_log_t)
+logging_log_filetrans(pcs_snmp_agent_t, pcs_snmp_agent_log_t, file)
+
+read_files_pattern(pcs_snmp_agent_t, pacemaker_t, pacemaker_t)
+stream_connect_pattern(pcs_snmp_agent_t, pacemaker_t, pacemaker_t, pacemaker_t)
+allow pcs_snmp_agent_t pacemaker_tmpfs_t:file mmap_rw_file_perms;
+
+corecmd_exec_bin(pcs_snmp_agent_t)
+
+files_read_usr_files(pcs_snmp_agent_t)
+
+fs_list_cgroup_dirs(pcs_snmp_agent_t)
+fs_read_cgroup_files(pcs_snmp_agent_t)
+
+kernel_read_kernel_sysctls(pcs_snmp_agent_t)
+kernel_read_system_state(pcs_snmp_agent_t)
+kernel_read_crypto_sysctls(pcs_snmp_agent_t)
+
+init_search_runtime(pcs_snmp_agent_t)
+init_read_state(pcs_snmp_agent_t)
+init_unix_stream_socket_connectto(pcs_snmp_agent_t)
+
+auth_use_nsswitch(pcs_snmp_agent_t)
+
+miscfiles_read_localization(pcs_snmp_agent_t)
+miscfiles_read_generic_certs(pcs_snmp_agent_t)
+
+ifdef(`init_systemd',`
+	init_get_generic_units_status(pcs_snmp_agent_t)
+	init_get_system_status(pcs_snmp_agent_t)
+	init_list_unit_dirs(pcs_snmp_agent_t)
+	init_service_status(pcs_snmp_agent_t)
+')
+
+optional_policy(`
+	corosync_domtrans(pcs_snmp_agent_t)
+	corosync_read_state(pcs_snmp_agent_t)
+')
+
+optional_policy(`
+	hostname_domtrans(pcs_snmp_agent_t)
+')
+
+optional_policy(`
+	snmp_stream_connect(pcs_snmp_agent_t)
+')
+
+optional_policy(`
+	systemd_read_journal_files(pcs_snmp_agent_t)
+')
+


### PR DESCRIPTION
create corosync_read_state interface, used by pcs_snmp_agent policy

update file context list for corosync to include corosync-cmapctl, this allows pcs_snmp_agent to domtrans when calling it

denial for execmem
type=AVC msg=audit(1610036202.427:3772): avc:  denied  { execmem } for  pid=10875 comm="ruby" scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:system_r:pcs_snmp_agent_t:s0 tclass=process permissive=1

create contexts for pcs_snmp_agent_t and allow it some self permissions

allow pcs_snmp_agent_t to create allows and transision context of those logs

allow pcs_snmp_agent_t to read kernel sysctls

allow pcs_snmp_agent_t to exec bin_t

allow pcs_snmp_agent_t to access pacemaker's cluster information base (cib)
type=AVC msg=audit(1610037438.918:4524): avc:  denied  { read write } for  pid=14866 comm="cibadmin" name="qb-request-cib_rw-header" dev="tmpfs" ino=160994 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:pacemaker_tmpfs_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037438.918:4524): avc:  denied  { open } for  pid=14866 comm="cibadmin" path="/dev/shm/qb-3925-14866-13-FPiaad/qb-request-cib_rw-header" dev="tmpfs" ino=160994 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:pacemaker_tmpfs_t:s0 tclass=file permissive=1
type=SYSCALL msg=audit(1610037438.918:4524): arch=c000003e syscall=2 success=yes exit=5 a0=7ffe28cb09e0 a1=2 a2=180 a3=7ffe28cb02a0 items=1 ppid=14857 pid=14866 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="cibadmin" exe="/usr/sbin/cibadmin" subj=system_u:system_r:pcs_snmp_agent_t:s0 key=(null)
type=AVC msg=audit(1610037438.919:4525): avc:  denied  { map } for  pid=14866 comm="cibadmin" path="/dev/shm/qb-3925-14866-13-FPiaad/qb-request-cib_rw-header" dev="tmpfs" ino=160994 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:pacemaker_tmpfs_t:s0 tclass=file permissive=1
type=SYSCALL msg=audit(1610037438.919:4525): arch=c000003e syscall=9 success=yes exit=140505675866112 a0=0 a1=203c a2=3 a3=1 items=0 ppid=14857 pid=14866 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="cibadmin" exe="/usr/sbin/cibadmin" subj=system_u:system_r:pcs_snmp_agent_t:s0 key=(null)
type=AVC msg=audit(1610037438.906:4523): avc:  denied  { connectto } for  pid=14866 comm="cibadmin" path=006369625F72770000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:system_r:pacemaker_t:s0 tclass=unix_stream_socket permissive=1
type=SYSCALL msg=audit(1610037438.906:4523): arch=c000003e syscall=42 success=yes exit=0 a0=4 a1=7ffe28cb2a40 a2=6e a3=7ffe28cb2460 items=0 ppid=14857 pid=14866 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="cibadmin" exe="/usr/sbin/cibadmin" subj=system_u:system_r:pcs_snmp_agent_t:s0 key=(null)

allow pcs_snmp_agent_t to read files with usr_t context
type=AVC msg=audit(1610037437.737:4513): avc:  denied  { getattr } for  pid=14857 comm="ruby" path="/usr/share/ruby/json.rb" dev="dm-0" ino=78097 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=lnk_file permissive=1
type=AVC msg=audit(1610037439.029:4532): avc:  denied  { read } for  pid=14869 comm="crm_mon" name="pacemaker" dev="dm-0" ino=78392 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1610037561.019:4615): avc:  denied  { read } for  pid=15257 comm="ruby" name="rubygems.rb" dev="dm-0" ino=78469 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037561.019:4615): avc:  denied  { open } for  pid=15257 comm="ruby" path="/usr/share/rubygems/rubygems.rb" dev="dm-0" ino=78469 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037561.019:4616): avc:  denied  { getattr } for  pid=15257 comm="ruby" path="/usr/share/rubygems/rubygems.rb" dev="dm-0" ino=78469 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037561.020:4617): avc:  denied  { ioctl } for  pid=15257 comm="ruby" path="/usr/share/rubygems/rubygems.rb" dev="dm-0" ino=78469 ioctlcmd=5401 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1

allow pcs_snmp_agent_t to to get cgroup information
type=AVC msg=audit(1610036387.957:3864): avc:  denied  { getattr } for  pid=11499 comm="systemctl" path="/sys/fs/cgroup/systemd/system.slice/pacemaker.service/cgroup.procs" dev="cgroup" ino=31992 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610036480.913:3921): avc:  denied  { read } for  pid=11807 comm="systemctl" name="pacemaker.service" dev="cgroup" ino=31990 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1610036665.036:4019): avc:  denied  { read } for  pid=12401 comm="systemctl" name="pacemaker.service" dev="cgroup" ino=31990 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1610036788.922:4099): avc:  denied  { read } for  pid=12798 comm="systemctl" name="pacemaker.service" dev="cgroup" ino=31990 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1610036944.042:4202): avc:  denied  { read } for  pid=13302 comm="systemctl" name="pacemaker.service" dev="cgroup" ino=31990 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1610036977.714:4223): avc:  denied  { read } for  pid=13416 comm="systemctl" name="cgroup.procs" dev="cgroup" ino=30811 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610036977.714:4223): avc:  denied  { open } for  pid=13416 comm="systemctl" path="/sys/fs/cgroup/systemd/system.slice/corosync.service/cgroup.procs" dev="cgroup" ino=30811 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=file permissive=1

allow pcs_snmp_agent_t to read nsswitch
type=AVC msg=audit(1610037562.211:4626): avc:  denied  { open } for  pid=15266 comm="cibadmin" path="/etc/nsswitch.conf" dev="dm-0" ino=40445 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037562.212:4627): avc:  denied  { getattr } for  pid=15266 comm="cibadmin" path="/etc/nsswitch.conf" dev="dm-0" ino=40445 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=1

allow pcs_snmp_agent_t to read zoneinfo
type=AVC msg=audit(1610035641.390:3398): avc:  denied  { search } for  pid=3838 comm="pcs_snmp_agent" name="zoneinfo" dev="dm-0" ino=69241 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:locale_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1610035767.532:3480): avc:  denied  { getattr } for  pid=3838 comm="pcs_snmp_agent" path="/usr/share/zoneinfo/GMT" dev="dm-0" ino=71453 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:locale_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610035767.664:3481): avc:  denied  { read } for  pid=9488 comm="ruby" name="GMT" dev="dm-0" ino=71453 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:locale_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610035767.664:3481): avc:  denied  { open } for  pid=9488 comm="ruby" path="/usr/share/zoneinfo/GMT" dev="dm-0" ino=71453 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:locale_t:s0 tclass=file permissive=1

allow pcs_snmp_agent_t to read certificates
type=AVC msg=audit(1610037375.994:4485): avc:  denied  { getattr } for  pid=14660 comm="ruby" path="/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" dev="dm-0" ino=38862 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037499.874:4565): avc:  denied  { read } for  pid=15055 comm="ruby" name="cert.pem" dev="dm-0" ino=38537 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=lnk_file permissive=1
type=AVC msg=audit(1610037529.975:4584): avc:  denied  { read } for  pid=15144 comm="ruby" name="tls-ca-bundle.pem" dev="dm-0" ino=38862 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037529.975:4584): avc:  denied  { open } for  pid=15144 comm="ruby" path="/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" dev="dm-0" ino=38862 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=file permissive=1

allow pcs_snmp_agent_t get service status

type=USER_AVC msg=audit(1610034251.683:2349): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { status } for auid=n/a uid=0 gid=0 path="/usr/lib/systemd/system/pacemaker.service" cmdline="systemctl status pacemaker.service" scontext=system_u:system_r:pcs_snmp_agent_t:s0
tcontext=system_u:object_r:systemd_unit_t:s0 tclass=service  exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'
type=USER_AVC msg=audit(1610034251.773:2363): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { status } for auid=n/a uid=0 gid=0 cmdline="systemctl is-enabled pacemaker.service" scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=s
ystem  exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'
type=USER_AVC msg=audit(1610034252.626:2367): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { status } for auid=n/a uid=0 gid=0 cmdline="systemctl status pacemaker_remote.service" scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:system_r:init_t:s0 tclas
s=service  exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'

type=AVC msg=audit(1610034251.757:2361): avc:  denied  { getattr } for  pid=4342 comm="systemctl" path="/etc/systemd/system" dev="dm-0" ino=38595 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:systemd_unit_t:s0 tclass=dir permissive=1

allow pcs_snmp_agent_t to search init_t dirs
type=AVC msg=audit(1610037317.490:4460): avc:  denied  { search } for  pid=14489 comm="systemctl" name="1" dev="proc" ino=9242 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=dir permissive=1

allow pcs_snmp_agent_t to connecto to systemd unix socket
type=AVC msg=audit(1610037533.196:4600): avc:  denied  { connectto } for  pid=15174 comm="systemctl" path="/run/systemd/private" scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=unix_stream_socket permissive=1

allow pcs_snmp_agent_t to run corosync in corosync_t domain
type=AVC msg=audit(1610037437.793:4515): avc:  denied  { execute } for  pid=14859 comm="ruby" name="corosync" dev="dm-0" ino=57633 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:corosync_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037437.793:4515): avc:  denied  { read open } for  pid=14859 comm="ruby" path="/usr/sbin/corosync" dev="dm-0" ino=57633 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:corosync_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037437.793:4515): avc:  denied  { execute_no_trans } for  pid=14859 comm="ruby" path="/usr/sbin/corosync" dev="dm-0" ino=57633 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:corosync_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037437.793:4515): avc:  denied  { map } for  pid=14859 comm="corosync" path="/usr/sbin/corosync" dev="dm-0" ino=57633 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:corosync_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610034246.149:2265): avc:  denied  { execute } for  pid=4258 comm="ruby" name="corosync-cmapctl" dev="dm-0" ino=57635 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1

allow pcs_snmp_agent_t to read corosync state
type=AVC msg=audit(1610037503.610:4570): avc:  denied  { open } for  pid=15101 comm="systemctl" path="/proc/3874/comm" dev="proc" ino=26243 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:system_r:corosync_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037503.611:4571): avc:  denied  { getattr } for  pid=15101 comm="systemctl" path="/proc/3874/comm" dev="proc" ino=26243 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:system_r:corosync_t:s0 tclass=file permissive=1

allow pcs_snmp_agent_t to exec hostname
type=AVC msg=audit(1610037469.569:4545): avc:  denied  { execute } for  pid=14951 comm="ruby" name="hostname" dev="dm-0" ino=54047 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:hostname_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037469.569:4545): avc:  denied  { read open } for  pid=14951 comm="ruby" path="/usr/bin/hostname" dev="dm-0" ino=54047 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:hostname_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037469.569:4545): avc:  denied  { execute_no_trans } for  pid=14951 comm="ruby" path="/usr/bin/hostname" dev="dm-0" ino=54047 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:hostname_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037469.569:4545): avc:  denied  { map } for  pid=14951 comm="hostname" path="/usr/bin/hostname" dev="dm-0" ino=54047 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:hostname_exec_t:s0 tclass=file permissive=1

allow pcs_snmp_agent_t to connecto to snmp socket
type=AVC msg=audit(1610034242.897:2197): avc:  denied  { write } for  pid=3838 comm="pcs_snmp_agent" name="master" dev="tmpfs" ino=30868 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:snmpd_var_lib_t:s0 tclass=sock_file permissive=1
type=AVC msg=audit(1610034242.897:2197): avc:  denied  { connectto } for  pid=3838 comm="pcs_snmp_agent" path="/var/agentx/master" scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:system_r:snmpd_t:s0 tclass=unix_stream_socket permissive=1

allow pcs_snmp_agent_t to read systemd journal files
type=AVC msg=audit(1610037472.176:4552): avc:  denied  { map } for  pid=14980 comm="systemctl" path="/var/log/journal/c7aa97546e1f4d3783a3aeffeeb749e3/system.journal" dev="tmpfs" ino=146184 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:systemd_journal_t:s0 tclass=file permissive=1
type=AVC msg=audit(1610037533.220:4602): avc:  denied  { read } for  pid=15174 comm="systemctl" name="/" dev="tmpfs" ino=10069 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:systemd_journal_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1610037533.220:4602): avc:  denied  { open } for  pid=15174 comm="systemctl" path="/var/log/journal" dev="tmpfs" ino=10069 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:systemd_journal_t:s0 tclass=dir permissive=1