### PR TITLE
stunnel: add log type and rules

### DIFF
--- a/policy/modules/services/stunnel.te
+++ b/policy/modules/services/stunnel.te
@@ -15,6 +15,9 @@ files_config_file(stunnel_etc_t)
 type stunnel_runtime_t alias stunnel_var_run_t;
 files_runtime_file(stunnel_runtime_t)
 
+type stunnel_log_t;
+logging_log_file(stunnel_log_t)
+
 type stunnel_tmp_t;
 files_tmp_file(stunnel_tmp_t)
 
@@ -41,6 +44,11 @@ files_tmp_filetrans(stunnel_t, stunnel_tmp_t, { file dir })
 manage_dirs_pattern(stunnel_t, stunnel_runtime_t, stunnel_runtime_t)
 manage_files_pattern(stunnel_t, stunnel_runtime_t, stunnel_runtime_t)
 files_runtime_filetrans(stunnel_t, stunnel_runtime_t, { dir file })
+
+manage_dirs_pattern(stunnel_t, stunnel_log_t, stunnel_log_t)
+create_files_pattern(stunnel_t, stunnel_log_t, stunnel_log_t)
+append_files_pattern(stunnel_t, stunnel_log_t, stunnel_log_t)
+logging_log_filetrans(stunnel_t, stunnel_log_t, { dir file })
 
 kernel_read_kernel_sysctls(stunnel_t)
 kernel_read_system_state(stunnel_t)


### PR DESCRIPTION
stunnel can be configured to log to its own log files. This commit adds the type and rules needed for this functionality.

Signed-off-by: Kenton Groombridge <me@concord.sh>