### PR TITLE
dmesg.te: Added files_read_etc_files()

### DIFF
--- a/policy/modules/admin/dmesg.te
+++ b/policy/modules/admin/dmesg.te
@@ -38,6 +38,7 @@ term_dontaudit_use_console(dmesg_t)
 domain_use_interactive_fds(dmesg_t)
 
 files_list_etc(dmesg_t)
+files_read_etc_files(dmesg_t)
 files_read_usr_files(dmesg_t)
 
 init_use_fds(dmesg_t)


### PR DESCRIPTION
Some distros store terminfo data in `/etc/terminfo/`, allow dmesg to read the directory for these.