### PR TITLE
Add an attribute for user applications to run other applications

### DIFF
--- a/policy/modules/apps/wm.if
+++ b/policy/modules/apps/wm.if
@@ -39,6 +39,7 @@ template(`wm_role_template',`
 	#
 
 	type $1_wm_t, wm_domain;
+	userdom_application_exec_domain($1_wm_t, $1)
 	userdom_user_application_domain($1_wm_t, wm_exec_t)
 	role $2 types $1_wm_t;
 

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -42,7 +42,7 @@ template(`systemd_role_template',`
 	type $1_systemd_t, systemd_user_session_type, systemd_log_parse_env_type;
 	init_pgm_spec_user_daemon_domain($1_systemd_t)
 	domain_user_exemption_target($1_systemd_t)
-	userdom_spec_user_application_exec_domain($1_systemd_t, $1)
+	userdom_application_exec_domain($1_systemd_t, $1)
 	ubac_constrained($1_systemd_t)
 	role $2 types $1_systemd_t;
 
@@ -198,8 +198,7 @@ template(`systemd_user_daemon_domain',`
 
 	domtrans_pattern($1_systemd_t, $2, $3)
 
-	allow $1_systemd_t $3:process signal_perms;
-	allow $3 $1_systemd_t:unix_stream_socket rw_socket_perms;
+	systemd_user_app_status($1, $3)
 ')
 
 ######################################
@@ -245,6 +244,46 @@ interface(`systemd_user_unix_stream_activated_socket',`
 
 	typeattribute $1 systemd_user_unix_stream_activated_socket_type;
 	systemd_user_activated_sock_file($2)
+')
+
+######################################
+## <summary>
+##   Allow the target domain to be monitored and have its output
+##   captured by the specified systemd user instance domain.
+## </summary>
+## <param name="prefix">
+##	<summary>
+##	Prefix for the user domain.
+##	</summary>
+## </param>
+## <param name="domain">
+##	<summary>
+##	Domain to allow the systemd user instance to monitor.
+##	</summary>
+## </param>
+#
+template(`systemd_user_app_status',`
+	gen_require(`
+		type $1_systemd_t;
+	')
+
+	# This interface does not imply permissions for the systemd user
+	# domain to run the application. Instead, these rules are necessary
+	# for a systemd --user instance to monitor an application as well as
+	# any child processes of that application, children of those, and so
+	# on.
+
+	# systemd --user instances need to be able to read the state of the
+	# app it runs and capture its output to journald
+	ps_process_pattern($1_systemd_t, $2)
+	allow $1_systemd_t $2:process signal_perms;
+	allow $2 $1_systemd_t:fd use;
+	allow $2 $1_systemd_t:unix_stream_socket rw_socket_perms;
+
+	# apps run by systemd --user instances need to be able to read the
+	# state of the systemd --user instance
+	ps_process_pattern($2, $1_systemd_t)
+	allow $2 $1_systemd_t:process sigchld;
 ')
 
 ######################################

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -42,6 +42,7 @@ template(`systemd_role_template',`
 	type $1_systemd_t, systemd_user_session_type, systemd_log_parse_env_type;
 	init_pgm_spec_user_daemon_domain($1_systemd_t)
 	domain_user_exemption_target($1_systemd_t)
+	userdom_spec_user_application_exec_domain($1_systemd_t, $1)
 	ubac_constrained($1_systemd_t)
 	role $2 types $1_systemd_t;
 

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -31,8 +31,9 @@ template(`userdom_base_user_template',`
 	')
 
 	attribute $1_file_type;
+	attribute $1_application_exec_domain;
 
-	type $1_t, userdomain;
+	type $1_t, userdomain, $1_application_exec_domain;
 	domain_type($1_t)
 	corecmd_shell_entry_type($1_t)
 	corecmd_bin_entry_type($1_t)
@@ -240,6 +241,34 @@ template(`userdom_user_content_access_template',`
 	tunable_policy(`$1_manage_all_user_content',`
 		userdom_manage_all_user_home_content($2)
 	')
+')
+
+#######################################
+## <summary>
+##	Associate the specified domain to be
+##	a domain capable of executing other
+##	applications on behalf of the specified
+##	user.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="userdomain_prefix">
+##	<summary>
+##	The prefix of the user domain (e.g., user
+##	is the prefix for user_t).
+##	</summary>
+## </param>
+## <rolebase/>
+#
+interface(`userdom_application_exec_domain',`
+	gen_require(`
+		attribute $2_application_exec_domain;
+	')
+
+	typeattribute $1 $2_application_exec_domain;
 ')
 
 #######################################


### PR DESCRIPTION
This addresses the issue raised in #365. With the advent of `systemd --user` support, we should support users running various applications through user units and other means. The problem is that any other such applications normally started by a user that transition to their own domain (i.e. `user_systemd_t`) do not have the proper permissions to run other applications.

Many applications' policies have their own way of granting run access to users. Some policies grant access directly with `myapp_domtrans`, `myapp_run`, or by granting an attribute. I think the best way to do this would be to streamline all such interfaces and templates to take exactly 3 parameters: the role prefix, the role, and the type of the user domain. This way we can have a single "proper" way to declare interfaces and templates like this, and we can ensure that calls to things like `screen_role_template` have everything they need.

~~In this PR I have only modified `apache` and `screen` to use this approach, and they are now using the proposed attribute for user application run access. I am opening this PR to hopefully get some early feedback on this approach, as the final result of this effort may be quite large.~~

This is a two-part PR. This PR addresses adding the required infrastructure for this feature, while the upcoming second PR will hook up this infrastructure into the application policies to support it. 

This PR only adds the aforementioned attribute, the interfaces required to support it, and assigns it to the `$1_systemd_t` and `$1_wm_t` domains.