### PR TITLE
Improve monolithic policy build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /tmp/
 
 .vagrant/
+
+# monolithic generated files
+/file_contexts
+/homedir_template
+/policy.conf

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -13,6 +13,11 @@ ifeq "$(kv)" ""
 	kv := $(pv)
 endif
 
+# dont print version warnings if we specified a lower version than the kernel supports
+ifneq "$(OUTPUT_POLICY)" ""
+	kv := $(shell if test $(kv) -gt $(pv); then echo $(pv); else echo $(kv); fi)
+endif
+
 # load_policy(8) loads policy from /etc/selinux/<SELINUXTYPE>/policy/policy.$(pv)
 # It does this by reading the /etc/selinux/config file SELINUXTYPE entry to
 # form the full path. $(polbinpath) will contain this evaluated path for use as
@@ -73,7 +78,7 @@ $(polver): $(policy_conf)
 	@echo "Compiling $(NAME) $(polver)"
 ifneq ($(pv),$(kv))
 	@echo
-	@echo "WARNING: Policy version mismatch!  Is your OUTPUT_POLICY set correctly?"
+	@echo "WARNING: Policy version mismatch (policy:$(pv) kernel:$(kv))!  Is your OUTPUT_POLICY set correctly?"
 	@echo
 endif
 	$(verbose) $(CHECKPOLICY) -U $(UNK_PERMS) $^ -o $@
@@ -86,7 +91,7 @@ $(loadpath): $(policy_conf)
 	@echo "Compiling and installing $(NAME) $(loadpath)"
 ifneq ($(pv),$(kv))
 	@echo
-	@echo "WARNING: Policy version mismatch!  Is your OUTPUT_POLICY set correctly?"
+	@echo "WARNING: Policy version mismatch (policy:$(pv) kernel:$(kv))!  Is your OUTPUT_POLICY set correctly?"
 	@echo
 endif
 	@$(INSTALL) -d -m 0755 $(@D)

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -111,7 +111,7 @@ ifneq ($(polbinpath).$(pv),$(loadpath))
 		Check $(topdir)/config file entry is: "SELINUXTYPE=$(NAME)")
 endif
 	@echo "Loading $(NAME) $(loadpath)"
-	$(verbose) $(LOADPOLICY) -q $(loadpath)
+	$(verbose) $(LOADPOLICY)
 
 ########################################
 #

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -217,7 +217,7 @@ $(fcpath): $(fc) $(loadpath) $(userpath)/system.users
 	@$(INSTALL) -d -m 0755 $(@D)
 	$(verbose) $(INSTALL) -m 0644 $(fc) $(fcpath)
 	$(verbose) $(INSTALL) -m 0644 $(homedir_template) $(homedirpath)
-	$(verbose) $(UMASK) 022 ; $(genhomedircon) -d $(topdir) -t $(NAME) $(USEPWD)
+	$(verbose) $(UMASK) 022 ; $(genhomedircon) -d $(topdir) -t $(NAME)
 
 ########################################
 #

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -267,4 +267,4 @@ clean:
 	$(verbose) rm -f *.res
 	$(verbose) rm -fR $(tmpdir)
 
-.PHONY: default policy install load reload enableaudit checklabels restorelabels relabel check longcheck clean
+.PHONY: default policy install load reload enableaudit checklabels restorelabels relabel resetlabels validate check longcheck clean

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -81,7 +81,7 @@ ifneq ($(pv),$(kv))
 	@echo "WARNING: Policy version mismatch (policy:$(pv) kernel:$(kv))!  Is your OUTPUT_POLICY set correctly?"
 	@echo
 endif
-	$(verbose) $(CHECKPOLICY) -U $(UNK_PERMS) $^ -o $@
+	$(verbose) $(CHECKPOLICY) -U $(UNK_PERMS) -S -O -E $^ -o $@
 
 ########################################
 #
@@ -95,7 +95,7 @@ ifneq ($(pv),$(kv))
 	@echo
 endif
 	@$(INSTALL) -d -m 0755 $(@D)
-	$(verbose) $(CHECKPOLICY) -U $(UNK_PERMS)  $^ -o $@
+	$(verbose) $(CHECKPOLICY) -U $(UNK_PERMS) -S -O -E $^ -o $@
 
 ########################################
 #

--- a/build.conf
+++ b/build.conf
@@ -8,7 +8,7 @@
 # version policy it supports.  Setting this will
 # override the version.  This only has an
 # effect for monolithic policies.
-#OUTPUT_POLICY = 18
+#OUTPUT_POLICY = 32
 
 # Policy Type
 # standard, mls, mcs

--- a/support/genhomedircon.py
+++ b/support/genhomedircon.py
@@ -138,9 +138,6 @@ class selinuxConfig:
 	def getFileContextFile(self):
 		return self.getFileContextDir()+"/file_contexts"
 
-	def getContextDir(self):
-		return self.selinuxdir+self.setype+self.contextdir
-
 	def getHomeDirTemplate(self):
 		return self.getFileContextDir()+"/homedir_template"
 
@@ -270,9 +267,6 @@ class selinuxConfig:
 			ret += self.getHomeRootContext(h)
 		ret += self.genHomeDirContext()
 		return ret
-
-	def printout(self):
-		print(self.genoutput())
 
 	def write(self):
 		try:

--- a/support/genhomedircon.py
+++ b/support/genhomedircon.py
@@ -143,10 +143,9 @@ class selinuxConfig:
 
 	def getHomeRootContext(self, homedir):
 		rc=getstatusoutput("grep HOME_ROOT  %s | sed -e \"s|^HOME_ROOT|%s|\"" % ( self.getHomeDirTemplate(), homedir))
-		if rc[0] == 0:
-			return rc[1]+"\n"
-		else:
-			errorExit("sed error " + rc[1])
+		if rc[0] != 0:
+			errorExit("sed error (" + str(rc[0]) + "): " + rc[1])
+		return rc[1]+"\n"
 
 	def getUsersFile(self):
 		return self.selinuxdir+self.setype+"/users/local.users"
@@ -211,7 +210,7 @@ class selinuxConfig:
 		users = self.getUsers()
 		ret=""
 		# Fill in HOME and ROLE for users that are defined
-		for u in users.keys():
+		for u in users:
 			ret += self.getHomeDirContext (u, users[u]["home"], users[u]["role"], users[u]["name"], users[u]["uid"])
 		return ret+"\n"
 
@@ -244,8 +243,7 @@ class selinuxConfig:
 				break
 		if exists == 1:
 			return 1
-		else:
-			return 0
+		return 0
 
 
 	def getHomeDirs(self):
@@ -301,11 +299,11 @@ try:
 						'nopasswd',
 						'dir='])
 	for o,a in gopts:
-		if o == '--type' or o == "-t":
+		if o in ('--type', '-t'):
 			setype=a
-		if o == '--nopasswd'  or o == "-n":
+		if o in ('--nopasswd', '-n'):
 			usepwd=0
-		if o == '--dir'  or o == "-d":
+		if o in ('--dir', '-d'):
 			directory=a
 		if o == '--help':
 			usage()

--- a/support/genhomedircon.py
+++ b/support/genhomedircon.py
@@ -266,7 +266,7 @@ class selinuxConfig:
 	def genoutput(self):
 		ret= self.heading()
 		for h in self.getHomeDirs():
-			ret += self.getHomeDirContext ("user_u" , h+'/[^/]*', "user")
+			ret += self.getHomeDirContext ("user_u" , h+'/[^/]+', "user")
 			ret += self.getHomeRootContext(h)
 		ret += self.genHomeDirContext()
 		return ret


### PR DESCRIPTION
Generate substituted file contexts for templated paths containing `%{USERNAME}` or `%{USERID}`, like semodules's genhomedircon.

Example:
```
  /run/user/%{USERID}  -d  gen_context(system_u:object_r:user_runtime_t,s0)
```
into
```
/run/user/[0-9]+  -d  gen_context(user_u:object_r:user_runtime_t,s0)
/run/user/0  -d  gen_context(root:object_r:user_runtime_t,s0)
```