### PR TITLE
${ROLE}_dbusd_t: allow domain transition from ${ROLE}_systemd_t

### DIFF
--- a/policy/modules/services/dbus.if
+++ b/policy/modules/services/dbus.if
@@ -64,6 +64,7 @@ template(`dbus_role_template',`
 		type system_dbusd_t, dbusd_exec_t;
 		type session_dbusd_tmp_t, session_dbusd_home_t;
 		type session_dbusd_runtime_t;
+		type $1_systemd_t;
 	')
 
 	##############################
@@ -97,6 +98,9 @@ template(`dbus_role_template',`
 	userdom_user_home_dir_filetrans($3, session_dbusd_home_t, dir, ".dbus")
 
 	domtrans_pattern($3, dbusd_exec_t, $1_dbusd_t)
+
+	domtrans_pattern($1_systemd_t, dbusd_exec_t, $1_dbusd_t)
+	allow $1_dbusd_t $1_systemd_t:unix_stream_socket { accept getattr getopt read write };
 
 	ps_process_pattern($3, $1_dbusd_t)
 	allow $3 $1_dbusd_t:process { ptrace signal_perms };


### PR DESCRIPTION
Allow dbus-daemon started by systemd running as user manager (with
e.g. type user_systemd_t) to transition to appropriate
type (e.g. user_dbusd_t). Also let dbus-daemon access user manager's
socket.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>