### PR TITLE
Assortment of systemd-related denial fixes

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1609,6 +1609,25 @@ interface(`files_relabel_config_dirs',`
 	relabel_dirs_pattern($1, configfile, configfile)
 ')
 
+#########################################
+## <summary>
+##	Do not audit attempts to relabel configuration directories
+## </summary>
+## <param name="domain">
+## 	<summary>
+##	Domain not to audit.
+##	</summary>
+## </param>
+##
+#
+interface(`files_dontaudit_relabel_config_dirs',`
+	gen_require(`
+		attribute configfile;
+	')
+
+	dontaudit $1 configfile:dir relabel_dir_perms;
+')
+
 ########################################
 ## <summary>
 ##	Read config files in /etc.
@@ -1665,6 +1684,25 @@ interface(`files_relabel_config_files',`
 	')
 
 	relabel_files_pattern($1, configfile, configfile)
+')
+
+#######################################
+## <summary>
+##	Do not audit attempts to relabel configuration files
+## </summary>
+## <param name="domain">
+## 	<summary>
+##	Domain not to audit.
+##	</summary>
+## </param>
+##
+#
+interface(`files_dontaudit_relabel_config_files',`
+	gen_require(`
+		attribute configfile;
+	')
+
+	dontaudit $1 configfile:file relabel_file_perms;
 ')
 
 ########################################

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -3119,6 +3119,26 @@ interface(`files_manage_etc_files',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to create, read, write,
+##	and delete generic files in /etc.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`files_dontaudit_manage_etc_files',`
+	gen_require(`
+		type etc_t;
+	')
+
+	dontaudit $1 etc_t:file manage_file_perms;
+')
+
+########################################
+## <summary>
 ##	Delete system configuration files in /etc.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -5078,6 +5078,25 @@ interface(`fs_relabel_tmpfs_blk_file',`
 
 ########################################
 ## <summary>
+##	Relabel named pipes on tmpfs filesystems.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_relabel_tmpfs_fifo_files',`
+	gen_require(`
+		type tmpfs_t;
+	')
+
+	allow $1 tmpfs_t:dir list_dir_perms;
+	relabel_fifo_files_pattern($1, tmpfs_t, tmpfs_t)
+')
+
+########################################
+## <summary>
 ##	Read and write, create and delete generic
 ##	files on tmpfs filesystems.
 ## </summary>

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -4999,13 +4999,28 @@ interface(`fs_dontaudit_use_tmpfs_chr_dev',`
 ##	</summary>
 ## </param>
 #
-interface(`fs_relabel_tmpfs_chr_file',`
+interface(`fs_relabel_tmpfs_chr_files',`
 	gen_require(`
 		type tmpfs_t;
 	')
 
 	allow $1 tmpfs_t:dir list_dir_perms;
 	relabel_chr_files_pattern($1, tmpfs_t, tmpfs_t)
+')
+
+########################################
+## <summary>
+##	Relabel character nodes on tmpfs filesystems.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_relabel_tmpfs_chr_file',`
+	refpolicywarn(`$0($*) has been deprecated, please use fs_relabel_tmpfs_chr_files() instead.')
+	fs_relabel_tmpfs_chr_files($1)
 ')
 
 ########################################
@@ -5037,13 +5052,28 @@ interface(`fs_rw_tmpfs_blk_files',`
 ##	</summary>
 ## </param>
 #
-interface(`fs_relabel_tmpfs_blk_file',`
+interface(`fs_relabel_tmpfs_blk_files',`
 	gen_require(`
 		type tmpfs_t;
 	')
 
 	allow $1 tmpfs_t:dir list_dir_perms;
 	relabel_blk_files_pattern($1, tmpfs_t, tmpfs_t)
+')
+
+########################################
+## <summary>
+##	Relabel block nodes on tmpfs filesystems.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_relabel_tmpfs_blk_file',`
+	refpolicywarn(`$0($*) has been deprecated, please use fs_relabel_tmpfs_blk_files() instead.')
+	fs_relabel_tmpfs_blk_files($1)
 ')
 
 ########################################

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -367,6 +367,24 @@ interface(`kernel_dgram_send',`
 
 ########################################
 ## <summary>
+##	Send messages to kernel netlink audit sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_rw_netlink_audit_sockets',`
+	gen_require(`
+		type kernel_t;
+	')
+
+	allow $1 kernel_t:netlink_audit_socket { rw_netlink_socket_perms };
+')
+
+########################################
+## <summary>
 ##	Allows caller to load kernel modules
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -190,6 +190,9 @@ optional_policy(`
 
 	# for passing around terminal file handles for machinectl shell
 	systemd_use_inherited_machined_ptys(system_dbusd_t)
+
+	# allow populating of /var/lib/dbus by systemd-tmpfilesd
+	systemd_tmpfilesd_managed(system_dbusd_var_lib_t, dir)
 ')
 
 optional_policy(`

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -87,7 +87,7 @@ type wtmp_t;
 logging_log_file(wtmp_t)
 
 optional_policy(`
-	systemd_tmpfilesd_managed(faillog_t, file)
+	systemd_tmpfilesd_managed(faillog_t, { dir file })
 	systemd_tmpfilesd_managed(var_auth_t, dir)
 ')
 

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -312,6 +312,8 @@ ifdef(`init_systemd',`
 	kernel_setsched(init_t)
 	kernel_link_key(init_t)
 	kernel_rw_unix_sysctls(init_t)
+	kernel_rw_stream_sockets(init_t)
+	kernel_rw_unix_dgram_sockets(init_t)
 
 	# run systemd misc initializations
 	# in the initrc_t domain, as would be
@@ -1027,6 +1029,9 @@ ifdef(`init_systemd',`
 	manage_lnk_files_pattern(initrc_t, systemdunit, systemdunit)
 	allow initrc_t systemdunit:service reload;
 	allow initrc_t init_script_file_type:service { stop start status reload };
+
+	# Access to notify socket for services with Type=notify
+	kernel_dgram_send(initrc_t)
 
 	# run systemd misc initializations
 	# in the initrc_t domain, as would be

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1057,6 +1057,7 @@ ifdef(`init_systemd',`
 	logging_manage_audit_config(initrc_t)
 	# journalctl:
 	logging_watch_runtime_dirs(initrc_t)
+	logging_manage_runtime_sockets(initrc_t)
 
 	# lvm2-activation-generator checks file labels
 	seutil_read_file_contexts(initrc_t)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -252,9 +252,10 @@ ifdef(`init_systemd',`
 
 	allow init_t init_path_unit_loc_type:{ dir file } { getattr watch };
 
-	# for /run/systemd/inaccessible/{chr,blk}
-	allow init_t init_runtime_t:blk_file create_blk_file_perms;
-	allow init_t init_runtime_t:chr_file create_chr_file_perms;
+	# for /run/systemd/inaccessible/{chr,blk,fifo}
+	allow init_t init_runtime_t:blk_file { create_blk_file_perms relabelto };
+	allow init_t init_runtime_t:chr_file { create_chr_file_perms relabelto };
+	allow init_t init_runtime_t:fifo_file { create_fifo_file_perms relabelto };
 
 	allow init_t systemprocess:process { dyntransition siginh };
 	allow init_t systemprocess:unix_stream_socket create_stream_socket_perms;
@@ -411,6 +412,9 @@ ifdef(`init_systemd',`
 	fs_remount_all_fs(init_t)
 	fs_relabelfrom_tmpfs_symlinks(init_t)
 	fs_unmount_all_fs(init_t)
+	fs_relabel_tmpfs_blk_files(init_t)
+	fs_relabel_tmpfs_chr_files(init_t)
+	fs_relabel_tmpfs_fifo_files(init_t)
 	# for privatetmp functions
 	fs_relabel_tmpfs_dirs(init_t)
 	fs_relabel_tmpfs_files(init_t)
@@ -484,6 +488,8 @@ ifdef(`init_systemd',`
 
 	# for systemd to read udev status
 	udev_read_runtime_files(init_t)
+
+	userdom_relabel_user_runtime_root_dirs(init_t)
 
 	tunable_policy(`init_mounton_non_security',`
 		files_mounton_non_security(init_t)

--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -681,10 +681,9 @@ interface(`logging_send_syslog_msg',`
 		# Allow systemd-journald to check whether the process died
 		allow syslogd_t $1:process signull;
 
-		ifdef(`distro_redhat',`
-			kernel_dgram_send($1)
-		')
+		kernel_dgram_send($1)
 	')
+
 ')
 
 ########################################

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -501,9 +501,6 @@ auth_use_nsswitch(syslogd_t)
 
 init_use_fds(syslogd_t)
 
-# cjp: this doesnt make sense
-logging_send_syslog_msg(syslogd_t)
-
 miscfiles_read_localization(syslogd_t)
 
 seutil_read_config(syslogd_t)
@@ -525,6 +522,7 @@ ifdef(`init_systemd',`
 	kernel_read_ring_buffer(syslogd_t)
 	kernel_rw_stream_sockets(syslogd_t)
 	kernel_rw_unix_dgram_sockets(syslogd_t)
+	kernel_rw_netlink_audit_sockets(syslogd_t)
 	kernel_use_fds(syslogd_t)
 
 	dev_read_kmsg(syslogd_t)
@@ -543,6 +541,9 @@ ifdef(`init_systemd',`
 	init_read_runtime_pipes(syslogd_t)
 	init_read_runtime_symlinks(syslogd_t)
 	init_read_state(syslogd_t)
+
+	# needed for systemd-initrd case when syslog socket is unlabelled
+	logging_send_syslog_msg(syslogd_t)
 
 	systemd_manage_journal_files(syslogd_t)
 

--- a/policy/modules/system/lvm.te
+++ b/policy/modules/system/lvm.te
@@ -29,6 +29,9 @@ files_type(lvm_etc_t)
 
 type lvm_lock_t;
 files_lock_file(lvm_lock_t)
+optional_policy(`
+        systemd_tmpfilesd_managed(lvm_lock_t, dir)
+')
 
 type lvm_metadata_t;
 files_type(lvm_metadata_t)

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -671,8 +671,8 @@ ifdef(`distro_debian',`
 ifdef(`distro_redhat', `
 	fs_rw_tmpfs_chr_files(setfiles_t)
 	fs_rw_tmpfs_blk_files(setfiles_t)
-	fs_relabel_tmpfs_blk_file(setfiles_t)
-	fs_relabel_tmpfs_chr_file(setfiles_t)
+	fs_relabel_tmpfs_blk_files(setfiles_t)
+	fs_relabel_tmpfs_chr_files(setfiles_t)
 ')
 
 ifdef(`distro_ubuntu',`

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -541,6 +541,10 @@ interface(`sysnet_manage_config',`
 	ifdef(`distro_redhat',`
 		manage_files_pattern($1, net_conf_t, net_conf_t)
 	')
+
+	ifdef(`init_systemd',`
+		manage_files_pattern($1, net_conf_t, net_conf_t)
+	')
 ')
 
 #######################################

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -57,6 +57,8 @@
 /usr/lib/systemd/system/systemd-rfkill.*	--	gen_context(system_u:object_r:systemd_rfkill_unit_t,s0)
 /usr/lib/systemd/system/systemd-socket-proxyd\.service	--	gen_context(system_u:object_r:systemd_socket_proxyd_unit_file_t,s0)
 
+/usr/share/factory(/.*)?	gen_context(system_u:object_r:systemd_factory_conf_t,s0)
+
 /var/\.updated				--	gen_context(system_u:object_r:systemd_update_run_t,s0)
 
 /var/lib/systemd/backlight(/.*)?	gen_context(system_u:object_r:systemd_backlight_var_lib_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1174,6 +1174,7 @@ interface(`systemd_tmpfilesd_managed',`
 		type systemd_tmpfiles_t;
 	')
 
+	allow systemd_tmpfiles_t $1:dir list_dir_perms;
 	allow systemd_tmpfiles_t $1:$2 { setattr relabelfrom relabelto create };
 ')
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1394,11 +1394,15 @@ tunable_policy(`systemd_tmpfilesd_factory', `
 	allow systemd_tmpfiles_t systemd_factory_conf_t:file read_file_perms;
 
 	files_manage_etc_files(systemd_tmpfiles_t)
+	files_relabel_config_dirs(systemd_tmpfiles_t)
+	files_relabel_config_files(systemd_tmpfiles_t)
 ',`
 	dontaudit systemd_tmpfiles_t systemd_factory_conf_t:dir list_dir_perms;
 	dontaudit systemd_tmpfiles_t systemd_factory_conf_t:file read_file_perms;
 
 	files_dontaudit_manage_etc_files(systemd_tmpfiles_t)
+	files_dontaudit_relabel_config_dirs(systemd_tmpfiles_t)
+	files_dontaudit_relabel_config_files(systemd_tmpfiles_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -443,6 +443,10 @@ systemd_log_parse_environment(systemd_generator_t)
 
 term_use_unallocated_ttys(systemd_generator_t)
 
+ifdef(`distro_gentoo',`
+	corecmd_shell_entry_type(systemd_generator_t)
+')
+
 optional_policy(`
 	fstools_exec(systemd_generator_t)
 ')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1330,6 +1330,7 @@ files_relabel_var_lib_dirs(systemd_tmpfiles_t)
 files_relabelfrom_home(systemd_tmpfiles_t)
 files_relabelto_home(systemd_tmpfiles_t)
 files_relabelto_etc_dirs(systemd_tmpfiles_t)
+files_setattr_lock_dirs(systemd_tmpfiles_t)
 # for /etc/mtab
 files_manage_etc_symlinks(systemd_tmpfiles_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -179,6 +179,7 @@ init_system_domain(systemd_networkd_t, systemd_networkd_exec_t)
 
 type systemd_networkd_runtime_t alias systemd_networkd_var_run_t;
 files_runtime_file(systemd_networkd_runtime_t)
+init_mountpoint(systemd_networkd_runtime_t)
 
 type systemd_networkd_unit_t;
 init_unit_file(systemd_networkd_unit_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1352,6 +1352,8 @@ auth_relabel_lastlog(systemd_tmpfiles_t)
 auth_relabel_login_records(systemd_tmpfiles_t)
 auth_setattr_login_records(systemd_tmpfiles_t)
 
+auth_use_nsswitch(systemd_tmpfiles_t)
+
 init_manage_utmp(systemd_tmpfiles_t)
 init_manage_var_lib_files(systemd_tmpfiles_t)
 # for /proc/1/environ

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -45,6 +45,14 @@ gen_tunable(systemd_socket_proxyd_bind_any, false)
 ## </desc>
 gen_tunable(systemd_socket_proxyd_connect_any, false)
 
+## <desc>
+## <p>
+## Allow systemd-tmpfilesd to populate missing configuration files from factory
+## template directory.
+## </p>
+## </desc>
+gen_tunable(systemd_tmpfilesd_factory, false)
+
 attribute systemd_log_parse_env_type;
 attribute systemd_tmpfiles_conf_type;
 attribute systemd_user_session_type;
@@ -103,6 +111,9 @@ files_type(systemd_coredump_var_lib_t)
 type systemd_detect_virt_t;
 type systemd_detect_virt_exec_t;
 init_daemon_domain(systemd_detect_virt_t, systemd_detect_virt_exec_t)
+
+type systemd_factory_conf_t;
+systemd_tmpfiles_conf_file(systemd_factory_conf_t)
 
 type systemd_generator_t;
 type systemd_generator_exec_t;
@@ -1283,6 +1294,7 @@ allow systemd_tmpfiles_t systemd_journal_t:dir relabel_dir_perms;
 allow systemd_tmpfiles_t systemd_journal_t:file relabel_file_perms;
 
 allow systemd_tmpfiles_t systemd_tmpfiles_conf_t:dir list_dir_perms;
+allow systemd_tmpfiles_t systemd_tmpfiles_conf_type:dir search_dir_perms;
 allow systemd_tmpfiles_t systemd_tmpfiles_conf_type:file read_file_perms;
 
 kernel_getattr_proc(systemd_tmpfiles_t)
@@ -1375,6 +1387,18 @@ tunable_policy(`systemd_tmpfiles_manage_all',`
 	files_manage_non_security_files(systemd_tmpfiles_t)
 	files_relabel_non_security_dirs(systemd_tmpfiles_t)
 	files_relabel_non_security_files(systemd_tmpfiles_t)
+')
+
+tunable_policy(`systemd_tmpfilesd_factory', `
+	allow systemd_tmpfiles_t systemd_factory_conf_t:dir list_dir_perms;
+	allow systemd_tmpfiles_t systemd_factory_conf_t:file read_file_perms;
+
+	files_manage_etc_files(systemd_tmpfiles_t)
+',`
+	dontaudit systemd_tmpfiles_t systemd_factory_conf_t:dir list_dir_perms;
+	dontaudit systemd_tmpfiles_t systemd_factory_conf_t:file read_file_perms;
+
+	files_dontaudit_manage_etc_files(systemd_tmpfiles_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -229,8 +229,8 @@ ifdef(`distro_redhat',`
 	fs_manage_tmpfs_sockets(udev_t)
 	fs_manage_tmpfs_blk_files(udev_t)
 	fs_manage_tmpfs_chr_files(udev_t)
-	fs_relabel_tmpfs_blk_file(udev_t)
-	fs_relabel_tmpfs_chr_file(udev_t)
+	fs_relabel_tmpfs_blk_files(udev_t)
+	fs_relabel_tmpfs_chr_files(udev_t)
 
 	term_search_ptys(udev_t)
 


### PR DESCRIPTION
Fix a number of issues related to systemd start-up in enforced mode, primarily focused on `systemd-tmpfilesd` and `systemd-networkd`.

Notable changes include:
 * Support for systemd-powered initrd (dracut). This is related to a feature in systemd, which allows it to pass certain socket file descriptors from the initrd's systemd daemon into the main systemd process. Since these are opened before the SELinux policy is loaded, all of them use the default label, which causes a number of denials, as the policy expects them to be labelled. This behaviour is controlled by a new global tunable `init_reuse_initrd_sockets`.
 * Support for factory template files in `systemd-tmpfilesd`.
 * `systemd-networkd` start-up fixes.