### PR TITLE
cleanup: Interface docs

### DIFF
--- a/policy/modules/apps/chromium.if
+++ b/policy/modules/apps/chromium.if
@@ -82,6 +82,11 @@ interface(`chromium_rw_tmp_pipes',`
 ##	Domain that creates the resource(s)
 ##	</summary>
 ## </param>
+## <param name="private_type">
+##	<summary>
+##	Private file type.
+##	</summary>
+## </param>
 ## <param name="class">
 ##	<summary>
 ##	Type of the resource created

--- a/policy/modules/apps/gnome.if
+++ b/policy/modules/apps/gnome.if
@@ -631,12 +631,6 @@ interface(`gnome_read_keyring_home_files',`
 ##	gnome configuration daemon over
 ##	dbus.
 ## </summary>
-## <param name="role_prefix">
-##	<summary>
-##	The prefix of the user domain (e.g., user
-##	is the prefix for user_t).
-##	</summary>
-## </param>
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.

--- a/policy/modules/apps/gpg.if
+++ b/policy/modules/apps/gpg.if
@@ -246,6 +246,22 @@ interface(`gpg_search_agent_tmp_dirs',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
+## <param name="file_type">
+##	<summary>
+##	Type to which the created node will be transitioned.
+##	</summary>
+## </param>
+## <param name="class">
+##	<summary>
+##	Object class(es) (single or set including {}) for which this
+##	the transition will occur.
+##	</summary>
+## </param>
+## <param name="name" optional="true">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
 #
 interface(`gpg_agent_tmp_filetrans',`
 	gen_require(`
@@ -265,6 +281,22 @@ interface(`gpg_agent_tmp_filetrans',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
+## <param name="file_type">
+##	<summary>
+##	Type to which the created node will be transitioned.
+##	</summary>
+## </param>
+## <param name="class">
+##	<summary>
+##	Object class(es) (single or set including {}) for which this
+##	the transition will occur.
+##	</summary>
+## </param>
+## <param name="name" optional="true">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
 #
 interface(`gpg_runtime_filetrans',`
 	gen_require(`
@@ -282,6 +314,22 @@ interface(`gpg_runtime_filetrans',`
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="file_type">
+##	<summary>
+##	Type to which the created node will be transitioned.
+##	</summary>
+## </param>
+## <param name="class">
+##	<summary>
+##	Object class(es) (single or set including {}) for which this
+##	the transition will occur.
+##	</summary>
+## </param>
+## <param name="name" optional="true">
+##	<summary>
+##	The name of the object being created.
 ##	</summary>
 ## </param>
 #

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -1019,7 +1019,7 @@ interface(`dev_manage_generic_chr_files',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="file">
+## <param name="file_type">
 ##	<summary>
 ##	Type to which the created node will be transitioned.
 ##	</summary>

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7791,7 +7791,7 @@ interface(`files_manage_generic_spool',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="file">
+## <param name="file_type">
 ##	<summary>
 ##	Type to which the created node will be transitioned.
 ##	</summary>


### PR DESCRIPTION
Change some interface documents to have common name for file_type.
Add missing parameter documentations. Drop extra parameter documentation.