### PR TITLE
policy/modules/services/minidlna.te: make xdg optional

### DIFF
--- a/policy/modules/services/minidlna.te
+++ b/policy/modules/services/minidlna.te
@@ -82,10 +82,6 @@ logging_search_logs(minidlna_t)
 miscfiles_read_localization(minidlna_t)
 miscfiles_read_public_files(minidlna_t)
 
-xdg_read_music(minidlna_t)
-xdg_read_pictures(minidlna_t)
-xdg_read_videos(minidlna_t)
-
 tunable_policy(`minidlna_read_generic_user_content',`
 	userdom_list_user_tmp(minidlna_t)
 	userdom_read_user_home_content_files(minidlna_t)
@@ -100,4 +96,10 @@ tunable_policy(`minidlna_read_generic_user_content',`
 	userdom_dontaudit_list_user_tmp(minidlna_t)
 	userdom_dontaudit_read_user_home_content_files(minidlna_t)
 	userdom_dontaudit_read_user_tmp_files(minidlna_t)
+')
+
+optional_policy(`
+	xdg_read_music(minidlna_t)
+	xdg_read_pictures(minidlna_t)
+	xdg_read_videos(minidlna_t)
 ')


### PR DESCRIPTION
Make xdg optional to avoid the following build failure:

```
 Compiling targeted policy.28
 env LD_LIBRARY_PATH="/home/buildroot/autobuild/instance-1/output-1/host/lib:/home/buildroot/autobuild/instance-1/output-1/host/usr/lib" /home/buildroot/autobuild/instance-1/output-1/host/usr/bin/checkpolicy -c 28 -U deny -S -O -E policy.conf -o policy.28
 policy/modules/services/minidlna.te:85:ERROR 'unknown type xdg_music_t' at token ';' on line 146109:
 #line 85
	allow minidlna_t xdg_music_t:dir { getattr search open };
 checkpolicy:  error(s) encountered while parsing configuration
 Rules.monolithic:78: recipe for target 'policy.28' failed
```

Fixes:
 - http://autobuild.buildroot.org/results/52490172afd9b72b08a7deb0bd3c2124398bbffa/build-end.log

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>