### PR TITLE
Add ubifs to filesystem policy

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -37,6 +37,7 @@ fs_use_xattr jfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr lustre gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr overlay gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr squashfs gen_context(system_u:object_r:fs_t,s0);
+fs_use_xattr ubifs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr xfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr zfs gen_context(system_u:object_r:fs_t,s0);
 


### PR DESCRIPTION
The ubifs in linux kernel supported the security xattr handler as early
as version 3.19.0 -rc6. Now add ubifs to the filesystem policy.

Signed-off-by: Xiongwei Song <xiongwei.song@windriver.com>