### PR TITLE
init: Add support for systemd StandardInputText.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@
 /policy/modules/kernel/corenetwork.te
 /tmp/
 
-.vagrant/
+/.vagrant/
+/.vscode/
 
 # monolithic generated files
 /file_contexts

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -183,9 +183,17 @@ interface(`init_domain',`
 	allow init_t $1:process rlimitinh;
 
 	ifdef(`init_systemd',`
+		gen_require(`
+			type init_tmpfs_t;
+		')
+
 		allow $1 init_t:unix_stream_socket { getattr read write ioctl };
 
 		allow init_t $1:process2 { nnp_transition nosuid_transition };
+
+		# StandardInputText uses a memfd rw shm segment.
+		# Cannot deny writes or it breaks.
+		allow $1 init_tmpfs_t:file rw_inherited_file_perms;
 	')
 ')
 
@@ -270,9 +278,17 @@ interface(`init_spec_daemon_domain',`
 	allow init_t $1:process rlimitinh;
 
 	ifdef(`init_systemd',`
+		gen_require(`
+			type init_tmpfs_t;
+		')
+
 		allow $1 init_t:unix_stream_socket { getattr read write ioctl };
 
 		allow init_t $1:process2 { nnp_transition nosuid_transition };
+
+		# StandardInputText uses a memfd rw shm segment.
+		# Cannot deny writes or it breaks.
+		allow $1 init_tmpfs_t:file rw_inherited_file_perms;
 	')
 
 	# daemons started from init will

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -112,6 +112,9 @@ files_type(initrc_state_t)
 type initrc_tmp_t;
 files_tmp_file(initrc_tmp_t)
 
+type init_tmpfs_t;
+files_tmpfs_file(init_tmpfs_t)
+
 type initrc_var_log_t;
 logging_log_file(initrc_var_log_t)
 
@@ -169,6 +172,9 @@ files_runtime_filetrans(init_t, initctl_t, fifo_file)
 
 # Modify utmp.
 allow init_t initrc_runtime_t:file { rw_file_perms setattr };
+
+allow init_t init_tmpfs_t:file manage_file_perms;
+fs_tmpfs_filetrans(init_t, init_tmpfs_t, file)
 
 kernel_read_system_state(init_t)
 kernel_share_state(init_t)
@@ -292,8 +298,6 @@ ifdef(`init_systemd',`
 	manage_lnk_files_pattern(init_t, init_runtime_t, init_runtime_t)
 	manage_sock_files_pattern(init_t, init_runtime_t, init_runtime_t)
 	manage_dirs_pattern(init_t, init_runtime_t, init_runtime_t)
-	# /memfd:systemd-state
-	fs_tmpfs_filetrans(init_t, init_runtime_t, file)
 
 	# mounton is required for systemd-timesyncd
 	allow init_t init_var_lib_t:dir { manage_dir_perms mounton };


### PR DESCRIPTION
This normally uses memfd which uses posix shm under the hood. Additionally, a direct shm use is a fallback if memfd is not available.