### PR TITLE
fail2ban: allow reading systemd journal

### DIFF
--- a/policy/modules/services/fail2ban.te
+++ b/policy/modules/services/fail2ban.te
@@ -121,6 +121,10 @@ optional_policy(`
 	shorewall_domtrans(fail2ban_t)
 ')
 
+optional_policy(`
+	systemd_read_journal_files(fail2ban_t)
+')
+
 ########################################
 #
 # Client Local policy


### PR DESCRIPTION
fail2ban can be configured to use the systemd journal, where the mmap permission is needed on the journal files.

Signed-off-by: Kenton Groombridge <me@concord.sh>