### PR TITLE
dovecot, postfix: add missing accesses

### DIFF
--- a/policy/modules/services/dovecot.if
+++ b/policy/modules/services/dovecot.if
@@ -63,6 +63,28 @@ interface(`dovecot_domtrans_deliver',`
 
 ########################################
 ## <summary>
+##	Read dovecot configuration content.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`dovecot_read_config',`
+	gen_require(`
+		type dovecot_etc_t;
+	')
+
+	files_search_etc($1)
+	allow $1 dovecot_etc_t:dir list_dir_perms;
+	allow $1 dovecot_etc_t:file read_file_perms;
+	allow $1 dovecot_etc_t:lnk_file read_lnk_file_perms;
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete
 ##	dovecot spool files.
 ## </summary>

--- a/policy/modules/services/postfix.te
+++ b/policy/modules/services/postfix.te
@@ -596,6 +596,8 @@ corecmd_exec_bin(postfix_pipe_t)
 
 optional_policy(`
 	dovecot_domtrans_deliver(postfix_pipe_t)
+	dovecot_read_config(postfix_pipe_t)
+	dovecot_stream_connect(postfix_pipe_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
postfix_pipe_t requires reading dovecot configuration and connecting to
dovecot stream sockets if configured to use dovecot for local mail
delivery.

Signed-off-by: Kenton Groombridge <me@concord.sh>