### PR TITLE
apache: add interface for list dir perms on httpd content

### DIFF
--- a/policy/modules/services/apache.if
+++ b/policy/modules/services/apache.if
@@ -520,6 +520,24 @@ interface(`apache_search_all_content',`
 	allow $1 httpdcontent:dir search_dir_perms;
 ')
 
+#######################################
+## <summary>
+##	List all apache content.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`apache_list_all_content',`
+	gen_require(`
+		attribute httpdcontent;
+	')
+
+	allow $1 httpdcontent:dir list_dir_perms;
+')
+
 ########################################
 ## <summary>
 ##	Create, read, write, and delete


### PR DESCRIPTION
This is needed by some webservers such as nginx when autoindexing is
enabled.

Signed-off-by: Kenton Groombridge <me@concord.sh>