### PR TITLE
Added support for tmux xdg config path

### DIFF
--- a/policy/modules/apps/screen.fc
+++ b/policy/modules/apps/screen.fc
@@ -1,3 +1,4 @@
+HOME_DIR/\.config/tmux(/.*)?	--	gen_context(system_u:object_r:screen_home_t,s0)
 HOME_DIR/\.screen(/.*)?		gen_context(system_u:object_r:screen_home_t,s0)
 HOME_DIR/\.screenrc	--	gen_context(system_u:object_r:screen_home_t,s0)
 HOME_DIR/\.tmux\.conf	--	gen_context(system_u:object_r:screen_home_t,s0)

--- a/policy/modules/apps/screen.te
+++ b/policy/modules/apps/screen.te
@@ -110,3 +110,7 @@ tunable_policy(`use_nfs_home_dirs',`
 	fs_manage_nfs_named_pipes(screen_domain)
 	fs_read_nfs_symlinks(screen_domain)
 ')
+
+optional_policy(`
+	xdg_search_config_dirs(screen_domain)
+')


### PR DESCRIPTION
tmux attempts to read `~/.config/tmux/tmux.conf` and displays a permission denied error without this addition.