### PR TITLE
style: policy: interfaces: doc: indent param blocks consistently

### DIFF
--- a/policy/modules/admin/blueman.if
+++ b/policy/modules/admin/blueman.if
@@ -5,9 +5,9 @@
 ##	Execute blueman in the blueman domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`blueman_domtrans',`

--- a/policy/modules/admin/brctl.if
+++ b/policy/modules/admin/brctl.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run brctl.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`brctl_domtrans',`

--- a/policy/modules/admin/kismet.if
+++ b/policy/modules/admin/kismet.if
@@ -43,9 +43,9 @@ interface(`kismet_role',`
 ##	Execute a domain transition to run kismet.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`kismet_domtrans',`

--- a/policy/modules/admin/ncftool.if
+++ b/policy/modules/admin/ncftool.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run ncftool.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`ncftool_domtrans',`

--- a/policy/modules/admin/puppet.if
+++ b/policy/modules/admin/puppet.if
@@ -6,9 +6,9 @@
 ##	domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`puppet_domtrans_puppetca',`

--- a/policy/modules/admin/quota.if
+++ b/policy/modules/admin/quota.if
@@ -51,9 +51,9 @@ interface(`quota_run',`
 ##	Execute quota nld in the quota nld domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
-##  Domain allowed to transition.
-## </summary>
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
 ## </param>
 #
 interface(`quota_domtrans_nld',`

--- a/policy/modules/admin/shorewall.if
+++ b/policy/modules/admin/shorewall.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run shorewall.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`shorewall_domtrans',`
@@ -25,9 +25,9 @@ interface(`shorewall_domtrans',`
 ##	using executables from /var/lib.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`shorewall_lib_domtrans',`

--- a/policy/modules/admin/shutdown.if
+++ b/policy/modules/admin/shutdown.if
@@ -31,9 +31,9 @@ interface(`shutdown_role',`
 ##	Execute a domain transition to run shutdown.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`shutdown_domtrans',`
@@ -94,9 +94,9 @@ interface(`shutdown_signal',`
 ##     Send SIGCHLD signals to shutdown.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`shutdown_sigchld',`

--- a/policy/modules/admin/sosreport.if
+++ b/policy/modules/admin/sosreport.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run sosreport.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`sosreport_domtrans',`

--- a/policy/modules/apps/chromium.if
+++ b/policy/modules/apps/chromium.if
@@ -10,7 +10,7 @@
 ##	</summary>
 ## </param>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	User domain for the role
 ##	</summary>
 ## </param>
@@ -59,7 +59,7 @@ interface(`chromium_role',`
 ##	Read-write access to Chromiums' temporary fifo files
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access
 ##	</summary>
 ## </param>
@@ -107,7 +107,7 @@ interface(`chromium_tmp_filetrans',`
 ## 	Execute a domain transition to the chromium domain (chromium_t)
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access
 ##	</summary>
 ## </param>
@@ -128,7 +128,7 @@ interface(`chromium_domtrans',`
 ## 	Execute chromium in the chromium domain and allow the specified role to access the chromium domain
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access
 ##	</summary>
 ## </param>

--- a/policy/modules/apps/gitosis.if
+++ b/policy/modules/apps/gitosis.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run gitosis.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`gitosis_domtrans',`

--- a/policy/modules/apps/java.if
+++ b/policy/modules/apps/java.if
@@ -263,9 +263,9 @@ interface(`java_manage_generic_home_content',`
 ##      temporary java content.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`java_manage_java_tmp',`

--- a/policy/modules/apps/livecd.if
+++ b/policy/modules/apps/livecd.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run livecd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`livecd_domtrans',`

--- a/policy/modules/apps/mozilla.if
+++ b/policy/modules/apps/mozilla.if
@@ -300,9 +300,9 @@ interface(`mozilla_domtrans',`
 ##	run mozilla plugin.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`mozilla_domtrans_plugin',`
@@ -347,9 +347,9 @@ interface(`mozilla_run_plugin',`
 ##	run mozilla plugin config.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`mozilla_domtrans_plugin_config',`

--- a/policy/modules/apps/pulseaudio.if
+++ b/policy/modules/apps/pulseaudio.if
@@ -48,9 +48,9 @@ interface(`pulseaudio_role',`
 ##	Execute a domain transition to run pulseaudio.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`pulseaudio_domtrans',`
@@ -96,9 +96,9 @@ interface(`pulseaudio_run',`
 ##	Execute pulseaudio in the caller domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`pulseaudio_exec',`
@@ -115,9 +115,9 @@ interface(`pulseaudio_exec',`
 ##	Do not audit attempts to execute pulseaudio.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain to not audit.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`pulseaudio_dontaudit_exec',`
@@ -172,9 +172,9 @@ interface(`pulseaudio_use_fds',`
 ##	file descriptors for pulseaudio.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`pulseaudio_dontaudit_use_fds',`

--- a/policy/modules/apps/screen.if
+++ b/policy/modules/apps/screen.if
@@ -96,9 +96,9 @@ template(`screen_role_template',`
 ##      Execute the screen runtime sock file.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 interface(`screen_execute_sock_file',`
 	gen_require(`

--- a/policy/modules/apps/seunshare.if
+++ b/policy/modules/apps/seunshare.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run seunshare.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`seunshare_domtrans',`

--- a/policy/modules/apps/syncthing.if
+++ b/policy/modules/apps/syncthing.if
@@ -5,14 +5,14 @@
 ##  Role access for Syncthing
 ## </summary>
 ## <param name="role">
-##  <summary>
-##  Role allowed access
-##  </summary>
+##	<summary>
+##	Role allowed access
+##	</summary>
 ## </param>
 ## <param name="domain">
-##  <summary>
-##  User domain for the role
-##  </summary>
+##	<summary>
+##	User domain for the role
+##	</summary>
 ## </param>
 #
 interface(`syncthing_role', `

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -175,9 +175,9 @@ interface(`dev_relabel_all_dev_nodes',`
 ##     Allow full relabeling (to and from) of all device files.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 ## <rolecap/>
 #
@@ -901,9 +901,9 @@ interface(`dev_relabel_generic_symlinks',`
 ##     Write generic sock files in /dev.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`dev_write_generic_sock_files',`
@@ -3470,9 +3470,9 @@ interface(`dev_create_null_dev',`
 ##     /lib/systemd/system/something.service is a link to /dev/null
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`dev_manage_null_service',`
@@ -3819,9 +3819,9 @@ interface(`dev_write_rand',`
 ##  Create the random device (/dev/random).
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`dev_create_rand_dev',`
@@ -4313,9 +4313,9 @@ interface(`dev_getattr_sysfs',`
 ##     mount a sysfs filesystem
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`dev_mount_sysfs',`
@@ -4369,9 +4369,9 @@ interface(`dev_dontaudit_read_sysfs',`
 ##     mounton sysfs directories.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`dev_mounton_sysfs_dirs',`
@@ -4610,9 +4610,9 @@ interface(`dev_create_sysfs_files',`
 ##     Relabel hardware state directories.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`dev_relabel_sysfs_dirs',`
@@ -4648,9 +4648,9 @@ interface(`dev_relabel_all_sysfs',`
 ##  Set the attributes of sysfs files, directories and symlinks.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`dev_setattr_all_sysfs',`
@@ -4765,9 +4765,9 @@ interface(`dev_write_urand',`
 ##  Create the urandom device (/dev/urandom).
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`dev_create_urand_dev',`
@@ -5209,9 +5209,9 @@ interface(`dev_write_video_dev',`
 ##      Read and write vfio devices.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`dev_rw_vfio_dev',`
@@ -5227,9 +5227,9 @@ interface(`dev_rw_vfio_dev',`
 ##      Relabel vfio devices.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`dev_relabelfrom_vfio_dev',`

--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -1426,9 +1426,9 @@ interface(`domain_entry_file_spec_domtrans',`
 ##	exploiting null deref bugs in the kernel.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`domain_mmap_low',`
@@ -1452,9 +1452,9 @@ interface(`domain_mmap_low',`
 ##	exploiting null deref bugs in the kernel.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`domain_mmap_low_uncond',`

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1595,7 +1595,7 @@ interface(`files_manage_config_dirs',`
 ##	Relabel configuration directories
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
@@ -1614,7 +1614,7 @@ interface(`files_relabel_config_dirs',`
 ##	Do not audit attempts to relabel configuration directories
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain not to audit.
 ##	</summary>
 ## </param>
@@ -1653,9 +1653,9 @@ interface(`files_read_config_files',`
 ## 	Manage all configuration files on filesystem
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access.
-## 	</summary>
+##	</summary>
 ## </param>
 ##
 #
@@ -1672,7 +1672,7 @@ interface(`files_manage_config_files',`
 ##	Relabel configuration files
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
@@ -1691,7 +1691,7 @@ interface(`files_relabel_config_files',`
 ##	Do not audit attempts to relabel configuration files
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain not to audit.
 ##	</summary>
 ## </param>
@@ -6206,7 +6206,7 @@ interface(`files_rw_lock_dirs',`
 ## 	Create lock directories
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access
 ##	</summary>
 ## </param>
@@ -6820,7 +6820,7 @@ interface(`files_pid_filetrans',`
 ## 	Create a generic lock directory within the run directories.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access
 ##	</summary>
 ## </param>
@@ -6902,9 +6902,9 @@ interface(`files_dontaudit_ioctl_all_pids',`
 ##     in the /var/run directory.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_manage_all_pid_dirs',`
@@ -6933,9 +6933,9 @@ interface(`files_read_all_pids',`
 ##     Execute generic programs in /var/run in the caller domain.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_exec_generic_pid_files',`
@@ -6948,9 +6948,9 @@ interface(`files_exec_generic_pid_files',`
 ##     Relabel all pid files.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_relabel_all_pid_files',`
@@ -6983,9 +6983,9 @@ interface(`files_delete_all_pids',`
 ##     Create all pid sockets.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_create_all_pid_sockets',`
@@ -6998,9 +6998,9 @@ interface(`files_create_all_pid_sockets',`
 ##     Create all pid named pipes.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_create_all_pid_pipes',`
@@ -7033,9 +7033,9 @@ interface(`files_read_runtime_files',`
 ##     Execute generic programs in /var/run in the caller domain.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_exec_runtime',`
@@ -7127,9 +7127,9 @@ interface(`files_delete_all_runtime_dirs',`
 ##     Create, read, write, and delete all runtime directories.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_manage_all_runtime_dirs',`
@@ -7284,9 +7284,9 @@ interface(`files_manage_all_runtime_files',`
 ##     Relabel all runtime files.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_relabel_all_runtime_files',`
@@ -7358,9 +7358,9 @@ interface(`files_relabel_all_runtime_symlinks',`
 ##     Create all runtime named pipes
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_create_all_runtime_pipes',`
@@ -7377,9 +7377,9 @@ interface(`files_create_all_runtime_pipes',`
 ##     Delete all runtime named pipes
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_delete_all_runtime_pipes',`
@@ -7396,9 +7396,9 @@ interface(`files_delete_all_runtime_pipes',`
 ##     Create all runtime sockets.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_create_all_runtime_sockets',`
@@ -7414,9 +7414,9 @@ interface(`files_create_all_runtime_sockets',`
 ##     Delete all runtime sockets.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_delete_all_runtime_sockets',`
@@ -7512,7 +7512,7 @@ interface(`files_runtime_filetrans',`
 ## 	Create a generic lock directory within the run directories.
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access
 ##	</summary>
 ## </param>
@@ -7535,9 +7535,9 @@ interface(`files_runtime_filetrans_lock_dir',`
 ##     Create all spool sockets
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_create_all_spool_sockets',`
@@ -7553,9 +7553,9 @@ interface(`files_create_all_spool_sockets',`
 ##     Delete all spool sockets
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`files_delete_all_spool_sockets',`

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -811,9 +811,9 @@ interface(`fs_relabel_cgroup_dirs',`
 ##     Get attributes of cgroup files.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`fs_getattr_cgroup_files',`
@@ -871,9 +871,9 @@ interface(`fs_watch_cgroup_files',`
 ##     Create cgroup lnk_files.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`fs_create_cgroup_links',`
@@ -2122,9 +2122,9 @@ interface(`fs_read_dos_files',`
 ##      Read and map files on a DOS filesystem.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`fs_mmap_read_dos_files',`
@@ -2197,9 +2197,9 @@ interface(`fs_list_efivars',`
 ##      - contains Linux Kernel configuration options for UEFI systems
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 ## <rolecap/>
 #
@@ -2575,9 +2575,9 @@ interface(`fs_rw_hugetlbfs_files',`
 ##      Read, map and write hugetlbfs files.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`fs_mmap_rw_hugetlbfs_files',`
@@ -3892,9 +3892,9 @@ interface(`fs_create_pstore_dirs',`
 ##     Relabel to/from pstore_t directories.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`fs_relabel_pstore_dirs',`
@@ -4740,9 +4740,9 @@ interface(`fs_dontaudit_write_tmpfs_dirs',`
 ##      Relabel from tmpfs_t dir
 ## </summary>
 ## <param name="type">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`fs_relabelfrom_tmpfs_dirs',`
@@ -5268,9 +5268,9 @@ interface(`fs_getattr_tracefs_dirs',`
 ##      search directories on a tracefs filesystem
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`fs_search_tracefs',`
@@ -5287,9 +5287,9 @@ interface(`fs_search_tracefs',`
 ##	on a trace filesystem.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`fs_getattr_tracefs_files',`

--- a/policy/modules/kernel/selinux.if
+++ b/policy/modules/kernel/selinux.if
@@ -467,9 +467,9 @@ interface(`selinux_set_all_booleans',`
 ##  view conditional portions of the policy.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 ## <rolecap/>
 #

--- a/policy/modules/roles/sysadm.if
+++ b/policy/modules/roles/sysadm.if
@@ -10,9 +10,9 @@
 ##	</summary>
 ## </param>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 ## <rolecap/>
 #

--- a/policy/modules/services/afs.if
+++ b/policy/modules/services/afs.if
@@ -6,9 +6,9 @@
 ##	afs client.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`afs_domtrans',`
@@ -43,9 +43,9 @@ interface(`afs_rw_udp_sockets',`
 ##	Read and write afs cache files.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`afs_rw_cache',`

--- a/policy/modules/services/aisexec.if
+++ b/policy/modules/services/aisexec.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run aisexec.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`aisexec_domtrans',`

--- a/policy/modules/services/apcupsd.if
+++ b/policy/modules/services/apcupsd.if
@@ -6,9 +6,9 @@
 ##	run apcupsd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`apcupsd_domtrans',`
@@ -79,9 +79,9 @@ interface(`apcupsd_read_log',`
 ##	Append apcupsd log files.
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access.
-## 	</summary>
+##	</summary>
 ## </param>
 #
 interface(`apcupsd_append_log',`
@@ -100,9 +100,9 @@ interface(`apcupsd_append_log',`
 ##	run httpd_apcupsd_cgi_script.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`apcupsd_cgi_script_domtrans',`

--- a/policy/modules/services/certbot.if
+++ b/policy/modules/services/certbot.if
@@ -6,9 +6,9 @@
 ##      domain.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed to transition.
-##      </summary>
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
 ## </param>
 #
 interface(`certbot_domtrans',`
@@ -26,14 +26,14 @@ interface(`certbot_domtrans',`
 ##      the firstboot domain.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed to transition.
-##      </summary>
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
 ## </param>
 ## <param name="role">
-##      <summary>
-##      Role allowed access.
-##      </summary>
+##	<summary>
+##	Role allowed access.
+##	</summary>
 ## </param>
 #
 interface(`certbot_run',`

--- a/policy/modules/services/certmaster.if
+++ b/policy/modules/services/certmaster.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run certmaster.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`certmaster_domtrans',`
@@ -105,7 +105,7 @@ interface(`certmaster_manage_log',`
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.
-## 	</summary>
+##	</summary>
 ## </param>
 ## <param name="role">
 ##	<summary>

--- a/policy/modules/services/certmonger.if
+++ b/policy/modules/services/certmonger.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run certmonger.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`certmonger_domtrans',`

--- a/policy/modules/services/cgroup.if
+++ b/policy/modules/services/cgroup.if
@@ -6,9 +6,9 @@
 ##	CG Clear.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`cgroup_domtrans_cgclear',`
@@ -26,9 +26,9 @@ interface(`cgroup_domtrans_cgclear',`
 ##	CG config parser.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`cgroup_domtrans_cgconfig',`
@@ -65,9 +65,9 @@ interface(`cgroup_initrc_domtrans_cgconfig',`
 ##	CG rules engine daemon.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`cgroup_domtrans_cgred',`

--- a/policy/modules/services/cobbler.if
+++ b/policy/modules/services/cobbler.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run cobblerd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`cobblerd_domtrans',`

--- a/policy/modules/services/colord.if
+++ b/policy/modules/services/colord.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run colord.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`colord_domtrans',`

--- a/policy/modules/services/cron.if
+++ b/policy/modules/services/cron.if
@@ -688,9 +688,9 @@ interface(`cron_use_system_job_fds',`
 ##      Create, read, write, and delete the system spool.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`cron_manage_system_spool',`
@@ -707,9 +707,9 @@ interface(`cron_manage_system_spool',`
 ##      Read the system spool.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`cron_read_system_spool',`
@@ -727,9 +727,9 @@ interface(`cron_read_system_spool',`
 ##      Read and write crond temporary files.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`cron_rw_tmp_files',`
@@ -917,7 +917,7 @@ interface(`cron_dontaudit_write_system_job_tmp_files',`
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.
-## 	</summary>
+##	</summary>
 ## </param>
 ## <rolecap/>
 #

--- a/policy/modules/services/cyphesis.if
+++ b/policy/modules/services/cyphesis.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run cyphesis.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`cyphesis_domtrans',`

--- a/policy/modules/services/dbus.if
+++ b/policy/modules/services/dbus.if
@@ -22,9 +22,9 @@ interface(`dbus_stub',`
 ##	Execute dbus in the caller domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`dbus_exec',`

--- a/policy/modules/services/ddclient.if
+++ b/policy/modules/services/ddclient.if
@@ -27,7 +27,7 @@ interface(`ddclient_domtrans',`
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-##	 Domain allowed to transition.
+##	Domain allowed to transition.
 ##	</summary>
 ## </param>
 ## <param name="role">

--- a/policy/modules/services/devicekit.if
+++ b/policy/modules/services/devicekit.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run devicekit.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`devicekit_domtrans',`

--- a/policy/modules/services/dnsmasq.if
+++ b/policy/modules/services/dnsmasq.if
@@ -102,9 +102,9 @@ interface(`dnsmasq_kill',`
 ##	Read dnsmasq config files.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`dnsmasq_read_config',`
@@ -121,9 +121,9 @@ interface(`dnsmasq_read_config',`
 ##	Write dnsmasq config files.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`dnsmasq_write_config',`

--- a/policy/modules/services/drbd.if
+++ b/policy/modules/services/drbd.if
@@ -6,9 +6,9 @@
 ##	run drbd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`drbd_domtrans',`

--- a/policy/modules/services/exim.if
+++ b/policy/modules/services/exim.if
@@ -5,9 +5,9 @@
 ##	Execute exim in the caller domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`exim_exec',`
@@ -24,9 +24,9 @@ interface(`exim_exec',`
 ##	Execute a domain transition to run exim.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`exim_domtrans',`
@@ -142,9 +142,9 @@ interface(`exim_read_log',`
 ##	Append exim log files.
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access.
-## 	</summary>
+##	</summary>
 ## </param>
 #
 interface(`exim_append_log',`

--- a/policy/modules/services/fail2ban.if
+++ b/policy/modules/services/fail2ban.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run fail2ban.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`fail2ban_domtrans',`
@@ -206,9 +206,9 @@ interface(`fail2ban_read_log',`
 ##	Append fail2ban log files.
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access.
-## 	</summary>
+##	</summary>
 ## </param>
 #
 interface(`fail2ban_append_log',`

--- a/policy/modules/services/firewalld.if
+++ b/policy/modules/services/firewalld.if
@@ -5,9 +5,9 @@
 ##	Read firewalld configuration files.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`firewalld_read_config_files',`

--- a/policy/modules/services/fprintd.if
+++ b/policy/modules/services/fprintd.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run fprintd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`fprintd_domtrans',`

--- a/policy/modules/services/gnomeclock.if
+++ b/policy/modules/services/gnomeclock.if
@@ -6,9 +6,9 @@
 ##	run gnomeclock.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`gnomeclock_domtrans',`

--- a/policy/modules/services/gpsd.if
+++ b/policy/modules/services/gpsd.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run gpsd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`gpsd_domtrans',`

--- a/policy/modules/services/gssproxy.if
+++ b/policy/modules/services/gssproxy.if
@@ -5,9 +5,9 @@
 ##	Execute gssproxy in the gssproxy domin.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`gssproxy_domtrans',`

--- a/policy/modules/services/icecast.if
+++ b/policy/modules/services/icecast.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run icecast.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`icecast_domtrans',`
@@ -114,9 +114,9 @@ interface(`icecast_read_log',`
 ##	Append icecast log files.
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access.
-## 	</summary>
+##	</summary>
 ## </param>
 #
 interface(`icecast_append_log',`

--- a/policy/modules/services/ifplugd.if
+++ b/policy/modules/services/ifplugd.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run ifplugd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`ifplugd_domtrans',`

--- a/policy/modules/services/kerberos.if
+++ b/policy/modules/services/kerberos.if
@@ -5,9 +5,9 @@
 ##	Execute kadmind in the caller domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`kerberos_exec_kadmind',`
@@ -24,9 +24,9 @@ interface(`kerberos_exec_kadmind',`
 ##	Execute a domain transition to run kpropd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`kerberos_domtrans_kpropd',`

--- a/policy/modules/services/kerneloops.if
+++ b/policy/modules/services/kerneloops.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run kerneloops.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`kerneloops_domtrans',`

--- a/policy/modules/services/knot.if
+++ b/policy/modules/services/knot.if
@@ -5,9 +5,9 @@
 ##      Execute knotc in the knotc domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
-##      Domain allowed to transition.
-## </summary>
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
 ## </param>
 #
 interface(`knot_domtrans_client',`
@@ -25,14 +25,14 @@ interface(`knot_domtrans_client',`
 ##      allow the specified role the knotc domain.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed to transition.
-##      </summary>
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
 ## </param>
 ## <param name="role">
-##      <summary>
-##      Role allowed access.
-##      </summary>
+##	<summary>
+##	Role allowed access.
+##	</summary>
 ## </param>
 ## <rolecap/>
 #
@@ -50,9 +50,9 @@ interface(`knot_run_client',`
 ##      Read knot config files.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`knot_read_config_files',`
@@ -70,14 +70,14 @@ interface(`knot_read_config_files',`
 ##      administrate an knot environment.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 ## <param name="role">
-##      <summary>
-##      Role allowed access.
-##      </summary>
+##	<summary>
+##	Role allowed access.
+##	</summary>
 ## </param>
 ## <rolecap/>
 #

--- a/policy/modules/services/ksmtuned.if
+++ b/policy/modules/services/ksmtuned.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run ksmtuned.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`ksmtuned_domtrans',`

--- a/policy/modules/services/lircd.if
+++ b/policy/modules/services/lircd.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run lircd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`lircd_domtrans',`
@@ -44,9 +44,9 @@ interface(`lircd_stream_connect',`
 ##	Read lircd etc files.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`lircd_read_config',`

--- a/policy/modules/services/memcached.if
+++ b/policy/modules/services/memcached.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run memcached.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`memcached_domtrans',`

--- a/policy/modules/services/modemmanager.if
+++ b/policy/modules/services/modemmanager.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run modemmanager.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`modemmanager_domtrans',`

--- a/policy/modules/services/mon.if
+++ b/policy/modules/services/mon.if
@@ -5,9 +5,9 @@
 ##      dontaudit using an inherited fd from mon_t
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain to not audit
-##      </summary>
+##	<summary>
+##	Domain to not audit
+##	</summary>
 ## </param>
 #
 interface(`mon_dontaudit_use_fds',`
@@ -23,9 +23,9 @@ interface(`mon_dontaudit_use_fds',`
 ##      dontaudit searching /var/lib/mon
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain to not audit
-##      </summary>
+##	<summary>
+##	Domain to not audit
+##	</summary>
 ## </param>
 #
 interface(`mon_dontaudit_search_var_lib',`

--- a/policy/modules/services/monit.if
+++ b/policy/modules/services/monit.if
@@ -89,14 +89,14 @@ interface(`monit_startstop_service',`
 ##	administrate an monit environment.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 ## <param name="role">
-##      <summary>
-##      Role allowed access.
-##      </summary>
+##	<summary>
+##	Role allowed access.
+##	</summary>
 ## </param>
 #
 interface(`monit_admin',`

--- a/policy/modules/services/mta.if
+++ b/policy/modules/services/mta.if
@@ -856,9 +856,9 @@ interface(`mta_spool_filetrans',`
 ##  Read mail spool files.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`mta_read_spool_files',`

--- a/policy/modules/services/networkmanager.if
+++ b/policy/modules/services/networkmanager.if
@@ -41,9 +41,9 @@ interface(`networkmanager_rw_packet_sockets',`
 ## Relabel networkmanager tun socket.
 ## </summary>
 ## <param name="domain">
-## <summary>
-## Domain allowed access.
-## </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`networkmanager_attach_tun_iface',`
@@ -311,9 +311,9 @@ interface(`networkmanager_read_runtime_files',`
 ##	a unix domain stream socket.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`networkmanager_stream_connect',`

--- a/policy/modules/services/nslcd.if
+++ b/policy/modules/services/nslcd.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run nslcd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`nslcd_domtrans',`

--- a/policy/modules/services/ntp.if
+++ b/policy/modules/services/ntp.if
@@ -143,9 +143,9 @@ interface(`ntp_initrc_domtrans',`
 ##      Read ntp conf files.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`ntp_read_conf_files',`

--- a/policy/modules/services/oddjob.if
+++ b/policy/modules/services/oddjob.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run oddjob.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`oddjob_domtrans',`

--- a/policy/modules/services/openct.if
+++ b/policy/modules/services/openct.if
@@ -23,9 +23,9 @@ interface(`openct_signull',`
 ##	Execute openct in the caller domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`openct_exec',`
@@ -42,9 +42,9 @@ interface(`openct_exec',`
 ##	Execute a domain transition to run openct.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`openct_domtrans',`

--- a/policy/modules/services/pingd.if
+++ b/policy/modules/services/pingd.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run pingd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`pingd_domtrans',`

--- a/policy/modules/services/plymouthd.if
+++ b/policy/modules/services/plymouthd.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run plymouthd.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`plymouthd_domtrans',`
@@ -24,9 +24,9 @@ interface(`plymouthd_domtrans',`
 ##	Execute plymouthd in the caller domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`plymouthd_exec',`
@@ -63,9 +63,9 @@ interface(`plymouthd_stream_connect',`
 ##	Execute plymouth in the caller domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`plymouthd_exec_plymouth',`
@@ -82,9 +82,9 @@ interface(`plymouthd_exec_plymouth',`
 ##	Execute a domain transition to run plymouth.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`plymouthd_domtrans_plymouth',`

--- a/policy/modules/services/policykit.if
+++ b/policy/modules/services/policykit.if
@@ -47,9 +47,9 @@ interface(`policykit_dbus_chat_auth',`
 ##	Execute a domain transition to run polkit_auth.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`policykit_domtrans_auth',`
@@ -111,9 +111,9 @@ interface(`policykit_signal_auth',`
 ##	Execute a domain transition to run polkit grant.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`policykit_domtrans_grant',`
@@ -195,9 +195,9 @@ interface(`policykit_rw_reload',`
 ##	Execute a domain transition to run polkit resolve.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`policykit_domtrans_resolve',`

--- a/policy/modules/services/postgresql.if
+++ b/policy/modules/services/postgresql.if
@@ -10,7 +10,7 @@
 ##	</summary>
 ## </param>
 ## <param name="user_domain">
-## 	<summary>
+##	<summary>
 ##	The type of the user domain.
 ##	</summary>
 ## </param>

--- a/policy/modules/services/ppp.if
+++ b/policy/modules/services/ppp.if
@@ -205,7 +205,7 @@ interface(`ppp_signull',`
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-##	 Domain allowed to transition.
+##	Domain allowed to transition.
 ##	</summary>
 ## </param>
 #
@@ -225,7 +225,7 @@ interface(`ppp_domtrans',`
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-##	 Domain allowed to transition.
+##	Domain allowed to transition.
 ##	</summary>
 ## </param>
 ## <param name="role">
@@ -254,7 +254,7 @@ interface(`ppp_run_cond',`
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-##	 Domain allowed to transition.
+##	Domain allowed to transition.
 ##	</summary>
 ## </param>
 ## <param name="role">
@@ -279,7 +279,7 @@ interface(`ppp_run',`
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-##	 Domain allowed access.
+##	Domain allowed access.
 ##	</summary>
 ## </param>
 #

--- a/policy/modules/services/rabbitmq.if
+++ b/policy/modules/services/rabbitmq.if
@@ -5,9 +5,9 @@
 ##	Execute rabbitmq in the rabbitmq domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`rabbitmq_domtrans',`

--- a/policy/modules/services/realmd.if
+++ b/policy/modules/services/realmd.if
@@ -5,9 +5,9 @@
 ##	Execute realmd in the realmd domain.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`realmd_domtrans',`

--- a/policy/modules/services/rpcbind.if
+++ b/policy/modules/services/rpcbind.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run rpcbind.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`rpcbind_domtrans',`

--- a/policy/modules/services/rsync.if
+++ b/policy/modules/services/rsync.if
@@ -155,9 +155,9 @@ interface(`rsync_exec',`
 ##	Read rsync config files.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`rsync_read_config',`
@@ -174,9 +174,9 @@ interface(`rsync_read_config',`
 ##	Write rsync config files.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`rsync_write_config',`

--- a/policy/modules/services/rtkit.if
+++ b/policy/modules/services/rtkit.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run rtkit_daemon.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`rtkit_daemon_domtrans',`

--- a/policy/modules/services/rwho.if
+++ b/policy/modules/services/rwho.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run rwho.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`rwho_domtrans',`

--- a/policy/modules/services/sanlock.if
+++ b/policy/modules/services/sanlock.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run sanlock.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`sanlock_domtrans',`

--- a/policy/modules/services/snort.if
+++ b/policy/modules/services/snort.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run snort.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`snort_domtrans',`

--- a/policy/modules/services/sssd.if
+++ b/policy/modules/services/sssd.if
@@ -101,9 +101,9 @@ interface(`sssd_write_config',`
 ##	sssd configuration files.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`sssd_manage_config',`

--- a/policy/modules/services/tpm2.if
+++ b/policy/modules/services/tpm2.if
@@ -108,9 +108,9 @@ interface(`tpm2_dontaudit_use_fds',`
 ##   tpm2-abrmd over dbus.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`tpm2_dbus_chat_abrmd',`

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -679,9 +679,9 @@ interface(`xserver_rw_console',`
 ##      Create the X windows console named pipes.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`xserver_create_console_pipes',`
@@ -697,9 +697,9 @@ interface(`xserver_create_console_pipes',`
 ##      relabel the X windows console named pipes.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`xserver_relabel_console_pipes',`
@@ -1231,9 +1231,9 @@ interface(`xserver_read_xkb_libs',`
 ##      Create xdm temporary directories.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain to allow access.
-##      </summary>
+##	<summary>
+##	Domain to allow access.
+##	</summary>
 ## </param>
 #
 interface(`xserver_create_xdm_tmp_dirs',`
@@ -1416,9 +1416,9 @@ interface(`xserver_kill',`
 ##      Allow reading xserver_t files to get cgroup and sessionid
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`xserver_read_state',`
@@ -1531,9 +1531,9 @@ interface(`xserver_read_tmp_files',`
 ##      talk to xserver_t by dbus
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`xserver_dbus_chat',`

--- a/policy/modules/services/zabbix.if
+++ b/policy/modules/services/zabbix.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run zabbix.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`zabbix_domtrans',`

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -454,9 +454,9 @@ interface(`auth_run_chk_passwd',`
 ##	Execute a domain transition to run unix_update.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`auth_domtrans_upd_passwd',`
@@ -694,9 +694,9 @@ interface(`auth_manage_shadow',`
 ##	</summary>
 ## </param>
 ## <param name="name" optional="true">
-##      <summary>
-##      The name of the object being created.
-##      </summary>
+##	<summary>
+##	The name of the object being created.
+##	</summary>
 ## </param>
 #
 interface(`auth_etc_filetrans_shadow',`
@@ -944,9 +944,9 @@ interface(`auth_rw_lastlog',`
 ##     Manage the last logins log.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`auth_manage_lastlog',`
@@ -1062,9 +1062,9 @@ interface(`auth_read_var_auth',`
 ##  and pam applets etc.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`auth_rw_var_auth',`

--- a/policy/modules/system/clock.if
+++ b/policy/modules/system/clock.if
@@ -50,7 +50,7 @@ interface(`clock_run',`
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-## 	Domain allowed access.
+##	Domain allowed access.
 ##	</summary>
 ## </param>
 #

--- a/policy/modules/system/hostname.if
+++ b/policy/modules/system/hostname.if
@@ -51,7 +51,7 @@ interface(`hostname_run',`
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.
-## 	</summary>
+##	</summary>
 ## </param>
 ## <rolecap/>
 #

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -9,9 +9,9 @@
 ##	This is normally used for systemd BindPaths options.
 ## </desc>
 ## <param name="file_type">
-##   <summary>
-##     Type to be used as a mountpoint.
-##   </summary>
+##	<summary>
+##	Type to be used as a mountpoint.
+##	</summary>
 ## </param>
 #
 interface(`init_mountpoint',`
@@ -89,9 +89,9 @@ interface(`init_script_file',`
 ##   systemd unit files.
 ## </summary>
 ## <param name="type">
-##   <summary>
-##   Type to be used for systemd unit files.
-##   </summary>
+##	<summary>
+##	Type to be used for systemd unit files.
+##	</summary>
 ## </param>
 #
 interface(`init_unit_file',`
@@ -1245,9 +1245,9 @@ interface(`init_shutdown_system',`
 ## 	Allow specified domain to get init status
 ## </summary>
 ## <param name="domain">
-## <summary>
-## 	Domain to allow access.
-## </summary>
+##	<summary>
+##	Domain to allow access.
+##	</summary>
 ## </param>
 #
 interface(`init_service_status',`
@@ -1264,9 +1264,9 @@ interface(`init_service_status',`
 ## 	Allow specified domain to get init start
 ## </summary>
 ## <param name="domain">
-## <summary>
-## 	Domain to allow access.
-## </summary>
+##	<summary>
+##	Domain to allow access.
+##	</summary>
 ## </param>
 #
 interface(`init_service_start',`
@@ -1304,9 +1304,9 @@ interface(`init_dbus_chat',`
 ##      read/follow symlinks under /var/lib/systemd/
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`init_read_var_lib_links',`
@@ -1323,9 +1323,9 @@ interface(`init_read_var_lib_links',`
 ##      List /var/lib/systemd/ dir
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`init_list_var_lib_dirs',`
@@ -1428,9 +1428,9 @@ interface(`init_search_pids',`
 ##  Allow listing of the /run/systemd directory.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`init_list_pids',`
@@ -1443,9 +1443,9 @@ interface(`init_list_pids',`
 ##  Create symbolic links in the /run/systemd directory.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`init_manage_pid_symlinks', `
@@ -1458,9 +1458,9 @@ interface(`init_manage_pid_symlinks', `
 ##  Create files in the /run/systemd directory.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`init_create_pid_files', `
@@ -1473,9 +1473,9 @@ interface(`init_create_pid_files', `
 ##  Write files in the /run/systemd directory.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`init_write_pid_files', `
@@ -1489,9 +1489,9 @@ interface(`init_write_pid_files', `
 ##  directories in the /run/systemd directory.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`init_manage_pid_dirs', `
@@ -1956,9 +1956,9 @@ interface(`init_script_file_domtrans',`
 ##      Send a kill signal to init scripts.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`init_kill_scripts',`
@@ -1974,9 +1974,9 @@ interface(`init_kill_scripts',`
 ##      Allow manage service for initrc_exec_t scripts
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Target domain
-##      </summary>
+##	<summary>
+##	Target domain
+##	</summary>
 ## </param>
 #
 interface(`init_manage_script_service',`
@@ -2021,7 +2021,7 @@ interface(`init_labeled_script_domtrans',`
 ## 	for all labeled init script types
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed to transition.
 ##	</summary>
 ## </param>
@@ -2039,9 +2039,9 @@ interface(`init_all_labeled_script_domtrans',`
 ##      Allow getting service status of initrc_exec_t scripts
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Target domain
-##      </summary>
+##	<summary>
+##	Target domain
+##	</summary>
 ## </param>
 #
 interface(`init_get_script_status',`
@@ -2157,9 +2157,9 @@ interface(`init_run_daemon',`
 ##     Start and stop init_script_file_type services
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     domain that can start and stop the services
-##     </summary>
+##	<summary>
+##	domain that can start and stop the services
+##	</summary>
 ## </param>
 #
 interface(`init_startstop_all_script_services',`
@@ -3104,9 +3104,9 @@ interface(`init_create_runtime_dirs',`
 ##      Read init_runtime_t files
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      domain
-##      </summary>
+##	<summary>
+##	domain
+##	</summary>
 ## </param>
 #
 interface(`init_read_runtime_files',`
@@ -3122,9 +3122,9 @@ interface(`init_read_runtime_files',`
 ##      Rename init_runtime_t files
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      domain
-##      </summary>
+##	<summary>
+##	domain
+##	</summary>
 ## </param>
 #
 interface(`init_rename_runtime_files',`
@@ -3140,9 +3140,9 @@ interface(`init_rename_runtime_files',`
 ##      Setattr init_runtime_t files
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      domain
-##      </summary>
+##	<summary>
+##	domain
+##	</summary>
 ## </param>
 #
 interface(`init_setattr_runtime_files',`
@@ -3158,9 +3158,9 @@ interface(`init_setattr_runtime_files',`
 ##      Delete init_runtime_t files
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      domain
-##      </summary>
+##	<summary>
+##	domain
+##	</summary>
 ## </param>
 #
 interface(`init_delete_runtime_files',`
@@ -3177,9 +3177,9 @@ interface(`init_delete_runtime_files',`
 ##  init sock file.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`init_write_runtime_socket',`
@@ -3386,8 +3386,8 @@ interface(`init_start_generic_units',`
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-## 	Domain to not audit.
-## </summary>
+##	Domain to not audit.
+##	</summary>
 ## </param>
 #
 interface(`init_stop_generic_units',`
@@ -3442,9 +3442,9 @@ interface(`init_get_all_units_status',`
 ##      All perms on all systemd units.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`init_manage_all_units',`
@@ -3482,8 +3482,8 @@ interface(`init_start_all_units',`
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-## 	Domain to not audit.
-## </summary>
+##	Domain to not audit.
+##	</summary>
 ## </param>
 #
 interface(`init_stop_all_units',`
@@ -3558,9 +3558,9 @@ interface(`init_linkable_keyring',`
 ##      Allow unconfined access to send instructions to init
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Target domain
-##      </summary>
+##	<summary>
+##	Target domain
+##	</summary>
 ## </param>
 #
 interface(`init_admin',`
@@ -3590,9 +3590,9 @@ interface(`init_admin',`
 ##      Allow getting init_t rlimit
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Source domain
-##      </summary>
+##	<summary>
+##	Source domain
+##	</summary>
 ## </param>
 #
 interface(`init_getrlimit',`

--- a/policy/modules/system/iscsi.if
+++ b/policy/modules/system/iscsi.if
@@ -5,9 +5,9 @@
 ##	Execute a domain transition to run iscsid.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`iscsid_domtrans',`

--- a/policy/modules/system/libraries.if
+++ b/policy/modules/system/libraries.if
@@ -51,7 +51,7 @@ interface(`libs_run_ldconfig',`
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.
-## 	</summary>
+##	</summary>
 ## </param>
 ## <rolecap/>
 #

--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -257,9 +257,9 @@ interface(`logging_run_auditd',`
 ##	Execute a domain transition to run the audit dispatcher.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`logging_domtrans_dispatcher',`
@@ -275,9 +275,9 @@ interface(`logging_domtrans_dispatcher',`
 ##	Signal the audit dispatcher.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed access.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`logging_signal_dispatcher',`
@@ -509,9 +509,9 @@ interface(`logging_setattr_syslogd_tmp_files',`
 ##  for syslogd.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`logging_audit_socket_activation', `
@@ -748,9 +748,9 @@ interface(`logging_relabelto_devlog_sock_files',`
 ##      Connect to the syslog control unix stream socket.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`logging_create_devlog',`
@@ -1057,9 +1057,9 @@ interface(`logging_append_all_logs',`
 ##      Append to all log files.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`logging_append_all_inherited_logs',`

--- a/policy/modules/system/lvm.if
+++ b/policy/modules/system/lvm.if
@@ -68,9 +68,9 @@ interface(`lvm_run',`
 ##      Send lvm a null signal.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`lvm_signull',`
@@ -177,9 +177,9 @@ interface(`lvm_create_lock_dirs',`
 ##      Read and write a lvm unnamed pipe.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`lvm_rw_inherited_pid_pipes',`

--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -786,9 +786,9 @@ interface(`miscfiles_manage_man_cache',`
 ##      Relabel from and to man cache.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`miscfiles_relabel_man_cache',`

--- a/policy/modules/system/mount.if
+++ b/policy/modules/system/mount.if
@@ -191,9 +191,9 @@ interface(`mount_rw_loopback_files',`
 ##	List mount runtime files.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`mount_list_runtime',`
@@ -209,9 +209,9 @@ interface(`mount_list_runtime',`
 ##	Watch mount runtime dirs.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`mount_watch_runtime_dirs',`
@@ -227,9 +227,9 @@ interface(`mount_watch_runtime_dirs',`
 ##	Watch mount runtime files.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`mount_watch_runtime_files',`
@@ -245,9 +245,9 @@ interface(`mount_watch_runtime_files',`
 ##	Watch reads on mount runtime files.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`mount_watch_reads_runtime_files',`
@@ -263,9 +263,9 @@ interface(`mount_watch_reads_runtime_files',`
 ##     Getattr on mount_runtime_t files
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`mount_getattr_runtime_files',`

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -377,9 +377,9 @@ interface(`sysnet_read_config',`
 ##     </p>
 ## </desc>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`sysnet_mmap_config_files',`

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -175,19 +175,19 @@ template(`systemd_role_template',`
 ##   specified systemd user instance.
 ## </summary>
 ## <param name="prefix">
-##   <summary>
-##     Prefix for the user domain.
-##   </summary>
+##	<summary>
+##	Prefix for the user domain.
+##	</summary>
 ## </param>
 ## <param name="entry_point">
-##   <summary>
-##     Entry point file type for the domain.
-##   </summary>
+##	<summary>
+##	Entry point file type for the domain.
+##	</summary>
 ## </param>
 ## <param name="domain">
-##   <summary>
-##     Domain to allow the systemd user domain to run.
-##   </summary>
+##	<summary>
+##	Domain to allow the systemd user domain to run.
+##	</summary>
 ## </param>
 #
 template(`systemd_user_daemon_domain',`
@@ -207,9 +207,9 @@ template(`systemd_user_daemon_domain',`
 ##   can be managed by systemd user instances for socket activation.
 ## </summary>
 ## <param name="file_type">
-##   <summary>
-##     File type to be associated.
-##   </summary>
+##	<summary>
+##	File type to be associated.
+##	</summary>
 ## </param>
 #
 interface(`systemd_user_activated_sock_file',`
@@ -227,14 +227,14 @@ interface(`systemd_user_activated_sock_file',`
 ##   for socket activation.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain to be associated.
-##   </summary>
+##	<summary>
+##	Domain to be associated.
+##	</summary>
 ## </param>
 ## <param name="sock_file_type">
-##   <summary>
-##     File type of the domain's sock files to be associated.
-##   </summary>
+##	<summary>
+##	File type of the domain's sock files to be associated.
+##	</summary>
 ## </param>
 #
 interface(`systemd_user_unix_stream_activated_socket',`
@@ -252,9 +252,9 @@ interface(`systemd_user_unix_stream_activated_socket',`
 ##   content.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_search_conf_home_content',`
@@ -271,9 +271,9 @@ interface(`systemd_search_conf_home_content',`
 ##   content.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_manage_conf_home_content',`
@@ -292,9 +292,9 @@ interface(`systemd_manage_conf_home_content',`
 ##   content.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_relabel_conf_home_content',`
@@ -313,9 +313,9 @@ interface(`systemd_relabel_conf_home_content',`
 ##   content.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_search_data_home_content',`
@@ -332,9 +332,9 @@ interface(`systemd_search_data_home_content',`
 ##   content.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_manage_data_home_content',`
@@ -353,9 +353,9 @@ interface(`systemd_manage_data_home_content',`
 ##   content.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_relabel_data_home_content',`
@@ -374,9 +374,9 @@ interface(`systemd_relabel_data_home_content',`
 ##   content.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_search_user_runtime',`
@@ -392,9 +392,9 @@ interface(`systemd_search_user_runtime',`
 ##   Allow the specified domain to read systemd user runtime files.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_user_runtime_files',`
@@ -410,9 +410,9 @@ interface(`systemd_read_user_runtime_files',`
 ##   Allow the specified domain to read systemd user runtime lnk files.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_user_runtime_lnk_files',`
@@ -429,9 +429,9 @@ interface(`systemd_read_user_runtime_lnk_files',`
 ##   user unit files.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_user_unit_files',`
@@ -449,9 +449,9 @@ interface(`systemd_read_user_unit_files',`
 ##   Allow the specified domain to read systemd user runtime unit files.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_user_runtime_units',`
@@ -469,9 +469,9 @@ interface(`systemd_read_user_runtime_units',`
 ##   directories.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_search_user_runtime_unit_dirs',`
@@ -488,9 +488,9 @@ interface(`systemd_search_user_runtime_unit_dirs',`
 ##   user runtime unit directories.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_list_user_runtime_unit_dirs',`
@@ -506,9 +506,9 @@ interface(`systemd_list_user_runtime_unit_dirs',`
 ##   Allow the specified domain to get the status of systemd user runtime units.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_status_user_runtime_units',`
@@ -525,9 +525,9 @@ interface(`systemd_status_user_runtime_units',`
 ##   Allow the specified domain to start systemd user runtime units.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_start_user_runtime_units',`
@@ -544,9 +544,9 @@ interface(`systemd_start_user_runtime_units',`
 ##   Allow the specified domain to stop systemd user runtime units.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_stop_user_runtime_units',`
@@ -563,9 +563,9 @@ interface(`systemd_stop_user_runtime_units',`
 ##   Allow the specified domain to reload systemd user runtime units.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_reload_user_runtime_units',`
@@ -583,9 +583,9 @@ interface(`systemd_reload_user_runtime_units',`
 ##   log parse environment type.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Type to be used as a log parse environment type.
-##   </summary>
+##	<summary>
+##	Type to be used as a log parse environment type.
+##	</summary>
 ## </param>
 #
 interface(`systemd_log_parse_environment',`
@@ -603,9 +603,9 @@ interface(`systemd_log_parse_environment',`
 ##   and groups allocated through the DynamicUser= option in systemd unit files
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access
-##   </summary>
+##	<summary>
+##	Domain allowed access
+##	</summary>
 ## </param>
 #
 interface(`systemd_use_nss',`
@@ -630,9 +630,9 @@ interface(`systemd_use_nss',`
 ##   that uses PrivateDevices=yes in section [Service].
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access
-##   </summary>
+##	<summary>
+##	Domain allowed access
+##	</summary>
 ## </param>
 #
 interface(`systemd_PrivateDevices',`
@@ -647,9 +647,9 @@ interface(`systemd_PrivateDevices',`
 ##  Allow domain to read udev hwdb file
 ## </summary>
 ## <param name="domain">
-## <summary>
-##  domain allowed access
-## </summary>
+##	<summary>
+##	domain allowed access
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_hwdb',`
@@ -665,9 +665,9 @@ interface(`systemd_read_hwdb',`
 ##  Allow domain to map udev hwdb file
 ## </summary>
 ## <param name="domain">
-## <summary>
-##  domain allowed access
-## </summary>
+##	<summary>
+##	domain allowed access
+##	</summary>
 ## </param>
 #
 interface(`systemd_map_hwdb',`
@@ -683,9 +683,9 @@ interface(`systemd_map_hwdb',`
 ##   Read systemd_login PID files.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_logind_pids',`
@@ -698,9 +698,9 @@ interface(`systemd_read_logind_pids',`
 ##   Manage systemd_login PID pipes.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_manage_logind_pid_pipes',`
@@ -713,9 +713,9 @@ interface(`systemd_manage_logind_pid_pipes',`
 ##     Write systemd_login named pipe.  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_write_logind_pid_pipes',`
@@ -728,9 +728,9 @@ interface(`systemd_write_logind_pid_pipes',`
 ##   Read systemd-logind runtime files.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_logind_runtime_files',`
@@ -748,9 +748,9 @@ interface(`systemd_read_logind_runtime_files',`
 ##   Manage systemd-logind runtime pipes.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_manage_logind_runtime_pipes',`
@@ -767,9 +767,9 @@ interface(`systemd_manage_logind_runtime_pipes',`
 ##     Write systemd-logind runtime named pipe.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_write_logind_runtime_pipes',`
@@ -788,9 +788,9 @@ interface(`systemd_write_logind_runtime_pipes',`
 ##   logind file descriptors.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_use_logind_fds',`
@@ -806,9 +806,9 @@ interface(`systemd_use_logind_fds',`
 ##      Read logind sessions files.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_logind_sessions_files',`
@@ -827,9 +827,9 @@ interface(`systemd_read_logind_sessions_files',`
 ##      Write inherited logind sessions pipes.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_write_inherited_logind_sessions_pipes',`
@@ -847,9 +847,9 @@ interface(`systemd_write_inherited_logind_sessions_pipes',`
 ##      Write inherited logind inhibit pipes.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_write_inherited_logind_inhibit_pipes',`
@@ -868,9 +868,9 @@ interface(`systemd_write_inherited_logind_inhibit_pipes',`
 ##   systemd logind over dbus.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_dbus_chat_logind',`
@@ -1001,9 +1001,9 @@ interface(`systemd_read_machines',`
 ##     Allow connecting to /run/systemd/userdb/io.systemd.Machine socket
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain that can access the socket
-##     </summary>
+##	<summary>
+##	Domain that can access the socket
+##	</summary>
 ## </param>
 #
 interface(`systemd_connect_machined',`
@@ -1020,9 +1020,9 @@ interface(`systemd_connect_machined',`
 ##   systemd hostnamed over dbus.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_dbus_chat_hostnamed',`
@@ -1040,9 +1040,9 @@ interface(`systemd_dbus_chat_hostnamed',`
 ##      allow systemd_passwd_agent to inherit fds
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain that owns the fds
-##      </summary>
+##	<summary>
+##	Domain that owns the fds
+##	</summary>
 ## </param>
 #
 interface(`systemd_use_passwd_agent_fds',`
@@ -1058,14 +1058,14 @@ interface(`systemd_use_passwd_agent_fds',`
 ##      allow systemd_passwd_agent to be run by admin
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain that runs it
-##      </summary>
+##	<summary>
+##	Domain that runs it
+##	</summary>
 ## </param>
 ## <param name="role">
-##      <summary>
-##      role that it runs in
-##      </summary>
+##	<summary>
+##	role that it runs in
+##	</summary>
 ## </param>
 #
 interface(`systemd_run_passwd_agent',`
@@ -1108,9 +1108,9 @@ interface(`systemd_use_passwd_agent',`
 ##      Transition to systemd_passwd_runtime_t when creating dirs
 ## </summary>
 ## <param name="domain">
-##      <summary>
+##	<summary>
 ##	Domain allowed access.
-##      </summary>
+##	</summary>
 ## </param>
 #
 interface(`systemd_filetrans_passwd_runtime_dirs',`
@@ -1129,9 +1129,9 @@ interface(`systemd_filetrans_passwd_runtime_dirs',`
 ##  directory.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_filetrans_userdb_runtime_dirs', `
@@ -1147,9 +1147,9 @@ interface(`systemd_filetrans_userdb_runtime_dirs', `
 ##  Allow to domain to create systemd-passwd symlink
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_manage_passwd_runtime_symlinks',`
@@ -1165,9 +1165,9 @@ interface(`systemd_manage_passwd_runtime_symlinks',`
 ##   Allow a domain to watch systemd-passwd runtime dirs.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_watch_passwd_runtime_dirs',`
@@ -1183,9 +1183,9 @@ interface(`systemd_watch_passwd_runtime_dirs',`
 ##      manage systemd unit dirs and the files in them  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_manage_all_units',`
@@ -1198,9 +1198,9 @@ interface(`systemd_manage_all_units',`
 ##      Allow domain to list the contents of systemd_journal_t dirs
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_list_journal_dirs',`
@@ -1216,9 +1216,9 @@ interface(`systemd_list_journal_dirs',`
 ##      Allow domain to read systemd_journal_t files
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_journal_files',`
@@ -1235,9 +1235,9 @@ interface(`systemd_read_journal_files',`
 ##      Allow domain to create/manage systemd_journal_t files
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_manage_journal_files',`
@@ -1255,9 +1255,9 @@ interface(`systemd_manage_journal_files',`
 ##      Allow domain to add a watch on systemd_journal_t directories
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_watch_journal_dirs',`
@@ -1314,7 +1314,7 @@ interface(`systemd_relabelto_journal_files',`
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.
-##	 </summary>
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_networkd_units',`
@@ -1334,7 +1334,7 @@ interface(`systemd_read_networkd_units',`
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.
-##	 </summary>
+##	</summary>
 ## </param>
 #
 interface(`systemd_manage_networkd_units',`
@@ -1409,9 +1409,9 @@ interface(`systemd_status_networkd',`
 ## Relabel systemd_networkd tun socket.
 ## </summary>
 ## <param name="domain">
-## <summary>
-## Domain allowed access.
-## </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_relabelfrom_networkd_tun_sockets',`
@@ -1427,9 +1427,9 @@ interface(`systemd_relabelfrom_networkd_tun_sockets',`
 ## Read/Write from systemd_networkd netlink route socket.
 ## </summary>
 ## <param name="domain">
-## <summary>
-## Domain allowed access.
-## </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_rw_networkd_netlink_route_sockets',`
@@ -1445,9 +1445,9 @@ interface(`systemd_rw_networkd_netlink_route_sockets',`
 ##  Allow domain to list dirs under /run/systemd/netif
 ## </summary>
 ## <param name="domain">
-## <summary>
-##  domain permitted the access
-## </summary>
+##	<summary>
+##	domain permitted the access
+##	</summary>
 ## </param>
 #
 interface(`systemd_list_networkd_runtime',`
@@ -1482,9 +1482,9 @@ interface(`systemd_watch_networkd_runtime_dirs',`
 ##  Allow domain to read files generated by systemd_networkd
 ## </summary>
 ## <param name="domain">
-## <summary>
-##  domain allowed access
-## </summary>
+##	<summary>
+##	domain allowed access
+##	</summary>
 ## </param>
 #
 
@@ -1502,9 +1502,9 @@ interface(`systemd_read_networkd_runtime',`
 ##     Allow systemd_logind_t to read process state for cgroup file
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain systemd_logind_t may access.
-##     </summary>
+##	<summary>
+##	Domain systemd_logind_t may access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_logind_state',`
@@ -1708,9 +1708,9 @@ interface(`systemd_relabelto_tmpfiles_conf_files',`
 ##	Allow systemd_tmpfiles_t to manage filesystem objects
 ## </summary>
 ## <param name="type">
-## <summary>
+##	<summary>
 ##	Type of object to manage
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`systemd_tmpfilesd_managed',`
@@ -1735,9 +1735,9 @@ interface(`systemd_tmpfilesd_managed',`
 ##   systemd resolved over dbus.
 ## </summary>
 ## <param name="domain">
-##   <summary>
-##     Domain allowed access.
-##   </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`systemd_dbus_chat_resolved',`
@@ -1755,9 +1755,9 @@ interface(`systemd_dbus_chat_resolved',`
 ##  Allow domain to read resolv.conf file generated by systemd_resolved
 ## </summary>
 ## <param name="domain">
-## <summary>
-##  domain allowed access
-## </summary>
+##	<summary>
+##	domain allowed access
+##	</summary>
 ## </param>
 #
 interface(`systemd_read_resolved_runtime',`
@@ -1773,9 +1773,9 @@ interface(`systemd_read_resolved_runtime',`
 ##  Allow domain to getattr on .updated file (generated by systemd-update-done
 ## </summary>
 ## <param name="domain">
-## <summary>
-##  domain allowed access
-## </summary>
+##	<summary>
+##	domain allowed access
+##	</summary>
 ## </param>
 #
 interface(`systemd_getattr_updated_runtime',`
@@ -1870,9 +1870,9 @@ interface(`systemd_domtrans_sysusers', `
 ##	</summary>
 ## </param>
 ## <param name="role">
-##  <summary>
-##  Role allowed access.
-##  </summary>
+##	<summary>
+##	Role allowed access.
+##	</summary>
 ## </param>
 ## <rolecap/>
 #

--- a/policy/modules/system/udev.if
+++ b/policy/modules/system/udev.if
@@ -295,9 +295,9 @@ interface(`udev_rw_db',`
 ##      Allow process to relabelto udev database  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`udev_relabelto_db',`
@@ -338,9 +338,9 @@ interface(`udev_search_pids',`
 ##      list udev pid content  (Deprecated)
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`udev_list_pids',`
@@ -420,7 +420,7 @@ interface(`udev_manage_pid_files',`
 ##	</summary>
 ## </param>
 ## <param name="name" optional="true">
-## 	<summary>
+##	<summary>
 ##	Name of the directory that is created
 ##	</summary>
 ## </param>
@@ -453,9 +453,9 @@ interface(`udev_search_runtime',`
 ##      List udev runtime dirs.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`udev_list_runtime',`

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -463,9 +463,9 @@ interface(`unconfined_stream_connect',`
 ##      unconfined domain stream.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain to not audit.
-##      </summary>
+##	<summary>
+##	Domain to not audit.
+##	</summary>
 ## </param>
 #
 interface(`unconfined_dontaudit_rw_stream_sockets',`

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -4503,9 +4503,9 @@ interface(`userdom_write_user_tmp_files',`
 ##      temporary files.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain to not audit.
-##      </summary>
+##	<summary>
+##	Domain to not audit.
+##	</summary>
 ## </param>
 #
 interface(`userdom_dontaudit_write_user_tmp_files',`
@@ -4760,9 +4760,9 @@ interface(`userdom_dbus_send_all_users',`
 ##     unserdomain stream.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain to not audit.
-##     </summary>
+##	<summary>
+##	Domain to not audit.
+##	</summary>
 ## </param>
 #
 interface(`userdom_dontaudit_rw_all_users_stream_sockets',`

--- a/policy/modules/system/xen.if
+++ b/policy/modules/system/xen.if
@@ -140,9 +140,9 @@ interface(`xen_rw_image_files',`
 ##	Append xend log files.
 ## </summary>
 ## <param name="domain">
-## 	<summary>
+##	<summary>
 ##	Domain allowed access.
-## 	</summary>
+##	</summary>
 ## </param>
 #
 interface(`xen_append_log',`
@@ -282,14 +282,14 @@ interface(`xen_stream_connect',`
 ##	</summary>
 ## </param>
 ## <param name="private type">
-##      <summary>
-##      The type of the object to be created.
-##      </summary>
+##	<summary>
+##	The type of the object to be created.
+##	</summary>
 ## </param>
 ## <param name="object">
-##      <summary>
-##      The object class of the object being created.
-##      </summary>
+##	<summary>
+##	The object class of the object being created.
+##	</summary>
 ## </param>
 #
 interface(`xen_pid_filetrans',`
@@ -307,14 +307,14 @@ interface(`xen_pid_filetrans',`
 ##	</summary>
 ## </param>
 ## <param name="private type">
-##      <summary>
-##      The type of the object to be created.
-##      </summary>
+##	<summary>
+##	The type of the object to be created.
+##	</summary>
 ## </param>
 ## <param name="object">
-##      <summary>
-##      The object class of the object being created.
-##      </summary>
+##	<summary>
+##	The object class of the object being created.
+##	</summary>
 ## </param>
 #
 interface(`xen_runtime_filetrans',`
@@ -330,9 +330,9 @@ interface(`xen_runtime_filetrans',`
 ##	Execute a domain transition to run xm.
 ## </summary>
 ## <param name="domain">
-## <summary>
+##	<summary>
 ##	Domain allowed to transition.
-## </summary>
+##	</summary>
 ## </param>
 #
 interface(`xen_domtrans_xm',`


### PR DESCRIPTION
There is more than 5000 parameter documentations. Only about 300 are
differently done. Change them to be consistently indented.

param with one space
and content inside with one tab

This was done with:

sed -ri '
/^##[[:space:]]*<param/,/^##[[:space:]]*<[/]param>/{
	s/^##[[:space:]]*/##\t/;
	s/^##[[:space:]]*(<[/]?summary)/##\t\1/;
	s/^##[[:space:]]*(<[/]?param)/## \1/;
}' policy/modules/*/*.if

Signed-off-by: Markus Linnala <Markus.Linnala@cybercom.com>