### PR TITLE
chronyd.te: Grant chronyd_t access to the net_admin capability

### DIFF
--- a/policy/modules/services/chronyd.te
+++ b/policy/modules/services/chronyd.te
@@ -5,6 +5,14 @@ policy_module(chronyd, 1.8.0)
 # Declarations
 #
 
+## <desc>
+##      <p>
+##      Determine whether chronyd can access NIC hardware
+##      timestamping features
+##      </p>
+## </desc>
+gen_tunable(chronyd_hwtimestamp, false)
+
 attribute_role chronyc_roles;
 
 type chronyd_t;
@@ -98,6 +106,11 @@ miscfiles_read_localization(chronyd_t)
 
 chronyd_dgram_send_cli(chronyd_t)
 chronyd_read_config(chronyd_t)
+
+tunable_policy(`chronyd_hwtimestamp',`
+	# net_admin required for SIOCSHWTSTAMP.
+	allow chronyd_t self:capability net_admin;
+')
 
 optional_policy(`
 	gpsd_rw_shm(chronyd_t)


### PR DESCRIPTION
This is required for its `hwtimestamp` option, which otherwise returns:

    ioctl(SIOCSHWTSTAMP) failed : Operation not permitted