### PR TITLE
virt: handle urandom unlink

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -3834,6 +3834,24 @@ interface(`dev_create_rand_dev',`
 
 ########################################
 ## <summary>
+##  Delete the random device (/dev/random).
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`dev_delete_rand_dev',`
+	gen_require(`
+		type device_t, random_device_t;
+	')
+
+	delete_chr_files_pattern($1, device_t, random_device_t)
+')
+
+########################################
+## <summary>
 ##	Read the realtime clock (/dev/rtc).
 ## </summary>
 ## <param name="domain">
@@ -4776,6 +4794,24 @@ interface(`dev_create_urand_dev',`
 	')
 
 	create_chr_files_pattern($1, device_t, urandom_device_t)
+')
+
+########################################
+## <summary>
+##  Delete the urandom device (/dev/urandom).
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`dev_delete_urand_dev',`
+	gen_require(`
+		type device_t, urandom_device_t;
+	')
+
+	delete_chr_files_pattern($1, device_t, urandom_device_t)
 ')
 
 ########################################

--- a/policy/modules/services/virt.te
+++ b/policy/modules/services/virt.te
@@ -619,6 +619,8 @@ corenet_tcp_connect_soundd_port(virtd_t)
 
 corenet_rw_tun_tap_dev(virtd_t)
 
+dev_delete_rand_dev(virtd_t)
+dev_delete_urand_dev(virtd_t)
 dev_rw_sysfs(virtd_t)
 dev_read_urand(virtd_t)
 dev_read_rand(virtd_t)


### PR DESCRIPTION
libvirt adds the following XML to VM definitions by default:

```
    <rng model='virtio'>
      <backend model='random'>/dev/urandom</backend>
      <address type='pci' domain='0x0000' bus='0x06' slot='0x00' function='0x0'/>
    </rng>
```

Which causes the VM to fail to start with:

```
error: Failed to start domain 'test1'
error: Unable to create device /dev/urandom: File exists
```

The AVC logged is:

```
type=AVC msg=audit(1622221825.029:3649): avc:  denied  { unlink } for  pid=6879 comm="rpc-worker" name="urandom" dev="tmpfs" ino=5 scontext=system_u:system_r:virtd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:urandom_device_t:s0 tclass=chr_file permissive=0
```