### PR TITLE
Secure_mode Boolean improvements

### DIFF
--- a/Rules.modular
+++ b/Rules.modular
@@ -167,14 +167,14 @@ $(tmpdir)/all_attrs_types.conf: $(tmpdir)/all_te_files.conf
 $(tmpdir)/all_post.conf: $(tmpdir)/all_te_files.conf $(tmpdir)/post_te_files.conf
 	$(verbose) cat $(tmpdir)/post_te_files.conf > $@
 # these have to run individually because order matters:
-	$(verbose) $(GREP) '^sid ' $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) '^fs_use_(xattr|task|trans)' $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^genfscon $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^portcon $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^netifcon $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^nodecon $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^ibpkeycon $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^ibendportcon $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*sid ' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*fs_use_(xattr|task|trans)' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*genfscon' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*portcon' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*netifcon' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*nodecon' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*ibpkeycon' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*ibendportcon' $(tmpdir)/all_te_files.conf >> $@ || true
 
 $(tmpdir)/only_te_rules.conf: $(tmpdir)/all_te_files.conf
 	$(verbose) $(comment_move_decl) $^ > $@

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -165,14 +165,14 @@ $(tmpdir)/all_attrs_types.conf: $(tmpdir)/all_te_files.conf
 $(tmpdir)/all_post.conf: $(tmpdir)/all_te_files.conf $(tmpdir)/post_te_files.conf
 	$(verbose) cat $(tmpdir)/post_te_files.conf > $@
 # these have to run individually because order matters:
-	$(verbose) $(GREP) '^sid ' $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) '^fs_use_(xattr|task|trans)' $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^genfscon $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^portcon $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^netifcon $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^nodecon $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^ibpkeycon $(tmpdir)/all_te_files.conf >> $@ || true
-	$(verbose) $(GREP) ^ibendportcon $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*sid ' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*fs_use_(xattr|task|trans)' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*genfscon' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*portcon' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*netifcon' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*nodecon' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*ibpkeycon' $(tmpdir)/all_te_files.conf >> $@ || true
+	$(verbose) $(GREP) '^[[:blank:]]*ibendportcon' $(tmpdir)/all_te_files.conf >> $@ || true
 
 $(tmpdir)/only_te_rules.conf: $(tmpdir)/all_te_files.conf
 	$(verbose) $(comment_move_decl) $^ > $@

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -4369,6 +4369,25 @@ interface(`files_load_kernel_modules',`
 
 ########################################
 ## <summary>
+##	Load kernel module files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_dontaudit_load_kernel_modules',`
+	gen_require(`
+		type modules_object_t;
+	')
+
+	dontaudit $1 modules_object_t:file read_file_perms;
+	dontaudit $1 modules_object_t:system module_load;
+')
+
+########################################
+## <summary>
 ##	List world-readable directories.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -497,7 +497,20 @@ optional_policy(`
 # Kernel module loading policy
 #
 
-if( ! secure_mode_insmod ) {
+if(secure_mode_insmod) {
+	dontaudit can_load_kernmodule self:capability sys_module;
+	dontaudit can_load_kernmodule self:system module_load;
+
+	files_dontaudit_load_kernel_modules(can_load_kernmodule)
+
+	# load_module() calls stop_machine() which
+	# calls sched_setscheduler()
+	# gt: there seems to be no trace of the above, at
+	# least in kernel versions greater than 2.6.37...
+	dontaudit can_load_kernmodule self:capability sys_nice;
+	dontaudit can_load_kernmodule kernel_t:process setsched;
+	dontaudit can_load_kernmodule kernel_t:key search;
+} else {
 	allow can_load_kernmodule self:capability sys_module;
 	allow can_load_kernmodule self:system module_load;
 

--- a/policy/modules/kernel/selinux.if
+++ b/policy/modules/kernel/selinux.if
@@ -40,7 +40,7 @@ interface(`selinux_labeled_boolean',`
 
 	# because of this statement, any module which
 	# calls this interface must be in the base module:
-	genfscon selinuxfs /booleans/$2 gen_context(system_u:object_r:$1,s0)
+	genfscon selinuxfs /booleans/$2 -- gen_context(system_u:object_r:$1,s0)
 ')
 
 ########################################

--- a/policy/modules/kernel/selinux.if
+++ b/policy/modules/kernel/selinux.if
@@ -400,7 +400,10 @@ interface(`selinux_set_generic_booleans',`
 	allow $1 security_t:dir list_dir_perms;
 	allow $1 boolean_t:file read_file_perms;
 
-	if(!secure_mode_setbool) {
+	if(secure_mode_setbool) {
+		dontaudit $1 { boolean_t security_t }:file write_file_perms;
+		dontaudit $1 security_t:security setbool;
+	} else {
 		allow $1 { boolean_t security_t }:file write_file_perms;
 		allow $1 security_t:security setbool;
 	}
@@ -441,7 +444,11 @@ interface(`selinux_set_all_booleans',`
 	allow $1 boolean_type:file read_file_perms;
 	allow $1 secure_mode_policyload_t:file read_file_perms;
 
-	if (!secure_mode_setbool) {
+	if (secure_mode_setbool) {
+		dontaudit $1 security_t:security setbool;
+		dontaudit $1 security_t:file write_file_perms;
+		dontaudit $1 { boolean_type -secure_mode_policyload_t }:file write_file_perms;
+	} else {
 		allow $1 security_t:security setbool;
 		allow $1 security_t:file write_file_perms;
 		allow $1 { boolean_type -secure_mode_policyload_t }:file write_file_perms;
@@ -449,6 +456,8 @@ interface(`selinux_set_all_booleans',`
 
 	if(!secure_mode_policyload && !secure_mode_setbool) {
 		allow $1 secure_mode_policyload_t:file write_file_perms;
+	} else {
+		dontaudit $1 secure_mode_policyload_t:file write_file_perms;
 	}
 ')
 

--- a/policy/modules/kernel/selinux.if
+++ b/policy/modules/kernel/selinux.if
@@ -391,17 +391,17 @@ interface(`selinux_read_policy',`
 #
 interface(`selinux_set_generic_booleans',`
 	gen_require(`
-		type security_t;
+		type boolean_t, security_t;
 		bool secure_mode_setbool;
 	')
 
 	dev_search_sysfs($1)
 
 	allow $1 security_t:dir list_dir_perms;
-	allow $1 security_t:file read_file_perms;
+	allow $1 boolean_t:file read_file_perms;
 
 	if(!secure_mode_setbool) {
-		allow $1 security_t:file write_file_perms;
+		allow $1 { boolean_t security_t }:file write_file_perms;
 		allow $1 security_t:security setbool;
 	}
 ')
@@ -443,6 +443,7 @@ interface(`selinux_set_all_booleans',`
 
 	if (!secure_mode_setbool) {
 		allow $1 security_t:security setbool;
+		allow $1 security_t:file write_file_perms;
 		allow $1 { boolean_type -secure_mode_policyload_t }:file write_file_perms;
 	}
 

--- a/policy/modules/kernel/selinux.te
+++ b/policy/modules/kernel/selinux.te
@@ -26,6 +26,9 @@ attribute can_setenforce;
 attribute can_setsecparam;
 attribute selinux_unconfined_type;
 
+type boolean_t, boolean_type;
+genfscon selinuxfs /booleans/ -- gen_context(system_u:object_r:boolean_t,s0)
+
 type secure_mode_policyload_t;
 selinux_labeled_boolean(secure_mode_policyload_t, secure_mode_policyload)
 
@@ -34,7 +37,7 @@ selinux_labeled_boolean(secure_mode_policyload_t, secure_mode_policyload)
 # the permissions in the security class.  It is also
 # applied to selinuxfs inodes.
 #
-type security_t, boolean_type;
+type security_t;
 files_mountpoint(security_t)
 fs_type(security_t)
 mls_trusted_object(security_t)

--- a/policy/modules/kernel/selinux.te
+++ b/policy/modules/kernel/selinux.te
@@ -57,7 +57,9 @@ allow can_setenforce security_t:file rw_file_perms;
 
 dev_search_sysfs(can_setenforce)
 
-if(!secure_mode_policyload) {
+if(secure_mode_policyload) {
+	dontaudit can_setenforce security_t:security setenforce;
+} else {
 	allow can_setenforce security_t:security setenforce;
 }
 
@@ -73,7 +75,9 @@ allow can_load_policy security_t:file rw_file_perms;
 
 dev_search_sysfs(can_load_policy)
 
-if(!secure_mode_policyload) {
+if(secure_mode_policyload) {
+	dontaudit can_load_policy security_t:security load_policy;
+} else {
 	allow can_load_policy security_t:security load_policy;
 }
 
@@ -104,18 +108,26 @@ allow selinux_unconfined_type boolean_type:file read_file_perms;
 # Access the security API.
 allow selinux_unconfined_type security_t:security { compute_av compute_create compute_member check_context compute_relabel compute_user setsecparam setcheckreqprot read_policy validate_trans };
 
-if (!secure_mode_policyload) {
+if (secure_mode_policyload) {
+	dontaudit selinux_unconfined_type security_t:security { load_policy setenforce };
+} else {
 	allow selinux_unconfined_type security_t:security { load_policy setenforce };
 }
 
-if (!secure_mode_setbool) {
+if (secure_mode_setbool) {
+	dontaudit selinux_unconfined_type security_t:security setbool;
+} else {
 	allow selinux_unconfined_type security_t:security setbool;
 }
 
 if (secure_mode_policyload && !secure_mode_setbool) {
 	allow selinux_unconfined_type { boolean_type -secure_mode_policyload_t }:file write_file_perms;
+} else {
+	dontaudit selinux_unconfined_type { boolean_type -secure_mode_policyload_t }:file write_file_perms;
 }
 
 if (!secure_mode_policyload && !secure_mode_setbool) {
 	allow selinux_unconfined_type boolean_type:file write_file_perms;
+} else {
+	dontaudit selinux_unconfined_type boolean_type:file write_file_perms;
 }


### PR DESCRIPTION
* Change default Boolean type to boolean_t. This will prevent other security_t writers from setting Boolean pending values, which could be activated unwittingly by setbool processes.

* Add dontaudits for secure_mode* Booleans.

Related to #354 