### PR TITLE
systemd: Drop second parameter in systemd_tmpfilesd_managed().

### DIFF
--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -23,7 +23,7 @@ fs_xattr_type(device_t)
 fs_use_trans devtmpfs gen_context(system_u:object_r:device_t,s0);
 
 optional_policy(`
-	systemd_tmpfilesd_managed(device_t, fifo_file)
+	systemd_tmpfilesd_managed(device_t)
 ')
 
 #

--- a/policy/modules/kernel/files.te
+++ b/policy/modules/kernel/files.te
@@ -183,7 +183,7 @@ files_runtime_file(var_run_t)
 files_mountpoint(var_run_t)
 
 optional_policy(`
-	systemd_tmpfilesd_managed(var_run_t, lnk_file)
+	systemd_tmpfilesd_managed(var_run_t)
 ')
 
 #

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -192,7 +192,7 @@ optional_policy(`
 	systemd_use_inherited_machined_ptys(system_dbusd_t)
 
 	# allow populating of /var/lib/dbus by systemd-tmpfilesd
-	systemd_tmpfilesd_managed(system_dbusd_var_lib_t, dir)
+	systemd_tmpfilesd_managed(system_dbusd_var_lib_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -97,8 +97,8 @@ type wtmp_t;
 logging_log_file(wtmp_t)
 
 optional_policy(`
-	systemd_tmpfilesd_managed(faillog_t, { dir file })
-	systemd_tmpfilesd_managed(var_auth_t, dir)
+	systemd_tmpfilesd_managed(faillog_t)
+	systemd_tmpfilesd_managed(var_auth_t)
 ')
 
 ########################################

--- a/policy/modules/system/lvm.te
+++ b/policy/modules/system/lvm.te
@@ -20,7 +20,7 @@ files_type(lvm_etc_t)
 type lvm_lock_t;
 files_lock_file(lvm_lock_t)
 optional_policy(`
-        systemd_tmpfilesd_managed(lvm_lock_t, dir)
+        systemd_tmpfilesd_managed(lvm_lock_t)
 ')
 
 type lvm_metadata_t;

--- a/policy/modules/system/miscfiles.te
+++ b/policy/modules/system/miscfiles.te
@@ -43,7 +43,7 @@ type man_t alias catman_t;
 files_type(man_t)
 
 optional_policy(`
-	systemd_tmpfilesd_managed(man_t, dir)
+	systemd_tmpfilesd_managed(man_t)
 ')
 
 type man_cache_t;

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1710,16 +1710,11 @@ interface(`systemd_relabelto_tmpfiles_conf_files',`
 
 #######################################
 ## <summary>
-##  Allow systemd_tmpfiles_t to manage filesystem objects
+##	Allow systemd_tmpfiles_t to manage filesystem objects
 ## </summary>
 ## <param name="type">
 ## <summary>
-##  type of object to manage
-## </summary>
-## </param>
-## <param name="class">
-## <summary>
-##  object class to manage
+##	Type of object to manage
 ## </summary>
 ## </param>
 #
@@ -1728,8 +1723,15 @@ interface(`systemd_tmpfilesd_managed',`
 		type systemd_tmpfiles_t;
 	')
 
-	allow systemd_tmpfiles_t $1:dir list_dir_perms;
-	allow systemd_tmpfiles_t $1:$2 { setattr relabelfrom relabelto create };
+	allow systemd_tmpfiles_t $1:dir { manage_dir_perms relabel_dir_perms  };
+	allow systemd_tmpfiles_t $1:file { create setattr unlink write_file_perms relabel_file_perms };
+	allow systemd_tmpfiles_t $1:lnk_file { create setattr unlink relabel_lnk_file_perms };
+	allow systemd_tmpfiles_t $1:fifo_file { create setattr unlink relabel_fifo_file_perms };
+
+	ifelse(`$2',`',`',`
+		refpolicywarn(`$0($*) second parameter is deprecated.')
+		allow systemd_tmpfiles_t $1:$2 { setattr relabelfrom relabelto create };
+	')
 ')
 
 ########################################


### PR DESCRIPTION
systemd-tmpfiles can manage various file classes but the permission vary depending on the class.
