### PR TITLE
xen: device and sysadm fixes

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -198,8 +198,10 @@ ifdef(`distro_suse', `
 /dev/xen/evtchn		-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/xen/gntdev		-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/xen/gntalloc	-c	gen_context(system_u:object_r:xen_device_t,s0)
+/dev/xen/hypercall	-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/xen/privcmd	-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/xen/xenbus		-c	gen_context(system_u:object_r:xen_device_t,s0)
+/dev/xen/xenbus_backend	-c	gen_context(system_u:object_r:xen_device_t,s0)
 
 ifdef(`distro_debian',`
 # this is a static /dev dir "backup mount"

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -324,6 +324,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	dev_rw_xen(sysadm_t)
+')
+
+optional_policy(`
 	dhcpd_admin(sysadm_t, sysadm_r)
 ')
 


### PR DESCRIPTION
Added character devices and sysadm read/write access to those character devices so userspace tooling in dom0 can function.