### PR TITLE
File context for nginx cache files

### DIFF
--- a/policy/modules/services/apache.fc
+++ b/policy/modules/services/apache.fc
@@ -118,6 +118,7 @@ ifdef(`distro_suse',`
 /var/cache/apache2(/.*)?					gen_context(system_u:object_r:httpd_cache_t,s0)
 /var/cache/httpd(/.*)?						gen_context(system_u:object_r:httpd_cache_t,s0)
 /var/cache/lighttpd(/.*)?					gen_context(system_u:object_r:httpd_cache_t,s0)
+/var/cache/nginx(/.*)?						gen_context(system_u:object_r:httpd_cache_t,s0)
 /var/cache/mason(/.*)?						gen_context(system_u:object_r:httpd_cache_t,s0)
 /var/cache/mediawiki(/.*)?					gen_context(system_u:object_r:httpd_cache_t,s0)
 /var/cache/mod_.*						gen_context(system_u:object_r:httpd_cache_t,s0)


### PR DESCRIPTION
Nginx cache files should have the httpd_cache_t context.