### PR TITLE
Add tunable to allow evdev passthrough with qemu

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -2189,6 +2189,24 @@ interface(`dev_manage_input_dev',`
 
 ########################################
 ## <summary>
+##	IOCTL the input event devices (/dev/input).
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_ioctl_input_dev',`
+	gen_require(`
+		type event_device_t;
+	')
+
+	allow $1 event_device_t:chr_file ioctl;
+')
+
+########################################
+## <summary>
 ##	Read and write ipmi devices (/dev/ipmi*).
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/virt.te
+++ b/policy/modules/services/virt.te
@@ -78,6 +78,14 @@ gen_tunable(virt_use_xserver, false)
 ## </desc>
 gen_tunable(virt_use_vfio, false)
 
+## <desc>
+##	<p>
+##	Determine whether confined virtual guests
+##	can use input devices via evdev pass through.
+##	</p>
+## </desc>
+gen_tunable(virt_use_evdev, false)
+
 attribute virt_ptynode;
 attribute virt_domain;
 attribute virt_image_type;
@@ -446,6 +454,12 @@ corenet_tcp_connect_all_ports(svirt_t)
 
 tunable_policy(`virt_use_vfio',`
 	dev_rw_vfio_dev(svirt_t)
+')
+
+tunable_policy(`virt_use_evdev',`
+	# qemu uses IOCTLs 0x01, 0x06, 0x90, and potentially others
+	# see qemu:include/standard-headers/linux/input.h
+	dev_ioctl_input_dev(svirt_t)
 ')
 
 ########################################


### PR DESCRIPTION
A feature of qemu allows users to pass through input devices directly into the virtual guest. When this is enabled, a user can press both CTRL keys at the same time, at which point the input devices specified on the qemu commandline have their input events sent directly to the guest. This is done via the IOCTL permission on the specified devices. This merge adds a boolean to allow this feature to be enabled.

Signed-off-by: Kenton Groombridge <me@concord.sh>