### PR TITLE
pcs_snmpd_agent_t fix denials to allow it to read needed queues

### DIFF
--- a/policy/modules/services/pacemaker.te
+++ b/policy/modules/services/pacemaker.te
@@ -160,12 +160,13 @@ logging_log_filetrans(pcs_snmp_agent_t, pcs_snmp_agent_log_t, file)
 
 read_files_pattern(pcs_snmp_agent_t, pacemaker_t, pacemaker_t)
 stream_connect_pattern(pcs_snmp_agent_t, pacemaker_t, pacemaker_t, pacemaker_t)
-allow pcs_snmp_agent_t pacemaker_tmpfs_t:file mmap_rw_file_perms;
+mmap_rw_files_pattern(pcs_snmp_agent_t, pacemaker_tmpfs_t, pacemaker_tmpfs_t)
 
 corecmd_exec_bin(pcs_snmp_agent_t)
 
 files_read_usr_files(pcs_snmp_agent_t)
 
+fs_getattr_tmpfs(pcs_snmp_agent_t)
 fs_list_cgroup_dirs(pcs_snmp_agent_t)
 fs_read_cgroup_files(pcs_snmp_agent_t)
 


### PR DESCRIPTION
Jan 27 18:16:51 audispd: node=virtual type=AVC msg=audit(1611771411.553:9337): avc:  denied  { search } for  pid=13880 comm="cibadmin" name="qb-6671-13880-13-bRhDEX" dev="tmpfs" ino=88809 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:pacemaker_tmpfs_t:s0 tclass=dir permissive=0
Jan 27 19:53:46 audispd: node=virtual type=AVC msg=audit(1611777226.144:25975): avc:  denied  { getattr } for  pid=29489 comm="systemctl" name="/" dev="tmpfs" ino=14072 scontext=system_u:system_r:pcs_snmp_agent_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=0

Signed-off-by: Dave Sugar <dsugar@tresys.com>