### PR TITLE
staff.te: Allow staff access to the virt stream

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -61,6 +61,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	virt_stream_connect(staff_t)
+')
+
+optional_policy(`
 	vlock_run(staff_t, staff_r)
 ')
 


### PR DESCRIPTION
This is needed when libvirtd is configured with:

```
unix_sock_group = "wheel"
unix_sock_rw_perms = "0770"
```

to allow non-root users to access the libvirt sockets remotely over SSH.