### PR TITLE
certbot: add support for acme.sh

### DIFF
--- a/policy/modules/services/certbot.fc
+++ b/policy/modules/services/certbot.fc
@@ -1,4 +1,6 @@
 /usr/bin/certbot	--	gen_context(system_u:object_r:certbot_exec_t,s0)
 /usr/bin/letsencrypt	--	gen_context(system_u:object_r:certbot_exec_t,s0)
+/usr/share/acme\.sh/acme\.sh	--	gen_context(system_u:object_r:certbot_exec_t,s0)
 /var/lib/letsencrypt(/.*)?	gen_context(system_u:object_r:certbot_lib_t,s0)
 /var/log/letsencrypt(/.*)?	gen_context(system_u:object_r:certbot_log_t,s0)
+/var/lib/acme\.sh(/.*)?		gen_context(system_u:object_r:certbot_lib_t,s0)

--- a/policy/modules/services/certbot.te
+++ b/policy/modules/services/certbot.te
@@ -1,5 +1,13 @@
 policy_module(certbot, 1.0.0)
 
+## <desc>
+##	<p>
+##	Determine whether additional rules
+##	should be enabled to support acme.sh
+##	</p>
+## </desc>
+gen_tunable(certbot_acmesh, false)
+
 ########################################
 #
 # Declarations
@@ -92,6 +100,11 @@ sysnet_read_config(certbot_t)
 
 userdom_dontaudit_search_user_home_dirs(certbot_t)
 userdom_use_user_ptys(certbot_t)
+
+tunable_policy(`certbot_acmesh',`
+	corecmd_exec_bin(certbot_t)
+	corecmd_exec_shell(certbot_t)
+')
 
 optional_policy(`
 	# for writing to webroot


### PR DESCRIPTION
acme.sh is an alternative to cerbot written in pure Unix shell.

Signed-off-by: Kenton Groombridge <me@concord.sh>