### PR TITLE
git: add policy for git application

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -28,6 +28,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	git_client_role_template(staff, staff_r, staff_t)
 	git_role(staff_r, staff_t)
 ')
 

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -17,6 +17,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	git_client_role_template(user, user_r, user_t)
 	git_role(user_r, user_t)
 ')
 

--- a/policy/modules/services/git.fc
+++ b/policy/modules/services/git.fc
@@ -1,4 +1,6 @@
 HOME_DIR/public_git(/.*)?		gen_context(system_u:object_r:git_user_content_t,s0)
+HOME_DIR/\.config/git(/.*)?		gen_context(system_u:object_r:git_xdg_config_t,s0)
+HOME_DIR/\.gitconfig	--	gen_context(system_u:object_r:git_xdg_config_t,s0)
 
 /usr/lib/git-core/git-daemon	--	gen_context(system_u:object_r:gitd_exec_t,s0)
 

--- a/policy/modules/services/git.if
+++ b/policy/modules/services/git.if
@@ -49,6 +49,73 @@ interface(`git_role',`
 
 ########################################
 ## <summary>
+##	Role access for Git client.
+## </summary>
+## <param name="role_prefix">
+##	<summary>
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
+##	</summary>
+## </param>
+## <param name="user_role">
+##	<summary>
+##	The role associated with the user domain.
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	The type of the user domain.
+##	</summary>
+## </param>
+#
+template(`git_client_role_template',`
+	gen_require(`
+		attribute git_client_domain;
+		type git_exec_t, git_home_t, git_home_hook_t;
+	')
+
+	########################################
+	#
+	# Declarations
+	#
+
+	type $1_git_t, git_client_domain;
+	userdom_user_application_domain($1_git_t, git_exec_t)
+	role $2 types $1_git_t;
+
+	########################################
+	#
+	# Policy
+	#
+	
+	domtrans_pattern($3, git_exec_t, $1_git_t)
+
+	allow $3 git_home_t:dir { manage_dir_perms relabel_dir_perms };
+	allow $3 git_home_t:file { manage_file_perms relabel_file_perms };
+	userdom_user_home_dir_filetrans($3, git_home_t, dir, ".git")
+
+	allow $3 git_home_hook_t:dir { manage_dir_perms relabel_dir_perms };
+	allow $3 git_home_hook_t:file { exec_file_perms manage_file_perms relabel_file_perms };
+	filetrans_pattern($3, git_home_t, git_home_hook_t, dir, "hooks")
+
+	allow $3 $1_git_t:process { ptrace signal_perms };
+	ps_process_pattern($3, $1_git_t)
+
+	auth_use_nsswitch($1_git_t)
+
+	# allow userdomains to exec git hooks
+	exec_files_pattern($3, git_home_t, git_home_t)
+	# transition back to the user domain when executing git hooks
+	domtrans_pattern($1_git_t, git_home_t, $3)
+
+	# transition to ssh client domain when performing ssh operations
+	optional_policy(`
+		ssh_client_domtrans($1_git_t)
+	')
+')
+
+########################################
+## <summary>
 ##	Read generic system content files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/git.te
+++ b/policy/modules/services/git.te
@@ -79,6 +79,15 @@ gen_tunable(git_system_use_cifs, false)
 ## </desc>
 gen_tunable(git_system_use_nfs, false)
 
+## <desc>
+##	<p>
+##	Determine whether Git client domains
+##	can manage all user home content,
+##	including application-specific data.
+##	</p>
+## </desc>
+gen_tunable(git_client_manage_all_user_home_content, false)
+
 attribute git_daemon;
 attribute_role git_session_roles;
 
@@ -92,11 +101,24 @@ type git_session_t, git_daemon;
 userdom_user_application_domain(git_session_t, gitd_exec_t)
 role git_session_roles types git_session_t;
 
+attribute git_client_domain;
+type git_exec_t;
+application_executable_file(git_exec_t)
+
 type git_sys_content_t;
 files_type(git_sys_content_t)
 
 type git_user_content_t;
 userdom_user_home_content(git_user_content_t)
+
+type git_home_t;
+userdom_user_home_content(git_home_t)
+
+type git_home_hook_t;
+userdom_user_home_content(git_home_hook_t)
+
+type git_xdg_config_t;
+xdg_config_content(git_xdg_config_t)
 
 ########################################
 #
@@ -273,3 +295,55 @@ files_read_usr_files(git_daemon)
 fs_search_auto_mountpoints(git_daemon)
 
 miscfiles_read_localization(git_daemon)
+
+########################################
+#
+# Git client policy
+#
+
+allow git_client_domain self:fifo_file rw_fifo_file_perms;
+
+manage_dirs_pattern(git_client_domain, git_home_t, git_home_t)
+manage_files_pattern(git_client_domain, git_home_t, git_home_t)
+manage_lnk_files_pattern(git_client_domain, git_home_t, git_home_t)
+
+list_dirs_pattern(git_client_domain, git_home_hook_t, git_home_hook_t)
+exec_files_pattern(git_client_domain, git_home_hook_t, git_home_hook_t)
+
+manage_dirs_pattern(git_client_domain, git_xdg_config_t, git_xdg_config_t)
+manage_files_pattern(git_client_domain, git_xdg_config_t, git_xdg_config_t)
+xdg_config_filetrans(git_client_domain, git_xdg_config_t, dir, "git")
+
+exec_files_pattern(git_client_domain, git_exec_t, git_exec_t)
+
+corecmd_exec_bin(git_client_domain)
+
+corenet_tcp_connect_git_port(git_client_domain)
+corenet_tcp_connect_http_port(git_client_domain)
+
+domain_use_interactive_fds(git_client_domain)
+
+files_read_usr_files(git_client_domain)
+
+miscfiles_read_generic_certs(git_client_domain)
+miscfiles_read_localization(git_client_domain)
+
+userdom_manage_user_tmp_dirs(git_client_domain)
+userdom_manage_user_tmp_files(git_client_domain)
+userdom_manage_user_tmp_symlinks(git_client_domain)
+userdom_manage_user_home_content_dirs(git_client_domain)
+userdom_manage_user_home_content_files(git_client_domain)
+userdom_manage_user_home_content_symlinks(git_client_domain)
+userdom_user_home_content_filetrans(git_client_domain, git_home_t, dir, ".git")
+userdom_use_user_terminals(git_client_domain)
+
+allow git_client_domain git_home_t:file map;
+userdom_map_user_home_content_files(git_client_domain)
+
+xdg_search_cache_dirs(git_client_domain)
+xdg_search_config_dirs(git_client_domain)
+
+tunable_policy(`git_client_manage_all_user_home_content',`
+	userdom_manage_all_user_home_content(git_client_domain)
+	userdom_map_all_user_home_content_files(git_client_domain)
+')

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -626,6 +626,24 @@ interface(`ssh_domtrans',`
 
 ########################################
 ## <summary>
+##	Execute the ssh client in the ssh client domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`ssh_client_domtrans',`
+	gen_require(`
+		type ssh_t, ssh_exec_t;
+	')
+
+	domtrans_pattern($1, ssh_exec_t, ssh_t)
+')
+
+########################################
+## <summary>
 ##	Execute the ssh client in the caller domain.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -2220,6 +2220,24 @@ interface(`userdom_manage_all_user_home_content',`
 
 ########################################
 ## <summary>
+##	Map all user home content, including application-specific resources.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`userdom_map_all_user_home_content_files',`
+	gen_require(`
+		attribute user_home_content_type;
+	')
+
+	allow $1 user_home_content_type:file map;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to append user home files.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The git application cannot normally be used by confined users as it requires the `map` permission on files in a repository. To address this, create a policy for the application and allow users to transition to it. `git_client_role_template()` is used to create the access needed for users, and the permissions for the git client are separate from those of the git daemon and git CGI.