### PR TITLE
policy/modules/apps/wireshark.te: make xdg optional

### DIFF
--- a/policy/modules/apps/wireshark.te
+++ b/policy/modules/apps/wireshark.te
@@ -93,8 +93,6 @@ userdom_use_user_terminals(wireshark_t)
 
 userdom_user_content_access_template(wireshark, wireshark_t)
 
-xdg_read_downloads(wireshark_t)
-
 tunable_policy(`use_nfs_home_dirs',`
 	fs_manage_nfs_dirs(wireshark_t)
 	fs_manage_nfs_files(wireshark_t)
@@ -114,6 +112,10 @@ optional_policy(`
 optional_policy(`
 	userhelper_use_fd(wireshark_t)
 	userhelper_sigchld(wireshark_t)
+')
+
+optional_policy(`
+	xdg_read_downloads(wireshark_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Make xdg optional to fix the following build failure:

```
 Compiling targeted policy.31
 env LD_LIBRARY_PATH="/tmp/instance-0/output-1/host/lib:/tmp/instance-0/output-1/host/usr/lib" /tmp/instance-0/output-1/host/usr/bin/checkpolicy -c 31 -U deny -S -O -E policy.conf -o policy.31
 policy/modules/apps/wireshark.te:96:ERROR 'unknown type xdg_downloads_t' at token ';' on line 645315:
 #line 96
	allow wireshark_t xdg_downloads_t:dir { getattr search open };
 checkpolicy:  error(s) encountered while parsing configuration
 make[1]: *** [Rules.monolithic:79: policy.31] Error 1
```

Fixes:
 - http://autobuild.buildroot.org/results/dfbc667e0c17072ddab89a03244f572d5234da50

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>