### PR TITLE
spamassassin: add rspamd support and tunable

### DIFF
--- a/policy/modules/services/spamassassin.fc
+++ b/policy/modules/services/spamassassin.fc
@@ -6,6 +6,8 @@ HOME_DIR/\.spamd(/.*)?			gen_context(system_u:object_r:spamd_home_t,s0)
 /etc/rc\.d/init\.d/spampd	--	gen_context(system_u:object_r:spamd_initrc_exec_t,s0)
 /etc/rc\.d/init\.d/mimedefang.*	--	gen_context(system_u:object_r:spamd_initrc_exec_t,s0)
 
+/etc/rspamd(/.*)?			gen_context(system_u:object_r:spamd_etc_t,s0)
+
 /usr/bin/mimedefang		--	gen_context(system_u:object_r:spamd_exec_t,s0)
 /usr/bin/mimedefang-multiplexor	--	gen_context(system_u:object_r:spamd_exec_t,s0)
 /usr/bin/sa-learn		--	gen_context(system_u:object_r:spamc_exec_t,s0)
@@ -14,16 +16,31 @@ HOME_DIR/\.spamd(/.*)?			gen_context(system_u:object_r:spamd_home_t,s0)
 /usr/bin/spamd			--	gen_context(system_u:object_r:spamd_exec_t,s0)
 /usr/bin/spampd			--	gen_context(system_u:object_r:spamd_exec_t,s0)
 /usr/bin/sa-update		--	gen_context(system_u:object_r:spamd_update_exec_t,s0)
+/usr/bin/rspamd			-l	gen_context(system_u:object_r:spamd_exec_t,s0)
+/usr/bin/rspamd-[^/]+	--	gen_context(system_u:object_r:spamd_exec_t,s0)
+/usr/bin/rspamc			-l	gen_context(system_u:object_r:spamc_exec_t,s0)
+/usr/bin/rspamc-[^/]+	--	gen_context(system_u:object_r:spamc_exec_t,s0)
+/usr/bin/rspamadm		-l	gen_context(system_u:object_r:spamc_exec_t,s0)
+/usr/bin/rspamadm-[^/]+	--	gen_context(system_u:object_r:spamc_exec_t,s0)
 
 /usr/sbin/spamd			--	gen_context(system_u:object_r:spamd_exec_t,s0)
 /usr/sbin/spampd		--	gen_context(system_u:object_r:spamd_exec_t,s0)
 
 /usr/lib/systemd/system/spamassassin\.service	--	gen_context(system_u:object_r:spamassassin_unit_t,s0)
 
+/usr/share/rspamd/elastic(/.*)?		gen_context(system_u:object_r:spamd_compiled_t,s0)
+/usr/share/rspamd/languages(/.*)?	gen_context(system_u:object_r:spamd_compiled_t,s0)
+/usr/share/rspamd/lualib(/.*)?		gen_context(system_u:object_r:spamd_compiled_t,s0)
+/usr/share/rspamd/plugins(/.*)?		gen_context(system_u:object_r:spamd_compiled_t,s0)
+/usr/share/rspamd/rules(/.*)?		gen_context(system_u:object_r:spamd_compiled_t,s0)
+
 /var/lib/spamassassin(/.*)?		gen_context(system_u:object_r:spamd_var_lib_t,s0)
 /var/lib/spamassassin/compiled(/.*)?	gen_context(system_u:object_r:spamd_compiled_t,s0)
+/var/lib/rspamd(/.*)?		gen_context(system_u:object_r:spamd_var_lib_t,s0)
+/var/lib/rspamd/rspamd\.sock	-s gen_context(system_u:object_r:spamd_runtime_t,s0)
 
 /var/log/spamd\.log.*		--	gen_context(system_u:object_r:spamd_log_t,s0)
+/var/log/rspamd\.log.*		--	gen_context(system_u:object_r:spamd_log_t,s0)
 /var/log/mimedefang.*		--	gen_context(system_u:object_r:spamd_log_t,s0)
 
 /var/vmail/\.spamassassin(/.*)?		gen_context(system_u:object_r:spamassassin_home_t,s0)

--- a/policy/modules/services/spamassassin.te
+++ b/policy/modules/services/spamassassin.te
@@ -21,6 +21,14 @@ gen_tunable(spamassassin_can_network, false)
 ## </desc>
 gen_tunable(spamd_enable_home_dirs, false)
 
+## <desc>
+##	<p>
+##	Determine whether extra rules should
+##	be enabled to support rspamd.
+##	</p>
+## </desc>
+gen_tunable(rspamd_spamd, false)
+
 type spamd_update_t;
 typealias spamd_update_t alias spamd_gpg_t;
 type spamd_update_exec_t;
@@ -80,6 +88,9 @@ files_type(spamd_spool_t)
 
 type spamd_tmp_t;
 files_tmp_file(spamd_tmp_t)
+
+type spamd_tmpfs_t;
+files_tmpfs_file(spamd_tmpfs_t)
 
 type spamd_var_lib_t;
 files_type(spamd_var_lib_t)
@@ -382,6 +393,30 @@ tunable_policy(`spamd_enable_home_dirs',`
 	userdom_manage_user_home_content_dirs(spamd_t)
 	userdom_manage_user_home_content_files(spamd_t)
 	userdom_manage_user_home_content_symlinks(spamd_t)
+')
+
+tunable_policy(`rspamd_spamd',`
+	allow spamd_t self:process setrlimit;
+	allow spamc_t self:process setrlimit;
+
+	list_dirs_pattern(spamd_t, spamd_etc_t, spamd_etc_t)
+	mmap_read_files_pattern(spamd_t, spamd_etc_t, spamd_etc_t)
+	allow spamd_t spamd_etc_t:dir watch;
+
+	mmap_read_files_pattern(spamd_t, spamd_var_lib_t, spamd_var_lib_t)
+	allow spamd_t spamd_var_lib_t:dir watch;
+	filetrans_pattern(spamd_t, spamd_var_lib_t, spamd_runtime_t, sock_file)
+
+	search_dirs_pattern(spamd_t, spamd_log_t, spamd_log_t)
+
+	fs_search_tmpfs(spamd_t)
+	manage_dirs_pattern(spamd_t, spamd_tmpfs_t, spamd_tmpfs_t)
+	manage_files_pattern(spamd_t, spamd_tmpfs_t, spamd_tmpfs_t)
+	mmap_read_files_pattern(spamd_t, spamd_tmpfs_t, spamd_tmpfs_t)
+	fs_tmpfs_filetrans(spamd_t, spamd_tmpfs_t, { dir file })
+
+	corenet_tcp_connect_http_port(spamd_t)
+	corenet_tcp_connect_redis_port(spamd_t)
 ')
 
 tunable_policy(`use_nfs_home_dirs',`


### PR DESCRIPTION
Additional rules are required to enable rspamd support. This commit adds
file contexts for rspamd's files and adds a tunable that enables the
additional rules needed for rspamd to function.

Signed-off-by: Kenton Groombridge <me@concord.sh>