### PR TITLE
rpc: remove obsolete comment line

### DIFF
--- a/policy/modules/services/rpc.te
+++ b/policy/modules/services/rpc.te
@@ -330,7 +330,6 @@ fs_mount_nfsd_fs(nfsd_t)
 fs_getattr_all_fs(nfsd_t)
 fs_getattr_all_dirs(nfsd_t)
 fs_rw_nfsd_fs(nfsd_t)
-# fs_manage_nfsd_fs(nfsd_t)
 
 storage_dontaudit_read_fixed_disk(nfsd_t)
 storage_raw_read_removable_device(nfsd_t)


### PR DESCRIPTION
There is no fs_manage_nfsd_fs interface.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>