### PR TITLE
Work with xdg module disabled

### DIFF
--- a/policy/modules/apps/gpg.te
+++ b/policy/modules/apps/gpg.te
@@ -359,8 +359,6 @@ miscfiles_read_localization(gpg_pinentry_t)
 
 userdom_use_user_terminals(gpg_pinentry_t)
 
-xdg_read_data_files(gpg_pinentry_t)
-
 tunable_policy(`use_nfs_home_dirs',`
 	fs_read_nfs_files(gpg_pinentry_t)
 ')
@@ -380,6 +378,10 @@ optional_policy(`
 
 optional_policy(`
 	pulseaudio_run(gpg_pinentry_t, gpg_pinentry_roles)
+')
+
+optional_policy(`
+	xdg_read_data_files(gpg_pinentry_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1182,9 +1182,6 @@ template(`userdom_unpriv_user_template', `
 		fs_exec_noxattr($1_t)
 	')
 
-	# Allow users to manage xdg content in their home directories
-	userdom_xdg_user_template($1)
-
 	# Allow users to run TCP servers (bind to ports and accept connection from
 	# the same domain and outside users) disabling this forces FTP passive mode
 	# and may change other protocols
@@ -1225,6 +1222,11 @@ template(`userdom_unpriv_user_template', `
 		systemd_use_logind_fds($1_t)
 		systemd_dbus_chat_hostnamed($1_t)
 		systemd_write_inherited_logind_inhibit_pipes($1_t)
+	')
+
+	# Allow users to manage xdg content in their home directories
+	optional_policy(`
+		userdom_xdg_user_template($1)
 	')
 
 	# Allow controlling usbguard


### PR DESCRIPTION
These two cases I see when building on a system without graphical interface.
Move userdom_xdg_user_template into optional block
gpg module doesn't require a graphical front end, move xdg_read_data_files into optional block

Signed-off-by: Dave Sugar <dsugar@tresys.com>