### PR TITLE
virt: Defined virt_runtime_common_t type

### DIFF
--- a/policy/modules/services/virt.fc
+++ b/policy/modules/services/virt.fc
@@ -58,6 +58,7 @@ HOME_DIR/VirtualMachines/isos(/.*)?	gen_context(system_u:object_r:virt_content_t
 /run/libguestfs(/.*)?	gen_context(system_u:object_r:virt_runtime_t,s0)
 /run/libvirtd\.pid	--	gen_context(system_u:object_r:virt_runtime_t,s0)
 /run/libvirt(/.*)?	gen_context(system_u:object_r:virt_runtime_t,s0)
+/run/libvirt/common(/.*)?	gen_context(system_u:object_r:virt_common_runtime_t,s0)
 /run/libvirt/lxc(/.*)?	gen_context(system_u:object_r:virtd_lxc_runtime_t,s0)
 /run/libvirt-sandbox(/.*)?	gen_context(system_u:object_r:virtd_lxc_runtime_t,s0)
 /run/libvirt/qemu(/.*)?	gen_context(system_u:object_r:svirt_runtime_t,s0-mls_systemhigh)

--- a/policy/modules/services/virt.te
+++ b/policy/modules/services/virt.te
@@ -129,6 +129,9 @@ type virt_image_t; # customizable
 virt_image(virt_image_t)
 files_mountpoint(virt_image_t)
 
+type virt_common_runtime_t;
+files_runtime_file(virt_common_runtime_t)
+
 type virt_content_t; # customizable
 virt_image(virt_content_t)
 userdom_user_home_content(virt_content_t)
@@ -576,6 +579,11 @@ manage_dirs_pattern(virtd_t, virt_runtime_t, virt_runtime_t)
 manage_files_pattern(virtd_t, virt_runtime_t, virt_runtime_t)
 manage_sock_files_pattern(virtd_t, virt_runtime_t, virt_runtime_t)
 files_runtime_filetrans(virtd_t, virt_runtime_t, { file dir })
+
+allow virtd_t virt_common_runtime_t:file append_file_perms;
+manage_dirs_pattern(virtd_t, virt_common_runtime_t, virt_common_runtime_t)
+manage_files_pattern(virtd_t, virt_common_runtime_t, virt_common_runtime_t)
+filetrans_pattern(virtd_t, virt_runtime_t, virt_common_runtime_t, dir, "common")
 
 manage_dirs_pattern(virtd_t, virtd_lxc_runtime_t, virtd_lxc_runtime_t)
 manage_files_pattern(virtd_t, virtd_lxc_runtime_t, virtd_lxc_runtime_t)
@@ -1366,6 +1374,9 @@ manage_files_pattern(virtlogd_t, virt_runtime_t, virtlogd_run_t)
 manage_sock_files_pattern(virtlogd_t, virt_runtime_t, virtlogd_run_t)
 filetrans_pattern(virtlogd_t, virt_runtime_t, virtlogd_run_t, sock_file)
 files_runtime_filetrans(virtlogd_t, virtlogd_run_t, file)
+
+allow virtlogd_t virt_common_runtime_t:file append_file_perms;
+manage_files_pattern(virtlogd_t, virt_runtime_t, virt_common_runtime_t)
 
 kernel_read_system_state(virtlogd_t)
 


### PR DESCRIPTION
For the new common/system.token file in libvirt 4.7.0 and added permissions to virtd_t and virtlogd_t.

Modelled on: https://github.com/fedora-selinux/selinux-policy/commit/1f761d0bbdc08d21a91cdcbd1909ddb53858e354
libvirt change introducing this: https://gitlab.com/libvirt/libvirt/-/commit/cbfebfc74741a00bddf67b7fa10892b757fffd6