### PR TITLE
policy/modules/services/ftp.te: make ssh optional

### DIFF
--- a/policy/modules/services/ftp.te
+++ b/policy/modules/services/ftp.te
@@ -481,10 +481,6 @@ tunable_policy(`sftpd_full_access',`
 	files_manage_non_auth_files(sftpd_t)
 ')
 
-tunable_policy(`sftpd_write_ssh_home',`
-	ssh_manage_home_files(sftpd_t)
-')
-
 tunable_policy(`use_samba_home_dirs',`
 	fs_list_cifs(sftpd_t)
 	fs_read_cifs_files(sftpd_t)
@@ -495,4 +491,10 @@ tunable_policy(`use_nfs_home_dirs',`
 	fs_list_nfs(sftpd_t)
 	fs_read_nfs_files(sftpd_t)
 	fs_read_nfs_symlinks(ftpd_t)
+')
+
+optional_policy(`
+	tunable_policy(`sftpd_write_ssh_home',`
+		ssh_manage_home_files(sftpd_t)
+	')
 ')


### PR DESCRIPTION
Make ssh optional to avoid the following build failure:

```
Compiling targeted policy.30
env LD_LIBRARY_PATH="/home/fabrice/buildroot/output/host/lib:/home/fabrice/buildroot/output/host/usr/lib" /home/fabrice/buildroot/output/host/usr/bin/checkpolicy -c 30 -U deny -S -O -E policy.conf -o policy.30
policy/modules/services/ftp.te:484:ERROR 'type ssh_home_t is not within scope' at token ';' on line 92051:
	allow sftpd_t ssh_home_t:dir { open read getattr lock search ioctl add_name remove_name write };
#line 484
checkpolicy:  error(s) encountered while parsing configuration
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>