### PR TITLE
roles: move dbus_role_template out of the condition block for sysadm/…

### DIFF
--- a/policy/modules/roles/auditadm.te
+++ b/policy/modules/roles/auditadm.te
@@ -40,10 +40,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	dbus_role_template(auditadm, auditadm_r, auditadm_t)
-')
-
-optional_policy(`
 	screen_role_template(auditadm, auditadm_r, auditadm_t)
 ')
 

--- a/policy/modules/roles/secadm.te
+++ b/policy/modules/roles/secadm.te
@@ -49,10 +49,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	dbus_role_template(secadm, secadm_r, secadm_t)
-')
-
-optional_policy(`
 	dmesg_exec(secadm_t)
 ')
 

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -98,19 +98,15 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		dbus_role_template(staff, staff_r, staff_t)
+		gnome_role_template(staff, staff_r, staff_t)
+	')
 
-		optional_policy(`
-			gnome_role_template(staff, staff_r, staff_t)
-		')
+	optional_policy(`
+		telepathy_role_template(staff, staff_r, staff_t)
+	')
 
-		optional_policy(`
-			telepathy_role_template(staff, staff_r, staff_t)
-		')
-
-		optional_policy(`
-			wm_role_template(staff, staff_r, staff_t)
-		')
+	optional_policy(`
+		wm_role_template(staff, staff_r, staff_t)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1226,15 +1226,11 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		dbus_role_template(sysadm, sysadm_r, sysadm_t)
+		gnome_role_template(sysadm, sysadm_r, sysadm_t)
+	')
 
-		optional_policy(`
-			gnome_role_template(sysadm, sysadm_r, sysadm_t)
-		')
-
-		optional_policy(`
-			wm_role_template(sysadm, sysadm_r, sysadm_t)
-		')
+	optional_policy(`
+		wm_role_template(sysadm, sysadm_r, sysadm_t)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -62,19 +62,15 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		dbus_role_template(user, user_r, user_t)
+		gnome_role_template(user, user_r, user_t)
+	')
 
-		optional_policy(`
-			gnome_role_template(user, user_r, user_t)
-		')
+	optional_policy(`
+		telepathy_role_template(user, user_r, user_t)
+	')
 
-		optional_policy(`
-			telepathy_role_template(user, user_r, user_t)
-		')
-
-		optional_policy(`
-			wm_role_template(user, user_r, user_t)
-		')
+	optional_policy(`
+		wm_role_template(user, user_r, user_t)
 	')
 
 	optional_policy(`

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -722,6 +722,7 @@ template(`userdom_common_user_template',`
 	')
 
 	optional_policy(`
+		dbus_role_template($1, $1_r, $1_t)
 		dbus_system_bus_client($1_t)
 
 		optional_policy(`
@@ -759,6 +760,10 @@ template(`userdom_common_user_template',`
 
 		optional_policy(`
 			xserver_dbus_chat_xdm($1_t)
+		')
+
+		optional_policy(`
+			systemd_role_template($1, $1_r, $1_t)
 		')
 	')
 
@@ -859,10 +864,6 @@ template(`userdom_common_user_template',`
 
 	optional_policy(`
 		slrnpull_search_spool($1_t)
-	')
-
-	optional_policy(`
-		systemd_role_template($1, $1_r, $1_t)
 	')
 
 	optional_policy(`


### PR DESCRIPTION
…staff/unprivuser

After commit cc8374fd24129a2a20669bda2b57d8b029945047 (various: systemd
user fixes and additional support), the dbus_role_template is required
for all roles. But for sysadm/staff/unprivuser, this piece of code is
not included if the DISTRO is set to redhat. Move it out of the
'ifndef distro_redhat' condition block, otherwise the label of the
instance is not correct.

Before the patch if set DISTRO=redhat:
root@qemux86-64:~# ps xZ | grep "systemd --user"
root:sysadm_r:sysadm_t  240 ? Ss 0:00 /lib/systemd/systemd --user

After the patch:
root@qemux86-64:~# ps xZ | grep "systemd --user"
root:sysadm_r:sysadm_systemd_t  218 ? Ss 0:00 /lib/systemd/systemd --user

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>