### PR TITLE
init: label systemd units in /etc

### DIFF
--- a/config/file_contexts.subs_dist
+++ b/config/file_contexts.subs_dist
@@ -15,6 +15,7 @@
 /libx32 /usr/lib
 /sbin /usr/sbin
 /etc/init.d /etc/rc.d/init.d
+/etc/systemd/system /usr/lib/systemd/system
 /lib/systemd /usr/lib/systemd
 /run/lock /var/lock
 /usr/lib32 /usr/lib


### PR DESCRIPTION
Units can be created and configured in `/etc/systemd/system`. This commit labels these files appropriately as `systemd_unit_t`.

Signed-off-by: Kenton Groombridge <me@concord.sh>