### PR TITLE
authlogin: add fcontext for tcb

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -3,10 +3,13 @@
 /etc/passwd\.lock	--	gen_context(system_u:object_r:shadow_lock_t,s0)
 /etc/gshadow.*		--	gen_context(system_u:object_r:shadow_t,s0)
 /etc/shadow.*		--	gen_context(system_u:object_r:shadow_t,s0)
+/etc/tcb(/.*)?		--	gen_context(system_u:object_r:shadow_t,s0)
 
 /usr/bin/login		--	gen_context(system_u:object_r:login_exec_t,s0)
 /usr/bin/pam_console_apply	--	gen_context(system_u:object_r:pam_console_exec_t,s0)
 /usr/bin/pam_timestamp_check	--	gen_context(system_u:object_r:pam_exec_t,s0)
+/usr/bin/tcb_convert		--	gen_context(system_u:object_r:updpwd_exec_t,s0)
+/usr/bin/tcb_unconvert		--	gen_context(system_u:object_r:updpwd_exec_t,s0)
 /usr/bin/unix_chkpwd		--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
 /usr/bin/unix_update		--	gen_context(system_u:object_r:updpwd_exec_t,s0)
 /usr/bin/unix_verify		--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
@@ -17,8 +20,12 @@
 
 /usr/lib/([^/]+/)?utempter/utempter --	gen_context(system_u:object_r:utempter_exec_t,s0)
 
+/usr/libexec/chkpwd/tcb_chkpwd	--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
+
 /usr/sbin/pam_console_apply	--	gen_context(system_u:object_r:pam_console_exec_t,s0)
 /usr/sbin/pam_timestamp_check	--	gen_context(system_u:object_r:pam_exec_t,s0)
+/usr/sbin/tcb_convert		--	gen_context(system_u:object_r:updpwd_exec_t,s0)
+/usr/sbin/tcb_unconvert		--	gen_context(system_u:object_r:updpwd_exec_t,s0)
 /usr/sbin/unix_chkpwd		--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
 /usr/sbin/unix_update		--	gen_context(system_u:object_r:updpwd_exec_t,s0)
 /usr/sbin/unix_verify		--	gen_context(system_u:object_r:chkpwd_exec_t,s0)


### PR DESCRIPTION
tcb is an alternative password shadowing scheme used by some Linux
distributions, like ALT Linux, Mandriva, OWL, and some others.

The /etc/tcb directory tree is used to store a single shadow file
inside of a subdirectory created for every local user.

The tcb_chkpwd binary is meant to provide the same functionality
as the unix_chkpwd binary.

The tcb_convert and tcb_uncovert binaries are used for conversions
from a UNIX shadow file to the tcb password shadowing scheme and
vice-versa.

Signed-off-by: Björn Esser <besser82@fedoraproject.org>