### PR TITLE
Resolve compile issue on RHEL7

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -118,8 +118,10 @@ template(`systemd_role_template',`
 	systemd_search_user_runtime_unit_dirs($1_systemd_t)
 	systemd_read_user_unit_files($1_systemd_t)
 
-	dbus_system_bus_client($1_systemd_t)
-	dbus_spec_session_bus_client($1, $1_systemd_t)
+	optional_policy(`
+		dbus_system_bus_client($1_systemd_t)
+		dbus_spec_session_bus_client($1, $1_systemd_t)
+	')
 
 	# userdomain rules
 	allow $3 $1_systemd_t:process signal;

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -81,11 +81,6 @@ template(`systemd_role_template',`
 	allow $1_systemd_t $3:file read_file_perms;
 	allow $1_systemd_t $3:lnk_file read_lnk_file_perms;
 
-	filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "generator.early")
-	filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "generator.late")
-	filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "transient")
-	filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "user")
-
 	dev_read_urand($1_systemd_t)
 
 	files_search_home($1_systemd_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -197,7 +197,7 @@ template(`systemd_role_template',`
 ##   </summary>
 ## </param>
 #
-template(`systemd_user_daemon_domain',`
+interface(`systemd_user_daemon_domain',`
 	gen_require(`
 		type $1_systemd_t;
 	')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1527,6 +1527,11 @@ type_transition systemd_user_session_type systemd_user_runtime_t:sock_file syste
 allow systemd_user_session_type systemd_user_tmpfs_t:file manage_file_perms;
 fs_tmpfs_filetrans(systemd_user_session_type, systemd_user_tmpfs_t, file)
 
+filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "generator.early")
+filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "generator.late")
+filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "transient")
+filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "user")
+
 # Run generators in /usr/lib/systemd/user-environment-generators with no domain transition
 can_exec(systemd_user_session_type, systemd_generator_exec_t)
 

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -679,6 +679,13 @@ template(`userdom_common_user_template',`
 		')
 	')
 
+	#DJS - 4-May-2021 moved here due to issues compiling on RHEL7.  I was getting
+	# errors related to multiple declaration of auditadm_systemd_t.  Moving outside
+	# an optional block seemed very important.
+	ifdef(`init_systemd',`
+		systemd_role_template($1, $1_r, $1_t)
+	')
+
 	tunable_policy(`user_direct_mouse',`
 		dev_read_mouse($1_t)
 	')
@@ -859,10 +866,6 @@ template(`userdom_common_user_template',`
 
 	optional_policy(`
 		slrnpull_search_spool($1_t)
-	')
-
-	optional_policy(`
-		systemd_role_template($1, $1_r, $1_t)
 	')
 
 	optional_policy(`


### PR DESCRIPTION
I was seeing the following error when compiling on RHEL7:

/usr/bin/checkmodule -m tmp/auditadm.tmp -o tmp/auditadm.mod
/usr/bin/checkmodule:  loading policy configuration from tmp/auditadm.tmp
policy/modules/roles/auditadm.te:42:ERROR 'duplicate declaration of type/attribute' at token 'auditadm_systemd_t' on line 31749:
		type auditadm_systemd_t;
/usr/bin/checkmodule:  error(s) encountered while parsing configuration
make: *** [tmp/auditadm.mod] Error 1

This is seen with the changes in cc8374fd24129a2a20669bda2b57d8b029945047

Signed-off-by: Dave Sugar <dsugar100@gmail.com>