### PR TITLE
cleanup: policy avahi: avahi_filetrans_pid: doc: add missing params

### DIFF
--- a/policy/modules/services/avahi.if
+++ b/policy/modules/services/avahi.if
@@ -255,7 +255,7 @@ interface(`avahi_dontaudit_search_pid',`
 #
 interface(`avahi_filetrans_pid',`
 	refpolicywarn(`$0($*) has been deprecated, please use avahi_filetrans_runtime() instead.')
-	avahi_filetrans_runtime($1)
+	avahi_filetrans_runtime($*)
 ')
 
 ########################################


### PR DESCRIPTION
Even if interface is deprecated, still use all documented parameters.

Signed-off-by: Markus Linnala <Markus.Linnala@cybercom.com>