### PR TITLE
Various fixes

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -912,6 +912,24 @@ interface(`kernel_getattr_proc',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to get the attributes of the proc filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`kernel_dontaudit_getattr_proc',`
+	gen_require(`
+		type proc_t;
+	')
+
+	dontaudit $1 proc_t:filesystem getattr;
+')
+
+########################################
+## <summary>
 ##	Mount on proc directories.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/dovecot.te
+++ b/policy/modules/services/dovecot.te
@@ -207,6 +207,7 @@ optional_policy(`
 
 optional_policy(`
 	mta_manage_spool(dovecot_t)
+	mta_watch_spool(dovecot_t)
 	mta_manage_mail_home_rw_content(dovecot_t)
 	mta_home_filetrans_mail_home_rw(dovecot_t, dir, "Maildir")
 	mta_home_filetrans_mail_home_rw(dovecot_t, dir, ".maildir")
@@ -254,6 +255,8 @@ allow dovecot_auth_t dovecot_runtime_t:fifo_file write_fifo_file_perms;
 manage_sock_files_pattern(dovecot_auth_t, dovecot_runtime_t, dovecot_runtime_t)
 
 allow dovecot_auth_t dovecot_t:unix_stream_socket { connectto rw_stream_socket_perms };
+
+kernel_dontaudit_getattr_proc(dovecot_auth_t)
 
 files_search_runtime(dovecot_auth_t)
 files_read_usr_files(dovecot_auth_t)

--- a/policy/modules/services/mta.if
+++ b/policy/modules/services/mta.if
@@ -955,6 +955,24 @@ interface(`mta_manage_spool',`
 	manage_lnk_files_pattern($1, mail_spool_t, mail_spool_t)
 ')
 
+########################################
+## <summary>
+##	Watch mail spool content.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`mta_watch_spool',`
+	gen_require(`
+		type mail_spool_t;
+	')
+
+	allow $1 mail_spool_t:{ dir file } watch;
+')
+
 #######################################
 ## <summary>
 ##	Create specified objects in the

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -262,6 +262,8 @@ corenet_sendrecv_xserver_server_packets(sshd_t)
 ifdef(`distro_debian',`
 	allow sshd_t self:process { getcap setcap };
 	auth_use_pam_motd_dynamic(sshd_t)
+',`
+	dontaudit sshd_t self:process { getcap setcap };
 ')
 
 ifdef(`init_systemd',`

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -104,6 +104,9 @@ allow chkpwd_t shadow_t:file read_file_perms;
 files_list_etc(chkpwd_t)
 
 kernel_read_crypto_sysctls(chkpwd_t)
+kernel_dontaudit_search_kernel_sysctl(chkpwd_t)
+kernel_dontaudit_read_kernel_sysctl(chkpwd_t)
+kernel_dontaudit_getattr_proc(chkpwd_t)
 
 domain_dontaudit_use_interactive_fds(chkpwd_t)
 

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -496,6 +496,7 @@ files_tmp_filetrans(semanage_t, semanage_tmp_t, { file dir })
 
 kernel_read_system_state(semanage_t)
 kernel_read_kernel_sysctls(semanage_t)
+kernel_dontaudit_getattr_proc(semanage_t)
 
 corecmd_exec_bin(semanage_t)
 corecmd_exec_shell(semanage_t)


### PR DESCRIPTION
Allow dovecot to watch the mail spool, and add various dontaudit rules
for several other domains.

Signed-off-by: Kenton Groombridge <me@concord.sh>