### PR TITLE
selinux: Add a secure_mode_setbool Boolean.

### DIFF
--- a/policy/modules/kernel/selinux.if
+++ b/policy/modules/kernel/selinux.if
@@ -392,14 +392,18 @@ interface(`selinux_read_policy',`
 interface(`selinux_set_generic_booleans',`
 	gen_require(`
 		type security_t;
+		bool secure_mode_setbool;
 	')
 
 	dev_search_sysfs($1)
 
 	allow $1 security_t:dir list_dir_perms;
-	allow $1 security_t:file rw_file_perms;
+	allow $1 security_t:file read_file_perms;
 
-	allow $1 security_t:security setbool;
+	if(!secure_mode_setbool) {
+		allow $1 security_t:file write_file_perms;
+		allow $1 security_t:security setbool;
+	}
 ')
 
 ########################################
@@ -428,18 +432,21 @@ interface(`selinux_set_all_booleans',`
 	gen_require(`
 		type security_t, secure_mode_policyload_t;
 		attribute boolean_type;
-		bool secure_mode_policyload;
+		bool secure_mode_policyload, secure_mode_setbool;
 	')
 
 	dev_search_sysfs($1)
 
 	allow $1 security_t:dir list_dir_perms;
-	allow $1 { boolean_type -secure_mode_policyload_t }:file rw_file_perms;
+	allow $1 boolean_type:file read_file_perms;
 	allow $1 secure_mode_policyload_t:file read_file_perms;
 
-	allow $1 security_t:security setbool;
+	if (!secure_mode_setbool) {
+		allow $1 security_t:security setbool;
+		allow $1 { boolean_type -secure_mode_policyload_t }:file write_file_perms;
+	}
 
-	if(!secure_mode_policyload) {
+	if(!secure_mode_policyload && !secure_mode_setbool) {
 		allow $1 secure_mode_policyload_t:file write_file_perms;
 	}
 ')

--- a/policy/modules/kernel/selinux.te
+++ b/policy/modules/kernel/selinux.te
@@ -7,12 +7,18 @@ policy_module(selinux, 1.18.0)
 
 ## <desc>
 ## <p>
-## Boolean to determine whether the system permits loading policy, setting
-## enforcing mode, and changing boolean values.  Set this to true and you
-## have to reboot to set it back.
+## Boolean to determine whether the system permits loading policy, and setting
+## enforcing mode.  Set this to true and you have to reboot to set it back.
 ## </p>
 ## </desc>
 gen_bool(secure_mode_policyload,false)
+
+## <desc>
+## <p>
+## Boolean to determine whether the system permits setting Booelan values.
+## </p>
+## </desc>
+gen_bool(secure_mode_setbool,false)
 
 attribute boolean_type;
 attribute can_load_policy;
@@ -91,12 +97,22 @@ dev_search_sysfs(can_setsecparam)
 allow selinux_unconfined_type security_t:dir list_dir_perms;
 allow selinux_unconfined_type security_t:file rw_file_perms;
 allow selinux_unconfined_type boolean_type:file read_file_perms;
-allow selinux_unconfined_type { boolean_type -secure_mode_policyload_t }:file write_file_perms;
 
 # Access the security API.
-allow selinux_unconfined_type security_t:security { compute_av compute_create compute_member check_context compute_relabel compute_user setbool setsecparam setcheckreqprot read_policy validate_trans };
+allow selinux_unconfined_type security_t:security { compute_av compute_create compute_member check_context compute_relabel compute_user setsecparam setcheckreqprot read_policy validate_trans };
 
-if(!secure_mode_policyload) {
+if (!secure_mode_policyload) {
 	allow selinux_unconfined_type security_t:security { load_policy setenforce };
-	allow selinux_unconfined_type secure_mode_policyload_t:file write_file_perms;
+}
+
+if (!secure_mode_setbool) {
+	allow selinux_unconfined_type security_t:security setbool;
+}
+
+if (secure_mode_policyload && !secure_mode_setbool) {
+	allow selinux_unconfined_type { boolean_type -secure_mode_policyload_t }:file write_file_perms;
+}
+
+if (!secure_mode_policyload && !secure_mode_setbool) {
+	allow selinux_unconfined_type boolean_type:file write_file_perms;
 }


### PR DESCRIPTION
Enabling this will disable all permissions for setting SELinux Booleans,
even for unconfined domains.

This does not affect setenforce.  Enable `secure_mode_policyload` along with
`secure_mode_setbool` to fully lock the SELinux security interface.

Fixes #354 
