### PR TITLE
lvm: add lvm_tmpfs_t type and rules

### DIFF
--- a/policy/modules/system/lvm.te
+++ b/policy/modules/system/lvm.te
@@ -42,6 +42,9 @@ init_unit_file(lvm_unit_t)
 type lvm_tmp_t;
 files_tmp_file(lvm_tmp_t)
 
+type lvm_tmpfs_t;
+files_tmpfs_file(lvm_tmpfs_t)
+
 type lvm_var_lib_t;
 files_type(lvm_var_lib_t)
 
@@ -182,6 +185,10 @@ allow lvm_t clvmd_t:unix_stream_socket { connectto rw_socket_perms };
 manage_dirs_pattern(lvm_t, lvm_tmp_t, lvm_tmp_t)
 manage_files_pattern(lvm_t, lvm_tmp_t, lvm_tmp_t)
 files_tmp_filetrans(lvm_t, lvm_tmp_t, { file dir })
+
+manage_dirs_pattern(lvm_t, lvm_tmpfs_t, lvm_tmpfs_t)
+manage_files_pattern(lvm_t, lvm_tmpfs_t, lvm_tmpfs_t)
+fs_tmpfs_filetrans(lvm_t, lvm_tmpfs_t, { dir file })
 
 # /lib/lvm-<version> holds the actual LVM binaries (and symlinks)
 read_files_pattern(lvm_t, lvm_exec_t, lvm_exec_t)


### PR DESCRIPTION
cryptsetup uses tmpfs when performing some operations on encrypted
volumes such as changing keys.

Signed-off-by: Kenton Groombridge <me@concord.sh>