### PR TITLE
Use correct interface or template declaration

### DIFF
--- a/policy/modules/admin/kismet.if
+++ b/policy/modules/admin/kismet.if
@@ -15,7 +15,7 @@
 ##	</summary>
 ## </param>
 #
-template(`kismet_role',`
+interface(`kismet_role',`
 	gen_require(`
 		type kismet_home_t, kismet_tmp_t, kismet_tmpfs_t;
 		type kismet_t;

--- a/policy/modules/apps/gnome.if
+++ b/policy/modules/apps/gnome.if
@@ -670,7 +670,7 @@ interface(`gnome_dbus_chat_gconfd',`
 ##	</summary>
 ## </param>
 #
-interface(`gnome_dbus_chat_gkeyringd',`
+template(`gnome_dbus_chat_gkeyringd',`
 	gen_require(`
 		type $1_gkeyringd_t;
 		class dbus send_msg;
@@ -738,7 +738,7 @@ interface(`gnome_spec_domtrans_all_gkeyringd',`
 ##	</summary>
 ## </param>
 #
-interface(`gnome_stream_connect_gkeyringd',`
+template(`gnome_stream_connect_gkeyringd',`
 	gen_require(`
 		type $1_gkeyringd_t, gnome_keyring_tmp_t;
 	')

--- a/policy/modules/apps/qemu.if
+++ b/policy/modules/apps/qemu.if
@@ -109,7 +109,7 @@ template(`qemu_domain_template',`
 ##	</summary>
 ## </param>
 #
-template(`qemu_role',`
+interface(`qemu_role',`
 	gen_require(`
 		type qemu_t;
 	')

--- a/policy/modules/apps/wm.if
+++ b/policy/modules/apps/wm.if
@@ -139,7 +139,7 @@ interface(`wm_exec',`
 ##	</summary>
 ## </param>
 #
-interface(`wm_dbus_chat',`
+template(`wm_dbus_chat',`
 	gen_require(`
 		type $1_wm_t;
 		class dbus send_msg;
@@ -247,7 +247,7 @@ interface(`wm_application_domain',`
 ##	</summary>
 ## </param>
 #
-interface(`wm_write_pipes',`
+template(`wm_write_pipes',`
 	gen_require(`
 		type $1_wm_t;
 	')

--- a/policy/modules/services/dbus.if
+++ b/policy/modules/services/dbus.if
@@ -190,7 +190,7 @@ interface(`dbus_connect_all_session_bus',`
 ##	</summary>
 ## </param>
 #
-interface(`dbus_connect_spec_session_bus',`
+template(`dbus_connect_spec_session_bus',`
 	gen_require(`
 		type $1_dbusd_t;
 		class dbus acquire_svc;
@@ -242,7 +242,7 @@ interface(`dbus_all_session_bus_client',`
 ##	</summary>
 ## </param>
 #
-interface(`dbus_spec_session_bus_client',`
+template(`dbus_spec_session_bus_client',`
 	gen_require(`
 		attribute dbusd_session_bus_client;
 		type $1_dbusd_t;
@@ -295,7 +295,7 @@ interface(`dbus_send_all_session_bus',`
 ##	</summary>
 ## </param>
 #
-interface(`dbus_send_spec_session_bus',`
+template(`dbus_send_spec_session_bus',`
 	gen_require(`
 		type $1_dbusd_t;
 		class dbus send_msg;
@@ -433,7 +433,7 @@ interface(`dbus_all_session_domain',`
 ##	</summary>
 ## </param>
 #
-interface(`dbus_spec_session_domain',`
+template(`dbus_spec_session_domain',`
 	gen_require(`
 		type $1_dbusd_t;
 	')

--- a/policy/modules/services/git.if
+++ b/policy/modules/services/git.if
@@ -15,7 +15,7 @@
 ##	</summary>
 ## </param>
 #
-template(`git_role',`
+interface(`git_role',`
 	gen_require(`
 		attribute_role git_session_roles;
 		type git_session_t, gitd_exec_t, git_user_content_t;

--- a/policy/modules/services/rlogin.if
+++ b/policy/modules/services/rlogin.if
@@ -29,7 +29,7 @@ interface(`rlogin_domtrans',`
 ##	</summary>
 ## </param>
 #
-template(`rlogin_read_home_content',`
+interface(`rlogin_read_home_content',`
 	gen_require(`
 		type rlogind_home_t;
 	')

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1428,7 +1428,7 @@ template(`userdom_admin_user_template',`
 ##	</summary>
 ## </param>
 #
-template(`userdom_security_admin_template',`
+interface(`userdom_security_admin_template',`
 	allow $1 self:capability { dac_override dac_read_search };
 
 	corecmd_exec_shell($1)


### PR DESCRIPTION
Following the guideline of interfaces not allowed to declare anything and not use prefix parameters, declare interfaces doing so as templates.

Also declare templates not using those features and not calling templates themselves as interfaces.

These changes originate from the discussion in https://github.com/TresysTechnology/selint/issues/205 and are found by new proposed SELint checks at https://github.com/TresysTechnology/selint/pull/206.

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>