### PR TITLE
ICMPv6 secmark fixes

### DIFF
--- a/policy/modules/services/dhcp.te
+++ b/policy/modules/services/dhcp.te
@@ -72,6 +72,7 @@ corenet_tcp_bind_generic_node(dhcpd_t)
 corenet_udp_bind_generic_node(dhcpd_t)
 
 corenet_sendrecv_dhcpd_server_packets(dhcpd_t)
+corenet_sendrecv_icmp_packets(dhcpd_t)
 corenet_tcp_bind_dhcpd_port(dhcpd_t)
 corenet_udp_bind_dhcpd_port(dhcpd_t)
 

--- a/policy/modules/services/radvd.te
+++ b/policy/modules/services/radvd.te
@@ -49,6 +49,8 @@ corenet_tcp_sendrecv_generic_node(radvd_t)
 corenet_udp_sendrecv_generic_node(radvd_t)
 corenet_raw_sendrecv_generic_node(radvd_t)
 
+corenet_sendrecv_icmp_packets(radvd_t)
+
 dev_read_sysfs(radvd_t)
 
 domain_use_interactive_fds(radvd_t)

--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -125,6 +125,7 @@ corenet_udp_bind_all_unreserved_ports(dhcpc_t)
 corenet_tcp_connect_all_ports(dhcpc_t)
 corenet_sendrecv_dhcpd_client_packets(dhcpc_t)
 corenet_sendrecv_all_server_packets(dhcpc_t)
+corenet_sendrecv_icmp_packets(dhcpc_t)
 
 dev_read_sysfs(dhcpc_t)
 # for SSP:


### PR DESCRIPTION
DHCP client needs to handle ICMPv6 packets required for router solicitation when combined with secmark:

```
dhcpcd[2258]: ipv6nd_sendrsprobe: Connection refused
kernel: audit: type=1400 audit(1625835757.027:410): avc:  denied  { send } for  pid=2258 comm="dhcpcd" saddr=... daddr=ff02::2 netif=eno1 scontext=system_u:system_r:dhcpc_t:s0 tcontext=system_u:object_r:icmp_packet_t:s0 tclass=packet permissive=0
```