### PR TITLE
fix: policy: init: there is no enabled_mls, it is enable_mls

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1029,7 +1029,7 @@ ifdef(`distro_suse',`
 	')
 ')
 
-ifdef(`enabled_mls',`
+ifdef(`enable_mls',`
 	optional_policy(`
 		# allow init scripts to su
 		su_restricted_domain_template(initrc, initrc_t, system_r)


### PR DESCRIPTION
This will enable su_restricted_domain_template where it was meant to be
enabled before, but was not actually.

Signed-off-by: Markus Linnala <Markus.Linnala@cybercom.com>