### PR TITLE
Hookup attribute for user applications to run other applications

### DIFF
--- a/policy/modules/admin/shutdown.if
+++ b/policy/modules/admin/shutdown.if
@@ -28,13 +28,23 @@
 #
 template(`shutdown_role',`
 	gen_require(`
+		attribute_role shutdown_roles;
 		type shutdown_t;
 	')
 
-	shutdown_run($3, $4)
+	roleattribute $4 shutdown_roles;
 
-	allow $3 shutdown_t:process { ptrace signal_perms };
-	ps_process_pattern($3, shutdown_t)
+	tunable_policy(`shutdown_allow_user_exec_domains',`
+		shutdown_domtrans($3)
+
+		allow $3 shutdown_t:process { ptrace signal_perms };
+		ps_process_pattern($3, shutdown_t)
+	',`
+		shutdown_domtrans($2)
+
+		allow $2 shutdown_t:process { ptrace signal_perms };
+		ps_process_pattern($2, shutdown_t)
+	')
 
 	optional_policy(`
 		systemd_user_app_status($1, shutdown_t)

--- a/policy/modules/admin/shutdown.if
+++ b/policy/modules/admin/shutdown.if
@@ -4,26 +4,41 @@
 ## <summary>
 ##	Role access for shutdown.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`shutdown_role',`
+template(`shutdown_role',`
 	gen_require(`
 		type shutdown_t;
 	')
 
-	shutdown_run($2, $1)
+	shutdown_run($3, $4)
 
-	allow $2 shutdown_t:process { ptrace signal_perms };
-	ps_process_pattern($2, shutdown_t)
+	allow $3 shutdown_t:process { ptrace signal_perms };
+	ps_process_pattern($3, shutdown_t)
+
+	optional_policy(`
+		systemd_user_app_status($1, shutdown_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/admin/shutdown.te
+++ b/policy/modules/admin/shutdown.te
@@ -1,5 +1,15 @@
 policy_module(shutdown, 1.7.0)
 
+## <desc>
+##	<p>
+##	Determine whether the user application exec
+##	domain attribute should be respected for
+##	shutdown access. If not enabled, only user
+##	domains themselves may use shutdown.
+##	</p>
+## </desc>
+gen_tunable(shutdown_allow_user_exec_domains, false)
+
 ########################################
 #
 # Declarations

--- a/policy/modules/admin/su.if
+++ b/policy/modules/admin/su.if
@@ -124,14 +124,19 @@ template(`su_restricted_domain_template', `
 ##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="user_role">
-##	<summary>
-##	The role associated with the user domain.
-##	</summary>
-## </param>
 ## <param name="user_domain">
 ##	<summary>
-##	The type of the user domain.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
@@ -143,9 +148,9 @@ template(`su_role_template',`
 	type $1_su_t;
 	userdom_user_application_domain($1_su_t, su_exec_t)
 	domain_interactive_fd($1_su_t)
-	role $2 types $1_su_t;
+	role $4 types $1_su_t;
 
-	allow $3 $1_su_t:process signal;
+	allow $2 $1_su_t:process signal;
 
 	allow $1_su_t self:capability { audit_control audit_write chown dac_override fowner net_bind_service setgid setuid sys_nice sys_resource };
 	dontaudit $1_su_t self:capability { net_admin sys_tty_config };
@@ -154,18 +159,18 @@ template(`su_role_template',`
 	allow $1_su_t self:netlink_audit_socket { nlmsg_relay create_netlink_socket_perms };
 	allow $1_su_t self:key { search write };
 
-	allow $1_su_t $3:key search;
+	allow $1_su_t $2:key search;
 
 	# Transition from the user domain to this domain.
-	domtrans_pattern($3, su_exec_t, $1_su_t)
+	domtrans_pattern($2, su_exec_t, $1_su_t)
 
-	ps_process_pattern($3, $1_su_t)
+	ps_process_pattern($2, $1_su_t)
 
 	# By default, revert to the calling domain when a shell is executed.
-	corecmd_shell_domtrans($1_su_t, $3)
-	allow $3 $1_su_t:fd use;
-	allow $3 $1_su_t:fifo_file rw_inherited_fifo_file_perms;
-	allow $3 $1_su_t:process sigchld;
+	corecmd_shell_domtrans($1_su_t, $2)
+	allow $2 $1_su_t:fd use;
+	allow $2 $1_su_t:fifo_file rw_inherited_fifo_file_perms;
+	allow $2 $1_su_t:process sigchld;
 
 	kernel_read_system_state($1_su_t)
 	kernel_read_kernel_sysctls($1_su_t)

--- a/policy/modules/admin/su.if
+++ b/policy/modules/admin/su.if
@@ -150,8 +150,6 @@ template(`su_role_template',`
 	domain_interactive_fd($1_su_t)
 	role $4 types $1_su_t;
 
-	allow $2 $1_su_t:process signal;
-
 	allow $1_su_t self:capability { audit_control audit_write chown dac_override fowner net_bind_service setgid setuid sys_nice sys_resource };
 	dontaudit $1_su_t self:capability { net_admin sys_tty_config };
 	allow $1_su_t self:process { setexec setsched setrlimit };
@@ -159,18 +157,8 @@ template(`su_role_template',`
 	allow $1_su_t self:netlink_audit_socket { nlmsg_relay create_netlink_socket_perms };
 	allow $1_su_t self:key { search write };
 
-	allow $1_su_t $2:key search;
-
-	# Transition from the user domain to this domain.
-	domtrans_pattern($2, su_exec_t, $1_su_t)
-
-	ps_process_pattern($2, $1_su_t)
-
 	# By default, revert to the calling domain when a shell is executed.
 	corecmd_shell_domtrans($1_su_t, $2)
-	allow $2 $1_su_t:fd use;
-	allow $2 $1_su_t:fifo_file rw_inherited_fifo_file_perms;
-	allow $2 $1_su_t:process sigchld;
 
 	kernel_read_system_state($1_su_t)
 	kernel_read_kernel_sysctls($1_su_t)
@@ -227,6 +215,34 @@ template(`su_role_template',`
 
 	optional_policy(`
 		auth_use_pam_systemd($1_su_t)
+	')
+
+	tunable_policy(`su_allow_user_exec_domains',`
+		allow $3 $1_su_t:process signal;
+
+		allow $1_su_t $3:key search;
+
+		# Transition from the user domain to this domain.
+		domtrans_pattern($3, su_exec_t, $1_su_t)
+
+		ps_process_pattern($3, $1_su_t)
+
+		allow $3 $1_su_t:fd use;
+		allow $3 $1_su_t:fifo_file rw_inherited_fifo_file_perms;
+		allow $3 $1_su_t:process sigchld;
+	',`
+		allow $2 $1_su_t:process signal;
+
+		allow $1_su_t $2:key search;
+
+		# Transition from the user domain to this domain.
+		domtrans_pattern($2, su_exec_t, $1_su_t)
+
+		ps_process_pattern($2, $1_su_t)
+
+		allow $2 $1_su_t:fd use;
+		allow $2 $1_su_t:fifo_file rw_inherited_fifo_file_perms;
+		allow $2 $1_su_t:process sigchld;
 	')
 
 	tunable_policy(`allow_polyinstantiation',`

--- a/policy/modules/admin/su.te
+++ b/policy/modules/admin/su.te
@@ -1,5 +1,15 @@
 policy_module(su, 1.16.0)
 
+## <desc>
+##	<p>
+##	Determine whether the user application
+##	exec domain attribute should be respected
+##	for su access. If not enabled, only user
+##	domains themselves may use su.
+##	</p>
+## </desc>
+gen_tunable(su_allow_user_exec_domains, false)
+
 ########################################
 #
 # Declarations

--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -17,14 +17,19 @@
 ##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="user_role">
-##	<summary>
-##	The user role.
-##	</summary>
-## </param>
 ## <param name="user_domain">
 ##	<summary>
-##	The user domain associated with the role.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
@@ -44,7 +49,7 @@ template(`sudo_role_template',`
 	userdom_user_application_domain($1_sudo_t, sudo_exec_t)
 	domain_interactive_fd($1_sudo_t)
 	domain_role_change_exemption($1_sudo_t)
-	role $2 types $1_sudo_t;
+	role $4 types $1_sudo_t;
 
 	##############################
 	#
@@ -77,8 +82,8 @@ template(`sudo_role_template',`
 	domtrans_pattern($3, sudo_exec_t, $1_sudo_t)
 
 	# By default, revert to the calling domain when a shell is executed.
-	corecmd_shell_domtrans($1_sudo_t, $3)
-	corecmd_bin_domtrans($1_sudo_t, $3)
+	corecmd_shell_domtrans($1_sudo_t, $2)
+	corecmd_bin_domtrans($1_sudo_t, $2)
 	allow $3 $1_sudo_t:fd use;
 	allow $3 $1_sudo_t:fifo_file rw_fifo_file_perms;
 	allow $3 $1_sudo_t:process signal_perms;
@@ -118,7 +123,7 @@ template(`sudo_role_template',`
 	term_relabel_all_ttys($1_sudo_t)
 	term_relabel_all_ptys($1_sudo_t)
 
-	auth_run_chk_passwd($1_sudo_t, $2)
+	auth_run_chk_passwd($1_sudo_t, $4)
 	# sudo stores a token in the pam runtime directory
 	auth_manage_pam_runtime_dirs($1_sudo_t)
 	auth_manage_pam_runtime_files($1_sudo_t)

--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -73,20 +73,9 @@ template(`sudo_role_template',`
 	allow $1_sudo_t self:key manage_key_perms;
 	dontaudit $1_sudo_t self:capability { dac_read_search sys_ptrace };
 
-	allow $1_sudo_t $3:key search;
-
-	# Transmit SIGWINCH to children
-	allow $1_sudo_t $3:process signal;
-
-	# Enter this derived domain from the user domain
-	domtrans_pattern($3, sudo_exec_t, $1_sudo_t)
-
 	# By default, revert to the calling domain when a shell is executed.
 	corecmd_shell_domtrans($1_sudo_t, $2)
 	corecmd_bin_domtrans($1_sudo_t, $2)
-	allow $3 $1_sudo_t:fd use;
-	allow $3 $1_sudo_t:fifo_file rw_fifo_file_perms;
-	allow $3 $1_sudo_t:process signal_perms;
 
 	kernel_read_kernel_sysctls($1_sudo_t)
 	kernel_read_system_state($1_sudo_t)
@@ -156,6 +145,32 @@ template(`sudo_role_template',`
 
 	ifdef(`hide_broken_symptoms', `
 		dontaudit $1_sudo_t $3:socket_class_set { read write };
+	')
+
+	tunable_policy(`sudo_allow_user_exec_domains',`
+		allow $1_sudo_t $3:key search;
+
+		# Transmit SIGWINCH to children
+		allow $1_sudo_t $3:process signal;
+
+		# Enter this derived domain from the user domain
+		domtrans_pattern($3, sudo_exec_t, $1_sudo_t)
+
+		allow $3 $1_sudo_t:fd use;
+		allow $3 $1_sudo_t:fifo_file rw_fifo_file_perms;
+		allow $3 $1_sudo_t:process signal_perms;
+	',`
+		allow $1_sudo_t $2:key search;
+
+		# Transmit SIGWINCH to children
+		allow $1_sudo_t $2:process signal;
+
+		# Enter this derived domain from the user domain
+		domtrans_pattern($2, sudo_exec_t, $1_sudo_t)
+
+		allow $2 $1_sudo_t:fd use;
+		allow $2 $1_sudo_t:fifo_file rw_fifo_file_perms;
+		allow $2 $1_sudo_t:process signal_perms;
 	')
 
 	tunable_policy(`use_nfs_home_dirs',`

--- a/policy/modules/admin/sudo.te
+++ b/policy/modules/admin/sudo.te
@@ -11,6 +11,16 @@ policy_module(sudo, 1.17.0)
 ## </desc>
 gen_tunable(sudo_all_tcp_connect_http_port, false)
 
+## <desc>
+##	<p>
+##	Determine whether the user application exec
+##	domain attribute should be respected for sudo
+##	access. If not enabled, only user domains
+##	themselves may use sudo.
+##	</p>
+## </desc>
+gen_tunable(sudo_allow_user_exec_domains, false)
+
 ########################################
 #
 # Declarations

--- a/policy/modules/apps/cdrecord.if
+++ b/policy/modules/apps/cdrecord.if
@@ -4,31 +4,46 @@
 ## <summary>
 ##	Role access for cdrecord.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`cdrecord_role',`
+template(`cdrecord_role',`
 	gen_require(`
 		attribute_role cdrecord_roles;
 		type cdrecord_t, cdrecord_exec_t;
 	')
 
-	roleattribute $1 cdrecord_roles;
+	roleattribute $4 cdrecord_roles;
 
-	domtrans_pattern($2, cdrecord_exec_t, cdrecord_t)
+	domtrans_pattern($3, cdrecord_exec_t, cdrecord_t)
 
-	allow cdrecord_t $2:unix_stream_socket rw_socket_perms;
+	allow cdrecord_t $3:unix_stream_socket rw_socket_perms;
 
-	allow $2 cdrecord_t:process { ptrace signal_perms };
-	ps_process_pattern($2, cdrecord_t)
+	allow $3 cdrecord_t:process { ptrace signal_perms };
+	ps_process_pattern($3, cdrecord_t)
+
+	optional_policy(`
+		systemd_user_app_status($1, cdrecord_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/apps/chromium.if
+++ b/policy/modules/apps/chromium.if
@@ -4,18 +4,29 @@
 ## <summary>
 ## 	Role access for chromium
 ## </summary>
+## <param name="role_prefix">
+##	<summary>
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
 ## <param name="role">
 ##	<summary>
 ##	Role allowed access
 ##	</summary>
 ## </param>
-## <param name="domain">
-##	<summary>
-##	User domain for the role
-##	</summary>
-## </param>
 #
-interface(`chromium_role',`
+template(`chromium_role',`
 	gen_require(`
 		type chromium_t;
 		type chromium_renderer_t;
@@ -24,34 +35,38 @@ interface(`chromium_role',`
 		class dbus send_msg;
 	')
 
-	role $1 types chromium_t;
-	role $1 types chromium_renderer_t;
-	role $1 types chromium_sandbox_t;
-	role $1 types chromium_naclhelper_t;
+	role $4 types chromium_t;
+	role $4 types chromium_renderer_t;
+	role $4 types chromium_sandbox_t;
+	role $4 types chromium_naclhelper_t;
 
 	# Transition from the user domain to the derived domain
-	chromium_domtrans($2)
+	chromium_domtrans($3)
 
 	# Allow ps to show chromium processes and allow the user to signal it
-	ps_process_pattern($2, chromium_t)
-	ps_process_pattern($2, chromium_renderer_t)
+	ps_process_pattern($3, chromium_t)
+	ps_process_pattern($3, chromium_renderer_t)
 
-	allow $2 chromium_t:process signal_perms;
-	allow $2 chromium_renderer_t:process signal_perms;
-	allow $2 chromium_sandbox_t:process signal_perms;
-	allow $2 chromium_naclhelper_t:process signal_perms;
-	allow chromium_t $2:process { signull signal };
+	allow $3 chromium_t:process signal_perms;
+	allow $3 chromium_renderer_t:process signal_perms;
+	allow $3 chromium_sandbox_t:process signal_perms;
+	allow $3 chromium_naclhelper_t:process signal_perms;
+	allow chromium_t $3:process { signull signal };
 
-	allow $2 chromium_t:unix_stream_socket connectto;
+	allow $3 chromium_t:unix_stream_socket connectto;
 
 	# for /tmp/.ICE-unix/* sockets
-	allow chromium_t $2:unix_stream_socket connectto;
+	allow chromium_t $3:unix_stream_socket connectto;
 
-	allow chromium_sandbox_t $2:fd use;
-	allow chromium_naclhelper_t $2:fd use;
+	allow chromium_sandbox_t $3:fd use;
+	allow chromium_naclhelper_t $3:fd use;
 
-	allow $2 chromium_t:dbus send_msg;
-	allow chromium_t $2:dbus send_msg;
+	allow $3 chromium_t:dbus send_msg;
+	allow chromium_t $3:dbus send_msg;
+
+	optional_policy(`
+		systemd_user_app_status($1, chromium_t)
+	')
 ')
 
 #######################################

--- a/policy/modules/apps/cryfs.if
+++ b/policy/modules/apps/cryfs.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for CryFS.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`cryfs_role',`
+template(`cryfs_role',`
 	gen_require(`
 		attribute_role cryfs_roles;
 		type cryfs_t, cryfs_exec_t;
@@ -26,15 +37,19 @@ interface(`cryfs_role',`
 	# Declarations
 	#
 
-	roleattribute $1 cryfs_roles;
+	roleattribute $4 cryfs_roles;
 
 	########################################
 	#
 	# Policy
 	#
 
-	domtrans_pattern($2, cryfs_exec_t, cryfs_t)
+	domtrans_pattern($3, cryfs_exec_t, cryfs_t)
 
-	allow $2 cryfs_t:process signal_perms;
-	ps_process_pattern($2, cryfs_t)
+	allow $3 cryfs_t:process signal_perms;
+	ps_process_pattern($3, cryfs_t)
+
+	optional_policy(`
+		systemd_user_app_status($1, cryfs_t)
+	')
 ')

--- a/policy/modules/apps/evolution.if
+++ b/policy/modules/apps/evolution.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for evolution.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`evolution_role',`
+template(`evolution_role',`
 	gen_require(`
 		attribute_role evolution_roles;
 		type evolution_t, evolution_exec_t, evolution_home_t;
@@ -27,21 +38,21 @@ interface(`evolution_role',`
 		type evolution_tmpfs_t, evolution_webcal_tmpfs_t;
 	')
 
-	roleattribute $1 evolution_roles;
+	roleattribute $4 evolution_roles;
 
-	domtrans_pattern($2, evolution_exec_t, evolution_t)
-	domtrans_pattern($2, evolution_alarm_exec_t, evolution_alarm_t)
-	domtrans_pattern($2, evolution_exchange_exec_t, evolution_exchange_t)
-	domtrans_pattern($2, evolution_server_exec_t, evolution_server_t)
-	domtrans_pattern($2, evolution_webcal_exec_t, evolution_webcal_t)
+	domtrans_pattern($3, evolution_exec_t, evolution_t)
+	domtrans_pattern($3, evolution_alarm_exec_t, evolution_alarm_t)
+	domtrans_pattern($3, evolution_exchange_exec_t, evolution_exchange_t)
+	domtrans_pattern($3, evolution_server_exec_t, evolution_server_t)
+	domtrans_pattern($3, evolution_webcal_exec_t, evolution_webcal_t)
 
-	allow $2 { evolution_t evolution_alarm_t evolution_exchange_t evolution_server_t evolution_webcal_t }:process { noatsecure ptrace signal_perms };
-	ps_process_pattern($2, { evolution_t evolution_alarm_t evolution_exchange_t })
-	ps_process_pattern($2, { evolution_server_t evolution_webcal_t })
+	allow $3 { evolution_t evolution_alarm_t evolution_exchange_t evolution_server_t evolution_webcal_t }:process { noatsecure ptrace signal_perms };
+	ps_process_pattern($3, { evolution_t evolution_alarm_t evolution_exchange_t })
+	ps_process_pattern($3, { evolution_server_t evolution_webcal_t })
 
-	allow evolution_t $2:dir search_dir_perms;
-	allow evolution_t $2:file read_file_perms;
-	allow evolution_t $2:lnk_file read_lnk_file_perms;
+	allow evolution_t $3:dir search_dir_perms;
+	allow evolution_t $3:file read_file_perms;
+	allow evolution_t $3:lnk_file read_lnk_file_perms;
 
 	allow $2 evolution_home_t:dir { relabel_dir_perms manage_dir_perms };
 	allow $2 evolution_home_t:file { relabel_file_perms manage_file_perms };
@@ -59,14 +70,22 @@ interface(`evolution_role',`
 	allow $2 { evolution_alarm_tmpfs_t evolution_exchange_tmpfs_t evolution_tmpfs_t evolution_webcal_tmpfs_t }:sock_file { manage_sock_file_perms relabel_sock_file_perms };
 	allow $2 { evolution_alarm_tmpfs_t evolution_exchange_tmpfs_t evolution_tmpfs_t evolution_webcal_tmpfs_t }:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
 
-	allow { evolution_t evolution_exchange_t } $2:unix_stream_socket connectto;
+	allow { evolution_t evolution_exchange_t } $3:unix_stream_socket connectto;
 
-	stream_connect_pattern($2, evolution_orbit_tmp_t, evolution_orbit_tmp_t, evolution_t)
-	stream_connect_pattern($2, evolution_exchange_orbit_tmp_t, evolution_exchange_orbit_tmp_t, evolution_exchange_t)
+	stream_connect_pattern($3, evolution_orbit_tmp_t, evolution_orbit_tmp_t, evolution_t)
+	stream_connect_pattern($3, evolution_exchange_orbit_tmp_t, evolution_exchange_orbit_tmp_t, evolution_exchange_t)
 
 	optional_policy(`
-		evolution_dbus_chat($2)
-		evolution_alarm_dbus_chat($2)
+		evolution_dbus_chat($3)
+		evolution_alarm_dbus_chat($3)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, evolution_t)
+		systemd_user_app_status($1, evolution_alarm_t)
+		systemd_user_app_status($1, evolution_exchange_t)
+		systemd_user_app_status($1, evolution_server_t)
+		systemd_user_app_status($1, evolution_webcal_t)
 	')
 ')
 

--- a/policy/modules/apps/games.if
+++ b/policy/modules/apps/games.if
@@ -4,39 +4,54 @@
 ## <summary>
 ##	Role access for games.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`games_role',`
+template(`games_role',`
 	gen_require(`
 		attribute_role games_roles;
 		type games_t, games_exec_t, games_tmp_t;
 		type games_tmpfs_t;
 	')
 
-	roleattribute $1 games_roles;
+	roleattribute $4 games_roles;
 
-	domtrans_pattern($2, games_exec_t, games_t)
+	domtrans_pattern($3, games_exec_t, games_t)
 
 	allow $2 games_tmp_t:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { games_tmp_t games_tmpfs_t }:file { manage_file_perms relabel_file_perms };
 	allow $2 games_tmpfs_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
 	allow $2 games_tmpfs_t:sock_file { manage_sock_file_perms relabel_sock_file_perms };
 
-	allow $2 games_t:process { ptrace signal_perms };
-	ps_process_pattern($2, games_t)
+	allow $3 games_t:process { ptrace signal_perms };
+	ps_process_pattern($3, games_t)
 
-	stream_connect_pattern($2, games_tmpfs_t, games_tmpfs_t, games_t)
+	stream_connect_pattern($3, games_tmpfs_t, games_tmpfs_t, games_t)
 
-	allow games_t $2:unix_stream_socket connectto;
+	allow games_t $3:unix_stream_socket connectto;
+
+	optional_policy(`
+		systemd_user_app_status($1, games_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/apps/gnome.if
+++ b/policy/modules/apps/gnome.if
@@ -6,18 +6,23 @@
 ## </summary>
 ## <param name="role_prefix">
 ##	<summary>
-##	The prefix of the user domain (e.g., user
-##	is the prefix for user_t).
-##	</summary>
-## </param>
-## <param name="user_role">
-##	<summary>
-##	The role associated with the user domain.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
 ## <param name="user_domain">
 ##	<summary>
-##	The type of the user domain.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
@@ -35,7 +40,7 @@ template(`gnome_role_template',`
 	# Gconf declarations
 	#
 
-	roleattribute $2 gconfd_roles;
+	roleattribute $4 gconfd_roles;
 
 	########################################
 	#
@@ -46,7 +51,7 @@ template(`gnome_role_template',`
 	userdom_user_application_domain($1_gkeyringd_t, gkeyringd_exec_t)
 	domain_user_exemption_target($1_gkeyringd_t)
 
-	role $2 types $1_gkeyringd_t;
+	role $4 types $1_gkeyringd_t;
 
 	########################################
 	#
@@ -55,13 +60,17 @@ template(`gnome_role_template',`
 
 	domtrans_pattern($3, gconfd_exec_t, gconfd_t)
 
-	allow $3 { gconf_home_t gconf_tmp_t }:dir { manage_dir_perms relabel_dir_perms };
-	allow $3 { gconf_home_t gconf_tmp_t }:file { manage_file_perms relabel_file_perms };
-	userdom_user_home_dir_filetrans($3, gconf_home_t, dir, ".gconf")
-	userdom_user_home_dir_filetrans($3, gconf_home_t, dir, ".gconfd")
+	allow $2 { gconf_home_t gconf_tmp_t }:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 { gconf_home_t gconf_tmp_t }:file { manage_file_perms relabel_file_perms };
+	userdom_user_home_dir_filetrans($2, gconf_home_t, dir, ".gconf")
+	userdom_user_home_dir_filetrans($2, gconf_home_t, dir, ".gconfd")
 
 	allow $3 gconfd_t:process { ptrace signal_perms };
 	ps_process_pattern($3, gconfd_t)
+
+	optional_policy(`
+		systemd_user_app_status($1, gconfd_t)
+	')
 
 	########################################
 	#
@@ -70,22 +79,22 @@ template(`gnome_role_template',`
 
 	domtrans_pattern($3, gkeyringd_exec_t, $1_gkeyringd_t)
 
-	allow $3 { gnome_home_t gnome_keyring_home_t gnome_keyring_tmp_t }:dir { relabel_dir_perms manage_dir_perms };
-	allow $3 { gnome_home_t gnome_keyring_home_t }:file { relabel_file_perms manage_file_perms };
+	allow $2 { gnome_home_t gnome_keyring_home_t gnome_keyring_tmp_t }:dir { relabel_dir_perms manage_dir_perms };
+	allow $2 { gnome_home_t gnome_keyring_home_t }:file { relabel_file_perms manage_file_perms };
 
-	userdom_user_home_dir_filetrans($3, gnome_home_t, dir, ".gnome")
-	userdom_user_home_dir_filetrans($3, gnome_home_t, dir, ".gnome2")
-	userdom_user_home_dir_filetrans($3, gnome_home_t, dir, ".gnome2_private")
+	userdom_user_home_dir_filetrans($2, gnome_home_t, dir, ".gnome")
+	userdom_user_home_dir_filetrans($2, gnome_home_t, dir, ".gnome2")
+	userdom_user_home_dir_filetrans($2, gnome_home_t, dir, ".gnome2_private")
 
-	gnome_home_filetrans($3, gnome_keyring_home_t, dir, "keyrings")
+	gnome_home_filetrans($2, gnome_keyring_home_t, dir, "keyrings")
 
-	allow $3 gnome_keyring_tmp_t:sock_file { relabel_sock_file_perms manage_sock_file_perms };
+	allow $2 gnome_keyring_tmp_t:sock_file { relabel_sock_file_perms manage_sock_file_perms };
 
 	ps_process_pattern($3, $1_gkeyringd_t)
 	allow $3 $1_gkeyringd_t:process { ptrace signal_perms };
 
-	corecmd_bin_domtrans($1_gkeyringd_t, $3)
-	corecmd_shell_domtrans($1_gkeyringd_t, $3)
+	corecmd_bin_domtrans($1_gkeyringd_t, $2)
+	corecmd_shell_domtrans($1_gkeyringd_t, $2)
 
 	gnome_stream_connect_gkeyringd($1, $3)
 
@@ -105,6 +114,10 @@ template(`gnome_role_template',`
 		optional_policy(`
 			wm_dbus_chat($1, $1_gkeyringd_t)
 		')
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, $1_gkeyringd_t)
 	')
 ')
 

--- a/policy/modules/apps/gpg.if
+++ b/policy/modules/apps/gpg.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for gpg.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`gpg_role',`
+template(`gpg_role',`
 	gen_require(`
 		attribute_role gpg_roles, gpg_agent_roles, gpg_helper_roles, gpg_pinentry_roles;
 		type gpg_t, gpg_exec_t, gpg_agent_t;
@@ -23,21 +34,21 @@ interface(`gpg_role',`
 		type gpg_pinentry_t, gpg_pinentry_tmp_t, gpg_secret_t;
 	')
 
-	roleattribute $1 gpg_roles;
-	roleattribute $1 gpg_agent_roles;
-	roleattribute $1 gpg_helper_roles;
-	roleattribute $1 gpg_pinentry_roles;
+	roleattribute $4 gpg_roles;
+	roleattribute $4 gpg_agent_roles;
+	roleattribute $4 gpg_helper_roles;
+	roleattribute $4 gpg_pinentry_roles;
 
-	domtrans_pattern($2, gpg_exec_t, gpg_t)
-	domtrans_pattern($2, gpg_agent_exec_t, gpg_agent_t)
+	domtrans_pattern($3, gpg_exec_t, gpg_t)
+	domtrans_pattern($3, gpg_agent_exec_t, gpg_agent_t)
 
-	allow $2 self:process setrlimit;
-	allow $2 { gpg_t gpg_agent_t gpg_helper_t gpg_pinentry_t }:process { ptrace signal_perms };
-	ps_process_pattern($2, { gpg_t gpg_agent_t gpg_helper_t gpg_pinentry_t })
+	allow $3 self:process setrlimit;
+	allow $3 { gpg_t gpg_agent_t gpg_helper_t gpg_pinentry_t }:process { ptrace signal_perms };
+	ps_process_pattern($3, { gpg_t gpg_agent_t gpg_helper_t gpg_pinentry_t })
 
-	allow gpg_pinentry_t $2:process signull;
-	allow gpg_helper_t $2:fd use;
-	allow { gpg_t gpg_agent_t gpg_helper_t gpg_pinentry_t } $2:fifo_file rw_inherited_fifo_file_perms;
+	allow gpg_pinentry_t $3:process signull;
+	allow gpg_helper_t $3:fd use;
+	allow { gpg_t gpg_agent_t gpg_helper_t gpg_pinentry_t } $3:fifo_file rw_inherited_fifo_file_perms;
 
 	allow $2 { gpg_agent_tmp_t gpg_secret_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { gpg_agent_tmp_t gpg_secret_t }:file { manage_file_perms relabel_file_perms };
@@ -47,7 +58,12 @@ interface(`gpg_role',`
 	userdom_user_home_dir_filetrans($2, gpg_secret_t, dir, ".gnupg")
 
 	optional_policy(`
-		gpg_pinentry_dbus_chat($2)
+		gpg_pinentry_dbus_chat($3)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, gpg_t)
+		systemd_user_app_status($1, gpg_agent_t)
 	')
 ')
 

--- a/policy/modules/apps/irc.if
+++ b/policy/modules/apps/irc.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for IRC.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`irc_role',`
+template(`irc_role',`
 	gen_require(`
 		attribute_role irc_roles;
 		type irc_t, irc_exec_t, irc_home_t;
@@ -27,17 +38,17 @@ interface(`irc_role',`
 	# Declarations
 	#
 
-	roleattribute $1 irc_roles;
+	roleattribute $4 irc_roles;
 
 	########################################
 	#
 	# Policy
 	#
 
-	domtrans_pattern($2, irc_exec_t, irc_t)
+	domtrans_pattern($3, irc_exec_t, irc_t)
 
-	ps_process_pattern($2, irc_t)
-	allow $2 irc_t:process { ptrace signal_perms };
+	ps_process_pattern($3, irc_t)
+	allow $3 irc_t:process { ptrace signal_perms };
 
 	allow $2 { irc_home_t irc_log_home_t irc_tmp_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { irc_home_t irc_log_home_t irc_tmp_t }:file { manage_file_perms relabel_file_perms };
@@ -45,4 +56,8 @@ interface(`irc_role',`
 	userdom_user_home_dir_filetrans($2, irc_home_t, dir, ".irssi")
 	userdom_user_home_dir_filetrans($2, irc_home_t, file, ".ircmotd")
 	userdom_user_home_dir_filetrans($2, irc_log_home_t, dir, "irclogs")
+
+	optional_policy(`
+		systemd_user_app_status($1, irc_t)
+	')
 ')

--- a/policy/modules/apps/java.if
+++ b/policy/modules/apps/java.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for java.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`java_role',`
+template(`java_role',`
 	gen_require(`
 		attribute_role java_roles;
 		type java_t, java_exec_t, java_tmp_t;
@@ -27,17 +38,17 @@ interface(`java_role',`
 	# Declarations
 	#
 
-	roleattribute $1 java_roles;
+	roleattribute $4 java_roles;
 
 	########################################
 	#
 	# Policy
 	#
 
-	domtrans_pattern($2, java_exec_t, java_t)
+	domtrans_pattern($3, java_exec_t, java_t)
 
-	allow $2 java_t:process { noatsecure siginh rlimitinh ptrace signal_perms };
-	ps_process_pattern($2, java_t)
+	allow $3 java_t:process { noatsecure siginh rlimitinh ptrace signal_perms };
+	ps_process_pattern($3, java_t)
 
 	allow $2 java_tmp_t:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { java_tmp_t java_tmpfs_t }:file { manage_file_perms relabel_file_perms };
@@ -45,10 +56,14 @@ interface(`java_role',`
 	allow $2 java_tmpfs_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
 	allow $2 java_tmpfs_t:sock_file { manage_sock_file_perms relabel_sock_file_perms };
 
-	allow java_t $2:process signull;
-	allow java_t $2:unix_stream_socket connectto;
-	allow java_t $2:unix_stream_socket { read write };
-	allow java_t $2:tcp_socket { read write };
+	allow java_t $3:process signull;
+	allow java_t $3:unix_stream_socket connectto;
+	allow java_t $3:unix_stream_socket { read write };
+	allow java_t $3:tcp_socket { read write };
+
+	optional_policy(`
+		systemd_user_app_status($1, java_t)
+	')
 ')
 
 #######################################
@@ -63,18 +78,23 @@ interface(`java_role',`
 ## </desc>
 ## <param name="role_prefix">
 ##	<summary>
-##	The prefix of the user domain (e.g., user
-##	is the prefix for user_t).
-##	</summary>
-## </param>
-## <param name="user_role">
-##	<summary>
-##	The role associated with the user domain.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
 ## <param name="user_domain">
 ##	<summary>
-##	The type of the user domain.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
@@ -122,7 +142,7 @@ template(`java_role_template',`
 	auth_use_nsswitch($1_java_t)
 
 	optional_policy(`
-		xserver_role($2, $1_java_t)
+		xserver_role($1, $1_java_t, $3, $4)
 	')
 ')
 

--- a/policy/modules/apps/libmtp.if
+++ b/policy/modules/apps/libmtp.if
@@ -4,27 +4,42 @@
 ## <summary>
 ##	Role access for libmtp.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`libmtp_role',`
+template(`libmtp_role',`
 	gen_require(`
 		attribute_role libmtp_roles;
 		type libmtp_t, libmtp_exec_t;
 	')
 
-	roleattribute $1 libmtp_roles;
+	roleattribute $4 libmtp_roles;
 
-	domtrans_pattern($2, libmtp_exec_t, libmtp_t)
+	domtrans_pattern($3, libmtp_exec_t, libmtp_t)
 
-	allow $2 libmtp_t:process { ptrace signal_perms };
-	ps_process_pattern($2, libmtp_t)
+	allow $3 libmtp_t:process { ptrace signal_perms };
+	ps_process_pattern($3, libmtp_t)
+
+	optional_policy(`
+		systemd_user_app_status($1, libmtp_t)
+	')
 ')

--- a/policy/modules/apps/mono.if
+++ b/policy/modules/apps/mono.if
@@ -12,18 +12,23 @@
 ## </desc>
 ## <param name="role_prefix">
 ##	<summary>
-##	The prefix of the user domain (e.g., user
-##	is the prefix for user_t).
-##	</summary>
-## </param>
-## <param name="user_role">
-##	<summary>
-##	The role associated with the user domain.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
 ## <param name="user_domain">
 ##	<summary>
-##	The type of the user domain.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
@@ -54,16 +59,16 @@ template(`mono_role_template',`
 	domtrans_pattern($3, mono_exec_t, $1_mono_t)
 
 	allow $3 $1_mono_t:process { ptrace noatsecure signal_perms };
-	ps_process_pattern($2, $1_mono_t)
+	ps_process_pattern($3, $1_mono_t)
 
-	corecmd_bin_domtrans($1_mono_t, $3)
+	corecmd_bin_domtrans($1_mono_t, $2)
 
 	userdom_manage_user_tmpfs_files($1_mono_t)
 
 	optional_policy(`
 		fs_dontaudit_rw_tmpfs_files($1_mono_t)
 
-		xserver_role($1, $1_mono_t, $1_application_exec_domain, $1_r)
+		xserver_role($1, $1_mono_t, $3, $4)
 	')
 ')
 

--- a/policy/modules/apps/mono.if
+++ b/policy/modules/apps/mono.if
@@ -63,7 +63,7 @@ template(`mono_role_template',`
 	optional_policy(`
 		fs_dontaudit_rw_tmpfs_files($1_mono_t)
 
-		xserver_role($1_r, $1_mono_t)
+		xserver_role($1, $1_mono_t, $1_application_exec_domain, $1_r)
 	')
 ')
 

--- a/policy/modules/apps/mozilla.if
+++ b/policy/modules/apps/mozilla.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for mozilla.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`mozilla_role',`
+template(`mozilla_role',`
 	gen_require(`
 		type mozilla_t, mozilla_exec_t, mozilla_home_t;
 		type mozilla_tmp_t, mozilla_tmpfs_t, mozilla_plugin_tmp_t;
@@ -28,25 +39,25 @@ interface(`mozilla_role',`
 	# Declarations
 	#
 
-	roleattribute $1 mozilla_roles;
+	roleattribute $4 mozilla_roles;
 
 	########################################
 	#
 	# Policy
 	#
 
-	domtrans_pattern($2, mozilla_exec_t, mozilla_t)
+	domtrans_pattern($3, mozilla_exec_t, mozilla_t)
 
-	allow $2 mozilla_t:process { noatsecure siginh rlimitinh ptrace signal_perms };
-	ps_process_pattern($2, mozilla_t)
+	allow $3 mozilla_t:process { noatsecure siginh rlimitinh ptrace signal_perms };
+	ps_process_pattern($3, mozilla_t)
 
-	allow mozilla_t $2:process signull;
-	allow mozilla_t $2:unix_stream_socket connectto;
+	allow mozilla_t $3:process signull;
+	allow mozilla_t $3:unix_stream_socket connectto;
 
-	allow $2 mozilla_t:fd use;
-	allow $2 mozilla_t:shm rw_shm_perms;
+	allow $3 mozilla_t:fd use;
+	allow $3 mozilla_t:shm rw_shm_perms;
 
-	stream_connect_pattern($2, mozilla_tmpfs_t, mozilla_tmpfs_t, mozilla_t)
+	stream_connect_pattern($3, mozilla_tmpfs_t, mozilla_tmpfs_t, mozilla_t)
 
 	allow $2 { mozilla_home_t mozilla_plugin_home_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { mozilla_home_t mozilla_plugin_home_t }:file { manage_file_perms relabel_file_perms };
@@ -68,7 +79,11 @@ interface(`mozilla_role',`
 	allow $2 { mozilla_tmpfs_t mozilla_plugin_tmpfs_t }:sock_file { manage_sock_file_perms relabel_sock_file_perms };
 
 	optional_policy(`
-		mozilla_dbus_chat($2)
+		mozilla_dbus_chat($3)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, mozilla_t)
 	')
 ')
 

--- a/policy/modules/apps/mplayer.if
+++ b/policy/modules/apps/mplayer.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for mplayer
 ## </summary>
+## <param name="role_prefix">
+##	<summary>
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
 ## <param name="role">
 ##	<summary>
 ##	Role allowed access
 ##	</summary>
 ## </param>
-## <param name="domain">
-##	<summary>
-##	User domain for the role
-##	</summary>
-## </param>
 #
-interface(`mplayer_role',`
+template(`mplayer_role',`
 	gen_require(`
 		attribute_role mencoder_roles, mplayer_roles;
 		type mencoder_t, mencoder_exec_t, mplayer_home_t;
@@ -27,19 +38,19 @@ interface(`mplayer_role',`
 	# Declarations
 	#
 
-	roleattribute $1 mencoder_roles;
-	roleattribute $1 mplayer_roles;
+	roleattribute $4 mencoder_roles;
+	roleattribute $4 mplayer_roles;
 
 	########################################
 	#
 	# Policy
 	#
 
-	domtrans_pattern($2, mencoder_exec_t, mencoder_t)
-	domtrans_pattern($2, mplayer_exec_t, mplayer_t)
+	domtrans_pattern($3, mencoder_exec_t, mencoder_t)
+	domtrans_pattern($3, mplayer_exec_t, mplayer_t)
 
-	allow $2 { mplayer_t mencoder_t }:process { getsched ptrace signal_perms };
-	ps_process_pattern($2, { mplayer_t mencoder_t })
+	allow $3 { mplayer_t mencoder_t }:process { getsched ptrace signal_perms };
+	ps_process_pattern($3, { mplayer_t mencoder_t })
 
 	allow $2 mplayer_home_t:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 mplayer_home_t:file { manage_file_perms relabel_file_perms };
@@ -50,6 +61,11 @@ interface(`mplayer_role',`
 	allow $2 mplayer_tmpfs_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
 	allow $2 mplayer_tmpfs_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
 	allow $2 mplayer_tmpfs_t:sock_file { manage_sock_file_perms relabel_sock_file_perms };
+
+	optional_policy(`
+		systemd_user_app_status($1, mencoder_t)
+		systemd_user_app_status($1, mplayer_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/apps/openoffice.if
+++ b/policy/modules/apps/openoffice.if
@@ -4,34 +4,49 @@
 ## <summary>
 ##	Role access for openoffice.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`ooffice_role',`
+template(`ooffice_role',`
 	gen_require(`
 		attribute_role ooffice_roles;
 		type ooffice_t, ooffice_exec_t;
-        ')
+	')
 
-	roleattribute $1 ooffice_roles;
+	roleattribute $4 ooffice_roles;
 
-	allow ooffice_t $2:unix_stream_socket connectto;
+	allow ooffice_t $3:unix_stream_socket connectto;
 
-	domtrans_pattern($2, ooffice_exec_t, ooffice_t)
+	domtrans_pattern($3, ooffice_exec_t, ooffice_t)
 
-	allow $2 ooffice_t:process { ptrace signal_perms };
-	ps_process_pattern($2, ooffice_t)
+	allow $3 ooffice_t:process { ptrace signal_perms };
+	ps_process_pattern($3, ooffice_t)
 
 	optional_policy(`
-		ooffice_dbus_chat($2)
+		ooffice_dbus_chat($3)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, ooffice_t)
 	')
 ')
 

--- a/policy/modules/apps/pulseaudio.if
+++ b/policy/modules/apps/pulseaudio.if
@@ -61,6 +61,25 @@ template(`pulseaudio_role',`
 
 ########################################
 ## <summary>
+##	Connect to pulseaudio and manage
+##	pulseaudio config data.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pulseaudio_client_domain',`
+	gen_require(`
+		attribute pulseaudio_client;
+	')
+
+	typeattribute $1 pulseaudio_client;
+')
+
+########################################
+## <summary>
 ##	Execute a domain transition to run pulseaudio.
 ## </summary>
 ## <param name="domain">
@@ -71,11 +90,8 @@ template(`pulseaudio_role',`
 #
 interface(`pulseaudio_domtrans',`
 	gen_require(`
-		attribute pulseaudio_client;
 		type pulseaudio_t, pulseaudio_exec_t;
 	')
-
-	typeattribute $1 pulseaudio_client;
 
 	corecmd_search_bin($1)
 	domtrans_pattern($1, pulseaudio_exec_t, pulseaudio_t)
@@ -100,12 +116,10 @@ interface(`pulseaudio_domtrans',`
 #
 interface(`pulseaudio_run',`
 	gen_require(`
-		attribute pulseaudio_client;
 		attribute_role pulseaudio_roles;
 	')
 
-	typeattribute $1 pulseaudio_client;
-
+	pulseaudio_client_domain($1)
 	pulseaudio_domtrans($1)
 	roleattribute $2 pulseaudio_roles;
 ')

--- a/policy/modules/apps/pulseaudio.if
+++ b/policy/modules/apps/pulseaudio.if
@@ -4,29 +4,41 @@
 ## <summary>
 ##	Role access for pulseaudio.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`pulseaudio_role',`
+template(`pulseaudio_role',`
 	gen_require(`
 		attribute pulseaudio_tmpfsfile;
 		type pulseaudio_t, pulseaudio_home_t, pulseaudio_tmpfs_t;
 		type pulseaudio_tmp_t;
 	')
 
-	pulseaudio_run($2, $1)
+	pulseaudio_run($2, $4)
+	pulseaudio_domtrans($3)
 
-	allow $2 pulseaudio_t:process { ptrace signal_perms };
-	allow $2 pulseaudio_t:fd use;
-	ps_process_pattern($2, pulseaudio_t)
+	allow $3 pulseaudio_t:process { ptrace signal_perms };
+	allow $3 pulseaudio_t:fd use;
+	ps_process_pattern($3, pulseaudio_t)
 
 	allow $2 pulseaudio_home_t:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 pulseaudio_home_t:file { manage_file_perms relabel_file_perms };
@@ -39,8 +51,12 @@ interface(`pulseaudio_role',`
 	allow $2 pulseaudio_tmp_t:file { manage_file_perms relabel_file_perms };
 	allow $2 pulseaudio_tmp_t:sock_file { manage_sock_file_perms relabel_sock_file_perms };
 
-	allow pulseaudio_t $2:unix_stream_socket connectto;
-	allow pulseaudio_t $2:process signull;
+	allow pulseaudio_t $3:unix_stream_socket connectto;
+	allow pulseaudio_t $3:process signull;
+
+	optional_policy(`
+		systemd_user_app_status($1, pulseaudio_t)
+	')
 ')
 
 ########################################
@@ -84,8 +100,11 @@ interface(`pulseaudio_domtrans',`
 #
 interface(`pulseaudio_run',`
 	gen_require(`
+		attribute pulseaudio_client;
 		attribute_role pulseaudio_roles;
 	')
+
+	typeattribute $1 pulseaudio_client;
 
 	pulseaudio_domtrans($1)
 	roleattribute $2 pulseaudio_roles;

--- a/policy/modules/apps/rssh.if
+++ b/policy/modules/apps/rssh.if
@@ -4,25 +4,36 @@
 ## <summary>
 ##	Role access for rssh.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`rssh_role',`
+template(`rssh_role',`
 	gen_require(`
 		attribute_role rssh_roles;
 		type rssh_t, rssh_exec_t, rssh_ro_t;
 		type rssh_rw_t;
 	')
 
-	roleattribute $1 rssh_roles;
+	roleattribute $4 rssh_roles;
 
 	domtrans_pattern($2, rssh_exec_t, rssh_t)
 

--- a/policy/modules/apps/screen.if
+++ b/policy/modules/apps/screen.if
@@ -10,14 +10,19 @@
 ##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="user_role">
-##	<summary>
-##	The role associated with the user domain.
-##	</summary>
-## </param>
 ## <param name="user_domain">
 ##	<summary>
 ##	The type of the user domain.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="user_role">
+##	<summary>
+##	The role associated with the user domain.
 ##	</summary>
 ## </param>
 #
@@ -39,7 +44,7 @@ template(`screen_role_template',`
 	domain_interactive_fd($1_screen_t)
 	role screen_roles types $1_screen_t;
 
-	roleattribute $2 screen_roles;
+	roleattribute $4 screen_roles;
 
 	########################################
 	#
@@ -56,38 +61,42 @@ template(`screen_role_template',`
 	dontaudit $3 $1_screen_t:unix_stream_socket { read write };
 	allow $1_screen_t $3:process signal;
 
-	allow $3 screen_tmp_t:dir { manage_dir_perms relabel_dir_perms };
-	allow $3 screen_tmp_t:file { manage_file_perms relabel_file_perms };
-	allow $3 screen_tmp_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
+	allow $2 screen_tmp_t:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 screen_tmp_t:file { manage_file_perms relabel_file_perms };
+	allow $2 screen_tmp_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
 
-	allow $3 screen_home_t:dir { manage_dir_perms relabel_dir_perms };
-	allow $3 screen_home_t:file { manage_file_perms relabel_file_perms };
-	allow $3 screen_home_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
-	allow $3 screen_home_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
+	allow $2 screen_home_t:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 screen_home_t:file { manage_file_perms relabel_file_perms };
+	allow $2 screen_home_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
+	allow $2 screen_home_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
 
-	userdom_user_home_dir_filetrans($3, screen_home_t, dir, ".screen")
-	userdom_user_home_dir_filetrans($3, screen_home_t, file, ".screenrc")
-	userdom_user_home_dir_filetrans($3, screen_home_t, file, ".tmux.conf")
+	userdom_user_home_dir_filetrans($2, screen_home_t, dir, ".screen")
+	userdom_user_home_dir_filetrans($2, screen_home_t, file, ".screenrc")
+	userdom_user_home_dir_filetrans($2, screen_home_t, file, ".tmux.conf")
 
-	manage_dirs_pattern($3, screen_runtime_t, screen_runtime_t)
-	manage_files_pattern($3, screen_runtime_t, screen_runtime_t)
-	manage_lnk_files_pattern($3, screen_runtime_t, screen_runtime_t)
-	manage_fifo_files_pattern($3, screen_runtime_t, screen_runtime_t)
+	manage_dirs_pattern($2, screen_runtime_t, screen_runtime_t)
+	manage_files_pattern($2, screen_runtime_t, screen_runtime_t)
+	manage_lnk_files_pattern($2, screen_runtime_t, screen_runtime_t)
+	manage_fifo_files_pattern($2, screen_runtime_t, screen_runtime_t)
 
-	corecmd_bin_domtrans($1_screen_t, $3)
-	corecmd_shell_domtrans($1_screen_t, $3)
+	corecmd_bin_domtrans($1_screen_t, $2)
+	corecmd_shell_domtrans($1_screen_t, $2)
 
 	auth_domtrans_chk_passwd($1_screen_t)
 	auth_use_nsswitch($1_screen_t)
 
-	userdom_user_home_domtrans($1_screen_t, $3)
+	userdom_user_home_domtrans($1_screen_t, $2)
 
 	tunable_policy(`use_samba_home_dirs',`
-		fs_cifs_domtrans($1_screen_t, $3)
+		fs_cifs_domtrans($1_screen_t, $2)
 	')
 
 	tunable_policy(`use_nfs_home_dirs',`
-		fs_nfs_domtrans($1_screen_t, $3)
+		fs_nfs_domtrans($1_screen_t, $2)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, $1_screen_t)
 	')
 ')
 

--- a/policy/modules/apps/syncthing.if
+++ b/policy/modules/apps/syncthing.if
@@ -4,28 +4,43 @@
 ## <summary>
 ##  Role access for Syncthing
 ## </summary>
+## <param name="role_prefix">
+##	<summary>
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
 ## <param name="role">
 ##	<summary>
 ##	Role allowed access
 ##	</summary>
 ## </param>
-## <param name="domain">
-##	<summary>
-##	User domain for the role
-##	</summary>
-## </param>
 #
-interface(`syncthing_role', `
+template(`syncthing_role', `
 	gen_require(`
 		attribute_role syncthing_roles;
 		type syncthing_t, syncthing_exec_t, syncthing_xdg_config_t;
 	')
 
-	roleattribute $1 syncthing_roles;
+	roleattribute $4 syncthing_roles;
 
-	domtrans_pattern($2, syncthing_exec_t, syncthing_t)
+	domtrans_pattern($3, syncthing_exec_t, syncthing_t)
 
 	allow $2 syncthing_xdg_config_t:file { manage_file_perms relabel_file_perms };
 	allow $2 syncthing_xdg_config_t:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 syncthing_xdg_config_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
+
+	optional_policy(`
+		systemd_user_app_status($1, syncthing_t)
+	')
 ')

--- a/policy/modules/apps/telepathy.if
+++ b/policy/modules/apps/telepathy.if
@@ -41,18 +41,23 @@ template(`telepathy_domain_template',`
 ## </desc>
 ## <param name="role_prefix">
 ##	<summary>
-##	The prefix of the user domain (e.g., user
-##	is the prefix for user_t).
-##	</summary>
-## </param>
-## <param name="user_role">
-##	<summary>
-##	The role associated with the user domain.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
 ## <param name="user_domain">
 ##	<summary>
-##	The type of the user domain.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
@@ -74,7 +79,7 @@ template(`telepathy_role_template',`
 		type telepathy_mission_control_home_t;
 	')
 
-	role $2 types telepathy_domain;
+	role $4 types telepathy_domain;
 
 	allow $3 telepathy_domain:process { ptrace signal_perms };
 	ps_process_pattern($3, telepathy_domain)
@@ -93,34 +98,38 @@ template(`telepathy_role_template',`
 	dbus_spec_session_domain($1, telepathy_stream_engine_t, telepathy_stream_engine_exec_t)
 	dbus_spec_session_domain($1, telepathy_msn_t, telepathy_msn_exec_t)
 
-	allow $3 { telepathy_mission_control_xdg_cache_t telepathy_xdg_cache_t telepathy_logger_xdg_cache_t }:dir { manage_dir_perms relabel_dir_perms };
-	allow $3 { telepathy_gabble_xdg_cache_t telepathy_mission_control_home_t telepathy_xdg_data_t }:dir { manage_dir_perms relabel_dir_perms };
-	allow $3 { telepathy_mission_control_xdg_data_t telepathy_sunshine_home_t telepathy_logger_xdg_data_t }:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 { telepathy_mission_control_xdg_cache_t telepathy_xdg_cache_t telepathy_logger_xdg_cache_t }:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 { telepathy_gabble_xdg_cache_t telepathy_mission_control_home_t telepathy_xdg_data_t }:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 { telepathy_mission_control_xdg_data_t telepathy_sunshine_home_t telepathy_logger_xdg_data_t }:dir { manage_dir_perms relabel_dir_perms };
 
-	allow $3 { telepathy_mission_control_xdg_cache_t telepathy_xdg_cache_t telepathy_logger_xdg_cache_t }:file { manage_file_perms relabel_file_perms };
-	allow $3 { telepathy_gabble_xdg_cache_t telepathy_mission_control_home_t telepathy_xdg_data_t }:file { manage_file_perms relabel_file_perms };
-	allow $3 { telepathy_mission_control_xdg_data_t telepathy_sunshine_home_t telepathy_logger_xdg_data_t }:file { manage_file_perms relabel_file_perms };
+	allow $2 { telepathy_mission_control_xdg_cache_t telepathy_xdg_cache_t telepathy_logger_xdg_cache_t }:file { manage_file_perms relabel_file_perms };
+	allow $2 { telepathy_gabble_xdg_cache_t telepathy_mission_control_home_t telepathy_xdg_data_t }:file { manage_file_perms relabel_file_perms };
+	allow $2 { telepathy_mission_control_xdg_data_t telepathy_sunshine_home_t telepathy_logger_xdg_data_t }:file { manage_file_perms relabel_file_perms };
 
-	filetrans_pattern($3, telepathy_xdg_cache_t, telepathy_gabble_xdg_cache_t, dir, "gabble")
-	# gnome_cache_filetrans($3, telepathy_gabble_cache_home_t, dir, "wocky")
+	filetrans_pattern($2, telepathy_xdg_cache_t, telepathy_gabble_xdg_cache_t, dir, "gabble")
+	# gnome_cache_filetrans($2, telepathy_gabble_cache_home_t, dir, "wocky")
 
-	filetrans_pattern($3, telepathy_xdg_cache_t, telepathy_logger_xdg_cache_t, dir, "logger")
-	# gnome_data_filetrans($3, telepathy_logger_data_home_t, dir, "TpLogger")
+	filetrans_pattern($2, telepathy_xdg_cache_t, telepathy_logger_xdg_cache_t, dir, "logger")
+	# gnome_data_filetrans($2, telepathy_logger_data_home_t, dir, "TpLogger")
 
-	userdom_user_home_dir_filetrans($3, telepathy_mission_control_home_t, dir, ".mission-control")
-	filetrans_pattern($3, telepathy_xdg_data_t, telepathy_mission_control_xdg_data_t, dir, "mission-control")
-	# gnome_cache_filetrans($3, telepathy_mission_control_cache_home_t, file, ".mc_connections")
+	userdom_user_home_dir_filetrans($2, telepathy_mission_control_home_t, dir, ".mission-control")
+	filetrans_pattern($2, telepathy_xdg_data_t, telepathy_mission_control_xdg_data_t, dir, "mission-control")
+	# gnome_cache_filetrans($2, telepathy_mission_control_cache_home_t, file, ".mc_connections")
 
-	userdom_user_home_dir_filetrans($3, telepathy_sunshine_home_t, dir, ".telepathy-sunshine")
+	userdom_user_home_dir_filetrans($2, telepathy_sunshine_home_t, dir, ".telepathy-sunshine")
 
-	# gnome_cache_filetrans($3, telepathy_cache_home_t, dir, "telepathy")
-	# gnome_data_filetrans($3, telepathy_data_home_t, dir, "telepathy")
+	# gnome_cache_filetrans($2, telepathy_cache_home_t, dir, "telepathy")
+	# gnome_data_filetrans($2, telepathy_data_home_t, dir, "telepathy")
 
-	allow $3 telepathy_tmp_content:dir { manage_dir_perms relabel_dir_perms };
-	allow $3 telepathy_tmp_content:file { manage_file_perms relabel_file_perms };
-	allow $3 telepathy_tmp_content:sock_file { manage_sock_file_perms relabel_sock_file_perms };
+	allow $2 telepathy_tmp_content:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 telepathy_tmp_content:file { manage_file_perms relabel_file_perms };
+	allow $2 telepathy_tmp_content:sock_file { manage_sock_file_perms relabel_sock_file_perms };
 
 	telepathy_mission_control_dbus_chat($3)
+
+	optional_policy(`
+		systemd_user_app_status($1, telepathy_domain)
+	')
 ')
 
 ########################################

--- a/policy/modules/apps/thunderbird.if
+++ b/policy/modules/apps/thunderbird.if
@@ -4,39 +4,54 @@
 ## <summary>
 ##	Role access for thunderbird.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`thunderbird_role',`
+template(`thunderbird_role',`
 	gen_require(`
 		attribute_role thunderbird_roles;
 		type thunderbird_t, thunderbird_exec_t, thunderbird_home_t;
 		type thunderbird_tmpfs_t;
 	')
 
-	roleattribute $1 thunderbird_roles;
+	roleattribute $4 thunderbird_roles;
 
-	domtrans_pattern($2, thunderbird_exec_t, thunderbird_t)
+	domtrans_pattern($3, thunderbird_exec_t, thunderbird_t)
 
-	stream_connect_pattern($2, thunderbird_tmpfs_t, thunderbird_tmpfs_t, thunderbird_t)
+	stream_connect_pattern($3, thunderbird_tmpfs_t, thunderbird_tmpfs_t, thunderbird_t)
 
-	allow thunderbird_t $2:unix_stream_socket connectto;
+	allow thunderbird_t $3:unix_stream_socket connectto;
 
-	allow $2 thunderbird_t:process { ptrace signal_perms };
-	ps_process_pattern($2, thunderbird_t)
+	allow $3 thunderbird_t:process { ptrace signal_perms };
+	ps_process_pattern($3, thunderbird_t)
 
 	allow $2 thunderbird_home_t:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 thunderbird_home_t:file { manage_file_perms relabel_file_perms };
 	allow $2 thunderbird_home_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
 	userdom_user_home_dir_filetrans($2, thunderbird_home_t, dir, ".thunderbird")
+
+	optional_policy(`
+		systemd_user_app_status($1, thunderbird_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/apps/tvtime.if
+++ b/policy/modules/apps/tvtime.if
@@ -4,30 +4,41 @@
 ## <summary>
 ##	Role access for tvtime
 ## </summary>
+## <param name="role_prefix">
+##	<summary>
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
 ## <param name="role">
 ##	<summary>
 ##	Role allowed access
 ##	</summary>
 ## </param>
-## <param name="domain">
-##	<summary>
-##	User domain for the role
-##	</summary>
-## </param>
 #
-interface(`tvtime_role',`
+template(`tvtime_role',`
 	gen_require(`
 		attribute_role tvtime_roles;
 		type tvtime_t, tvtime_exec_t, tvtime_tmp_t;
 		type tvtime_home_t, tvtime_tmpfs_t;
 	')
 
-	roleattribute $1 tvtime_roles;
+	roleattribute $4 tvtime_roles;
 
-	domtrans_pattern($2, tvtime_exec_t, tvtime_t)
+	domtrans_pattern($3, tvtime_exec_t, tvtime_t)
 
-	ps_process_pattern($2, tvtime_t)
-	allow $2 tvtime_t:process { ptrace signal_perms };
+	ps_process_pattern($3, tvtime_t)
+	allow $3 tvtime_t:process { ptrace signal_perms };
 
 	allow $2 { tvtime_home_t tvtime_tmp_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { tvtime_home_t tvtime_tmpfs_t tvtime_tmp_t }:file { manage_file_perms relabel_file_perms };
@@ -35,4 +46,8 @@ interface(`tvtime_role',`
 	allow $2 tvtime_tmpfs_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
 	allow $2 tvtime_tmpfs_t:sock_file { manage_sock_file_perms relabel_sock_file_perms };
 	userdom_user_home_dir_filetrans($2, tvtime_home_t, dir, ".tvtime")
+
+	optional_policy(`
+		systemd_user_app_status($1, tvtime_t)
+	')
 ')

--- a/policy/modules/apps/uml.if
+++ b/policy/modules/apps/uml.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for uml.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`uml_role',`
+template(`uml_role',`
 	gen_require(`
 		attribute_role uml_roles;
 		type uml_t, uml_exec_t;
@@ -23,16 +34,16 @@ interface(`uml_role',`
 		type uml_tmpfs_t;
 	')
 
-	roleattribute $1 uml_roles;
+	roleattribute $4 uml_roles;
 
-	domtrans_pattern($2, uml_exec_t, uml_t)
+	domtrans_pattern($3, uml_exec_t, uml_t)
 
-	dgram_send_pattern($2, uml_tmpfs_t, uml_tmpfs_t, uml_t)
+	dgram_send_pattern($3, uml_tmpfs_t, uml_tmpfs_t, uml_t)
 
-	allow uml_t $2:unix_dgram_socket sendto;
+	allow uml_t $3:unix_dgram_socket sendto;
 
-	ps_process_pattern($2, uml_t)
-	allow $2 uml_t:process { ptrace signal_perms };
+	ps_process_pattern($3, uml_t)
+	allow $3 uml_t:process { ptrace signal_perms };
 
 	allow $2 { uml_ro_t uml_rw_t uml_tmp_t uml_exec_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { uml_ro_t uml_rw_t uml_tmp_t uml_tmpfs_t uml_exec_t }:file { manage_file_perms relabel_file_perms };
@@ -40,6 +51,10 @@ interface(`uml_role',`
 	allow $2 { uml_ro_t uml_rw_t uml_tmpfs_t }:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
 	allow $2 { uml_ro_t uml_rw_t uml_tmpfs_t }:sock_file { manage_sock_file_perms relabel_sock_file_perms };
 	userdom_user_home_dir_filetrans($2, uml_rw_t, dir, ".uml")
+
+	optional_policy(`
+		systemd_user_app_status($1, uml_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/apps/userhelper.if
+++ b/policy/modules/apps/userhelper.if
@@ -4,20 +4,25 @@
 ## <summary>
 ##	The role template for the userhelper module.
 ## </summary>
-## <param name="userrole_prefix">
+## <param name="role_prefix">
 ##	<summary>
 ##	The prefix of the user role (e.g., user
 ##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="user_role">
-##	<summary>
-##	The user role.
-##	</summary>
-## </param>
 ## <param name="user_domain">
 ##	<summary>
-##	The user domain associated with the role.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
@@ -37,7 +42,7 @@ template(`userhelper_role_template',`
 	userdom_user_application_domain($1_consolehelper_t, consolehelper_exec_t)
 
 	role consolehelper_roles types $1_consolehelper_t;
-	roleattribute $2 consolehelper_roles;
+	roleattribute $4 consolehelper_roles;
 
 	type $1_userhelper_t, userhelper_type;
 	userdom_user_application_domain($1_userhelper_t, userhelper_exec_t)
@@ -48,7 +53,7 @@ template(`userhelper_role_template',`
 	domain_subj_id_change_exemption($1_userhelper_t)
 
 	role userhelper_roles types $1_userhelper_t;
-	roleattribute $2 userhelper_roles;
+	roleattribute $4 userhelper_roles;
 
 	########################################
 	#
@@ -72,6 +77,10 @@ template(`userhelper_role_template',`
 		')
 	')
 
+	optional_policy(`
+		systemd_user_app_status($1, $1_consolehelper_t)
+	')
+
 	########################################
 	#
 	# Userhelper local policy
@@ -81,7 +90,7 @@ template(`userhelper_role_template',`
 
 	dontaudit $3 $1_userhelper_t:process signal;
 
-	corecmd_bin_domtrans($1_userhelper_t, $3)
+	corecmd_bin_domtrans($1_userhelper_t, $2)
 
 	auth_domtrans_chk_passwd($1_userhelper_t)
 	auth_use_nsswitch($1_userhelper_t)
@@ -94,6 +103,10 @@ template(`userhelper_role_template',`
 			sysadm_bin_spec_domtrans($1_userhelper_t)
 			sysadm_entry_spec_domtrans($1_userhelper_t)
 		')
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, $1_userhelper_t)
 	')
 ')
 

--- a/policy/modules/apps/vmware.if
+++ b/policy/modules/apps/vmware.if
@@ -4,29 +4,40 @@
 ## <summary>
 ##	Role access for vmware.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`vmware_role',`
+template(`vmware_role',`
 	gen_require(`
 		type vmware_t, vmware_exec_t, vmware_file_t;
 		type vmware_conf_t, vmware_tmp_t, vmware_tmpfs_t;
 	')
 
-	role $1 types vmware_t;
+	role $4 types vmware_t;
 
-	domtrans_pattern($2, vmware_exec_t, vmware_t)
+	domtrans_pattern($3, vmware_exec_t, vmware_t)
 
-	ps_process_pattern($2, vmware_t)
-	allow $2 vmware_t:process { ptrace signal_perms };
+	ps_process_pattern($3, vmware_t)
+	allow $3 vmware_t:process { ptrace signal_perms };
 
 	allow $2 { vmware_tmp_t vmware_file_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { vmware_conf_t vmware_file_t vmware_tmp_t vmware_tmpfs_t }:file { manage_file_perms relabel_file_perms };
@@ -35,6 +46,10 @@ interface(`vmware_role',`
 	allow $2 vmware_tmpfs_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
 	userdom_user_home_dir_filetrans($2, vmware_file_t, dir, ".vmware")
 	userdom_user_home_dir_filetrans($2, vmware_file_t, dir, "vmware")
+
+	optional_policy(`
+		systemd_user_app_status($1, vmware_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/apps/wine.if
+++ b/policy/modules/apps/wine.if
@@ -97,7 +97,7 @@ template(`wine_role_template',`
 	')
 
 	optional_policy(`
-		xserver_role($1_r, $1_wine_t)
+		xserver_role($1, $1_wine_t, $1_application_exec_domain, $1_r)
 	')
 ')
 

--- a/policy/modules/apps/wine.if
+++ b/policy/modules/apps/wine.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for wine.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`wine_role',`
+template(`wine_role',`
 	gen_require(`
 		attribute_role wine_roles;
 		type wine_exec_t, wine_t, wine_tmp_t;
@@ -24,18 +35,18 @@ interface(`wine_role',`
 
 	roleattribute $1 wine_roles;
 
-	domtrans_pattern($2, wine_exec_t, wine_t)
+	domtrans_pattern($3, wine_exec_t, wine_t)
 
-	allow wine_t $2:unix_stream_socket connectto;
-	allow wine_t $2:process signull;
+	allow wine_t $3:unix_stream_socket connectto;
+	allow wine_t $3:process signull;
 
-	ps_process_pattern($2, wine_t)
-	allow $2 wine_t:process { ptrace signal_perms };
+	ps_process_pattern($3, wine_t)
+	allow $3 wine_t:process { ptrace signal_perms };
 
-	allow $2 wine_t:fd use;
-	allow $2 wine_t:shm { associate getattr };
-	allow $2 wine_t:shm rw_shm_perms;
-	allow $2 wine_t:unix_stream_socket connectto;
+	allow $3 wine_t:fd use;
+	allow $3 wine_t:shm { associate getattr };
+	allow $3 wine_t:shm rw_shm_perms;
+	allow $3 wine_t:unix_stream_socket connectto;
 
 	allow $2 { wine_tmp_t wine_home_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { wine_tmp_t wine_home_t }:file { manage_file_perms relabel_file_perms };
@@ -55,18 +66,23 @@ interface(`wine_role',`
 ## </desc>
 ## <param name="role_prefix">
 ##	<summary>
-##	The prefix of the user domain (e.g., user
-##	is the prefix for user_t).
-##	</summary>
-## </param>
-## <param name="user_role">
-##	<summary>
-##	The role associated with the user domain.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
 ## <param name="user_domain">
 ##	<summary>
-##	The type of the user domain.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
@@ -86,7 +102,7 @@ template(`wine_role_template',`
 
 	domtrans_pattern($3, wine_exec_t, $1_wine_t)
 
-	corecmd_bin_domtrans($1_wine_t, $3)
+	corecmd_bin_domtrans($1_wine_t, $2)
 
 	userdom_manage_user_tmpfs_files($1_wine_t)
 
@@ -97,7 +113,7 @@ template(`wine_role_template',`
 	')
 
 	optional_policy(`
-		xserver_role($1, $1_wine_t, $1_application_exec_domain, $1_r)
+		xserver_role($1, $1_wine_t, $3, $4)
 	')
 ')
 

--- a/policy/modules/apps/wireshark.if
+++ b/policy/modules/apps/wireshark.if
@@ -4,30 +4,41 @@
 ## <summary>
 ##	Role access for wireshark.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`wireshark_role',`
+template(`wireshark_role',`
 	gen_require(`
 		attribute_role wireshark_roles;
 		type wireshark_t, wireshark_exec_t, wireshark_home_t;
 		type wireshark_tmp_t, wireshark_tmpfs_t;
 	')
 
-	roleattribute $1 wireshark_roles;
+	roleattribute $4 wireshark_roles;
 
-	domtrans_pattern($2, wireshark_exec_t, wireshark_t)
+	domtrans_pattern($3, wireshark_exec_t, wireshark_t)
 
-	allow $2 wireshark_t:process { ptrace signal_perms };
-	ps_process_pattern($2, wireshark_t)
+	allow $3 wireshark_t:process { ptrace signal_perms };
+	ps_process_pattern($3, wireshark_t)
 
 	allow $2 { wireshark_tmp_t wireshark_home_t wireshark_tmpfs_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { wireshark_tmp_t wireshark_home_t wireshark_tmpfs_t }:file { manage_file_perms relabel_file_perms };
@@ -35,6 +46,10 @@ interface(`wireshark_role',`
 	allow $2 wireshark_tmpfs_t:sock_file { manage_sock_file_perms relabel_sock_file_perms };
 	allow $2 wireshark_tmpfs_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
 	userdom_user_home_dir_filetrans($2, wireshark_home_t, dir, ".wireshark")
+
+	optional_policy(`
+		systemd_user_app_status($1, wireshark_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/apps/wm.if
+++ b/policy/modules/apps/wm.if
@@ -12,18 +12,23 @@
 ## </desc>
 ## <param name="role_prefix">
 ##	<summary>
-##	The prefix of the user domain (e.g., user
-##	is the prefix for user_t).
-##	</summary>
-## </param>
-## <param name="user_role">
-##	<summary>
-##	The role associated with the user domain.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
 ## <param name="user_domain">
 ##	<summary>
-##	The type of the user domain.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
@@ -41,7 +46,7 @@ template(`wm_role_template',`
 	type $1_wm_t, wm_domain;
 	userdom_application_exec_domain($1_wm_t, $1)
 	userdom_user_application_domain($1_wm_t, wm_exec_t)
-	role $2 types $1_wm_t;
+	role $4 types $1_wm_t;
 
 	########################################
 	#
@@ -60,8 +65,8 @@ template(`wm_role_template',`
 
 	domtrans_pattern($3, wm_exec_t, $1_wm_t)
 
-	corecmd_bin_domtrans($1_wm_t, $3)
-	corecmd_shell_domtrans($1_wm_t, $3)
+	corecmd_bin_domtrans($1_wm_t, $2)
+	corecmd_shell_domtrans($1_wm_t, $2)
 
 	mls_file_read_all_levels($1_wm_t)
 	mls_file_write_all_levels($1_wm_t)
@@ -71,7 +76,7 @@ template(`wm_role_template',`
 
 	auth_use_nsswitch($1_wm_t)
 
-	xserver_role($2, $1_wm_t)
+	xserver_role($1, $1_wm_t, $3, $4)
 	xserver_manage_core_devices($1_wm_t)
 
 	wm_write_pipes($1, $3)
@@ -95,12 +100,16 @@ template(`wm_role_template',`
 	')
 
 	optional_policy(`
-		policykit_run_auth($1_wm_t, $2)
+		policykit_run_auth($1_wm_t, $4)
 		policykit_signal_auth($1_wm_t)
 	')
 
 	optional_policy(`
-		pulseaudio_run($1_wm_t, $2)
+		pulseaudio_run($1_wm_t, $4)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, $1_wm_t)
 	')
 ')
 

--- a/policy/modules/apps/xscreensaver.if
+++ b/policy/modules/apps/xscreensaver.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for xscreensaver.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`xscreensaver_role',`
+template(`xscreensaver_role',`
 	gen_require(`
 		attribute_role xscreensaver_roles;
 		attribute_role xscreensaver_helper_roles;
@@ -24,18 +35,22 @@ interface(`xscreensaver_role',`
 		type xscreensaver_config_t, xscreensaver_tmpfs_t;
 	')
 
-	roleattribute $1 xscreensaver_roles;
-	roleattribute $1 xscreensaver_helper_roles;
+	roleattribute $4 xscreensaver_roles;
+	roleattribute $4 xscreensaver_helper_roles;
 
-	domtrans_pattern($2, xscreensaver_exec_t, xscreensaver_t)
+	domtrans_pattern($3, xscreensaver_exec_t, xscreensaver_t)
 
-	allow $2 xscreensaver_t:process { ptrace signal_perms };
-	ps_process_pattern($2, xscreensaver_t)
+	allow $3 xscreensaver_t:process { ptrace signal_perms };
+	ps_process_pattern($3, xscreensaver_t)
 
 	allow $2 xscreensaver_config_t:file { manage_file_perms relabel_file_perms };
 
 	allow $2 xscreensaver_tmpfs_t:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 xscreensaver_tmpfs_t:file { manage_file_perms relabel_file_perms };
 
-	allow xscreensaver_helper_t $2:fd use;
+	allow xscreensaver_helper_t $3:fd use;
+
+	optional_policy(`
+		systemd_user_app_status($1, xscreensaver_t)
+	')
 ')

--- a/policy/modules/roles/auditadm.te
+++ b/policy/modules/roles/auditadm.te
@@ -52,7 +52,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	sudo_role_template(auditadm, auditadm_r, auditadm_t)
+	sudo_role_template(auditadm, auditadm_t, auditadm_application_exec_domain, auditadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/auditadm.te
+++ b/policy/modules/roles/auditadm.te
@@ -48,7 +48,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	su_role_template(auditadm, auditadm_r, auditadm_t)
+	su_role_template(auditadm, auditadm_t, auditadm_application_exec_domain, auditadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/auditadm.te
+++ b/policy/modules/roles/auditadm.te
@@ -40,7 +40,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	screen_role_template(auditadm, auditadm_r, auditadm_t)
+	screen_role_template(auditadm, auditadm_t, auditadm_application_exec_domain, auditadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/guest.te
+++ b/policy/modules/roles/guest.te
@@ -17,7 +17,7 @@ kernel_read_system_state(guest_t)
 #
 
 optional_policy(`
-	apache_role(guest_r, guest_t)
+	apache_role(guest, guest_t, guest_application_exec_domain, guest_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/guest.te
+++ b/policy/modules/roles/guest.te
@@ -17,10 +17,6 @@ kernel_read_system_state(guest_t)
 #
 
 optional_policy(`
-	apache_role(guest, guest_t, guest_application_exec_domain, guest_r)
-')
-
-optional_policy(`
 	dbus_role_template(guest, guest_r, guest_t)
 ')
 

--- a/policy/modules/roles/secadm.te
+++ b/policy/modules/roles/secadm.te
@@ -57,7 +57,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	screen_role_template(secadm, secadm_r, secadm_t)
+	screen_role_template(secadm, secadm_t, secadm_application_exec_domain, secadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/secadm.te
+++ b/policy/modules/roles/secadm.te
@@ -65,7 +65,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	sudo_role_template(secadm, secadm_r, secadm_t)
+	sudo_role_template(secadm, secadm_t, secadm_application_exec_domain, secadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/secadm.te
+++ b/policy/modules/roles/secadm.te
@@ -29,7 +29,7 @@ mls_file_write_all_levels(secadm_t)
 mls_file_upgrade(secadm_t)
 mls_file_downgrade(secadm_t)
 
-auth_role(secadm_r, secadm_t)
+auth_role(secadm, secadm_t, secadm_application_exec_domain, secadm_r)
 files_relabel_non_auth_files(secadm_t)
 auth_relabel_shadow(secadm_t)
 

--- a/policy/modules/roles/secadm.te
+++ b/policy/modules/roles/secadm.te
@@ -61,7 +61,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	su_role_template(secadm, secadm_r, secadm_t)
+	su_role_template(secadm, secadm_t, secadm_application_exec_domain, secadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -37,7 +37,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	postgresql_role(staff_r, staff_t)
+	postgresql_role(staff, staff_t, staff_application_exec_domain, staff_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -195,7 +195,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		userhelper_role_template(staff, staff_r, staff_t)
+		userhelper_role_template(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -58,7 +58,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	syncthing_role(staff_r, staff_t)
+	syncthing_role(staff, staff_t, staff_application_exec_domain, staff_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -199,7 +199,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		vmware_role(staff_r, staff_t)
+		vmware_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -167,7 +167,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		screen_role_template(staff, staff_r, staff_t)
+		screen_role_template(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -143,7 +143,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		mta_role(staff_r, staff_t)
+		mta_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -203,7 +203,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		wireshark_role(staff_r, staff_t)
+		wireshark_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -175,7 +175,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		su_role_template(staff, staff_r, staff_t)
+		su_role_template(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -70,7 +70,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	xscreensaver_role(staff_r, staff_t)
+	xscreensaver_role(staff, staff_t, staff_application_exec_domain, staff_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -159,7 +159,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		razor_role(staff_r, staff_t)
+		razor_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -87,7 +87,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		cdrecord_role(staff_r, staff_t)
+		cdrecord_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -207,6 +207,6 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		wm_role_template(staff, staff_r, staff_t)
+		wm_role_template(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 ')

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -91,7 +91,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		chromium_role(staff_r, staff_t)
+		chromium_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -147,7 +147,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		ooffice_role(staff_r, staff_t)
+		ooffice_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -171,7 +171,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		spamassassin_role(staff_r, staff_t)
+		spamassassin_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -163,7 +163,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		rssh_role(staff_r, staff_t)
+		rssh_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -131,7 +131,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		lpd_role(staff_r, staff_t)
+		lpd_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -123,7 +123,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		java_role(staff_r, staff_t)
+		java_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -115,7 +115,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		gpg_role(staff_r, staff_t)
+		gpg_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -179,7 +179,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		telepathy_role_template(staff, staff_r, staff_t)
+		telepathy_role_template(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -103,7 +103,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		evolution_role(staff_r, staff_t)
+		evolution_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -127,7 +127,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		libmtp_role(staff_r, staff_t)
+		libmtp_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -16,7 +16,7 @@ userdom_unpriv_user_template(staff)
 corenet_ib_access_unlabeled_pkeys(staff_t)
 
 optional_policy(`
-	apache_role(staff_r, staff_t)
+	apache_role(staff, staff_t, staff_application_exec_domain, staff_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -45,7 +45,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	ssh_role_template(staff, staff_r, staff_t)
+	ssh_role_template(staff, staff_t, staff_application_exec_domain, staff_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -107,7 +107,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		games_role(staff_r, staff_t)
+		games_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -49,7 +49,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	sudo_role_template(staff, staff_r, staff_t)
+	sudo_role_template(staff, staff_t, staff_application_exec_domain, staff_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -99,7 +99,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		dirmngr_role(staff_r, staff_t)
+		dirmngr_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -95,7 +95,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		cron_role(staff_r, staff_t)
+		cron_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -28,8 +28,8 @@ optional_policy(`
 ')
 
 optional_policy(`
-	git_client_role_template(staff, staff_r, staff_t)
-	git_role(staff_r, staff_t)
+	git_client_role_template(staff, staff_t, staff_application_exec_domain, staff_r)
+	git_role(staff, staff_t, staff_application_exec_domain, staff_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -139,7 +139,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		mplayer_role(staff_r, staff_t)
+		mplayer_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -79,7 +79,7 @@ optional_policy(`
 
 ifndef(`distro_redhat',`
 	optional_policy(`
-		auth_role(staff_r, staff_t)
+		auth_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -135,7 +135,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		mozilla_role(staff_r, staff_t)
+		mozilla_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -155,7 +155,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		pyzor_role(staff_r, staff_t)
+		pyzor_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -74,7 +74,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	xserver_role(staff_r, staff_t)
+	xserver_role(staff, staff_t, staff_application_exec_domain, staff_r)
 ')
 
 ifndef(`distro_redhat',`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -83,7 +83,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		bluetooth_role(staff_r, staff_t)
+		bluetooth_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -191,7 +191,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		uml_role(staff_r, staff_t)
+		uml_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -119,7 +119,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		irc_role(staff_r, staff_t)
+		irc_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -151,7 +151,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		pulseaudio_role(staff_r, staff_t)
+		pulseaudio_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -111,7 +111,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		gnome_role_template(staff, staff_r, staff_t)
+		gnome_role_template(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -183,7 +183,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		thunderbird_role(staff_r, staff_t)
+		thunderbird_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -187,7 +187,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		tvtime_role(staff_r, staff_t)
+		tvtime_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -992,7 +992,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	ssh_role_template(sysadm, sysadm_r, sysadm_t)
+	ssh_role_template(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -988,7 +988,7 @@ optional_policy(`
 
 optional_policy(`
 	spamassassin_admin(sysadm_t, sysadm_r)
-	spamassassin_role(sysadm_r, sysadm_t)
+	spamassassin_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -709,7 +709,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	ooffice_role(sysadm_r, sysadm_t)
+	ooffice_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1210,7 +1210,7 @@ ifndef(`distro_redhat',`
 
 	optional_policy(`
 		bluetooth_admin(sysadm_t, sysadm_r)
-		bluetooth_role(sysadm_r, sysadm_t)
+		bluetooth_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1172,7 +1172,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	wireshark_role(sysadm_r, sysadm_t)
+	wireshark_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1012,7 +1012,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	sudo_role_template(sysadm, sysadm_r, sysadm_t)
+	sudo_role_template(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1084,7 +1084,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	uml_role(sysadm_r, sysadm_t)
+	uml_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -633,7 +633,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	mplayer_role(sysadm_r, sysadm_t)
+	mplayer_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1258,7 +1258,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		java_role(sysadm_r, sysadm_t)
+		java_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1238,7 +1238,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		games_role(sysadm_r, sysadm_t)
+		games_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1246,7 +1246,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		gpg_role(sysadm_r, sysadm_t)
+		gpg_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -885,7 +885,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	rssh_role(sysadm_r, sysadm_t)
+	rssh_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -440,7 +440,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	hadoop_role(sysadm_r, sysadm_t)
+	hadoop_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -572,7 +572,7 @@ optional_policy(`
 
 optional_policy(`
 	lpd_run_checkpc(sysadm_t, sysadm_r)
-	lpd_role(sysadm_r, sysadm_t)
+	lpd_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1008,7 +1008,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	su_role_template(sysadm, sysadm_r, sysadm_t)
+	su_role_template(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1250,7 +1250,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		irc_role(sysadm_r, sysadm_t)
+		irc_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1205,7 +1205,7 @@ optional_policy(`
 
 ifndef(`distro_redhat',`
 	optional_policy(`
-		auth_role(sysadm_r, sysadm_t)
+		auth_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -140,7 +140,7 @@ optional_policy(`
 	apache_run_helper(sysadm_t, sysadm_r)
 	#apache_run_all_scripts(sysadm_t, sysadm_r)
 	#apache_domtrans_sys_script(sysadm_t)
-	apache_role(sysadm_r, sysadm_t)
+	apache_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -813,7 +813,7 @@ optional_policy(`
 
 optional_policy(`
 	pyzor_admin(sysadm_t, sysadm_r)
-	pyzor_role(sysadm_r, sysadm_t)
+	pyzor_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1230,7 +1230,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		dirmngr_role(sysadm_r, sysadm_t)
+		dirmngr_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1262,6 +1262,6 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		wm_role_template(sysadm, sysadm_r, sysadm_t)
+		wm_role_template(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 ')

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -641,7 +641,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	mta_role(sysadm_r, sysadm_t)
+	mta_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -543,7 +543,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	libmtp_role(sysadm_r, sysadm_t)
+	libmtp_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -625,7 +625,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	mozilla_role(sysadm_r, sysadm_t)
+	mozilla_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1222,7 +1222,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		cron_admin_role(sysadm_r, sysadm_t)
+		cron_admin_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1218,7 +1218,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		chromium_role(sysadm_r, sysadm_t)
+		chromium_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1234,7 +1234,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		evolution_role(sysadm_r, sysadm_t)
+		evolution_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1068,7 +1068,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	tvtime_role(sysadm_r, sysadm_t)
+	tvtime_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1226,7 +1226,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		cryfs_role(sysadm_r, sysadm_t)
+		cryfs_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -847,7 +847,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	razor_role(sysadm_r, sysadm_t)
+	razor_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1143,7 +1143,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	vmware_role(sysadm_r, sysadm_t)
+	vmware_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1180,7 +1180,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	xscreensaver_role(sysadm_r, sysadm_t)
+	xscreensaver_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -926,7 +926,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	screen_role_template(sysadm, sysadm_r, sysadm_t)
+	screen_role_template(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1214,7 +1214,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		cdrecord_role(sysadm_r, sysadm_t)
+		cdrecord_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -955,7 +955,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	shutdown_role(sysadm_r, sysadm_t)
+	shutdown_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1104,7 +1104,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	userhelper_role_template(sysadm, sysadm_r, sysadm_t)
+	userhelper_role_template(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1184,7 +1184,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	xserver_role(sysadm_r, sysadm_t)
+	xserver_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1049,7 +1049,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	thunderbird_role(sysadm_r, sysadm_t)
+	thunderbird_role(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1242,7 +1242,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		gnome_role_template(sysadm, sysadm_r, sysadm_t)
+		gnome_role_template(sysadm, sysadm_t, sysadm_application_exec_domain, sysadm_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -183,7 +183,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		vmware_role(user_r, user_t)
+		vmware_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -99,7 +99,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		lpd_role(user_r, user_t)
+		lpd_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -51,7 +51,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		cdrecord_role(user_r, user_t)
+		cdrecord_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -171,7 +171,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		tvtime_role(user_r, user_t)
+		tvtime_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -83,7 +83,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		hadoop_role(user_r, user_t)
+		hadoop_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -38,7 +38,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	xserver_role(user_r, user_t)
+	xserver_role(user, user_t, user_application_exec_domain, user_r)
 ')
 
 ifndef(`distro_redhat',`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -43,7 +43,7 @@ optional_policy(`
 
 ifndef(`distro_redhat',`
 	optional_policy(`
-		auth_role(user_r, user_t)
+		auth_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -95,7 +95,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		libmtp_role(user_r, user_t)
+		libmtp_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -143,7 +143,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		spamassassin_role(user_r, user_t)
+		spamassassin_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -79,7 +79,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		gpg_role(user_r, user_t)
+		gpg_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -119,7 +119,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		postgresql_role(user_r, user_t)
+		postgresql_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -47,7 +47,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		bluetooth_role(user_r, user_t)
+		bluetooth_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -151,7 +151,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		su_role_template(user, user_r, user_t)
+		su_role_template(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -13,7 +13,7 @@ policy_module(unprivuser, 2.12.1)
 userdom_unpriv_user_template(user)
 
 optional_policy(`
-	apache_role(user_r, user_t)
+	apache_role(user, user_t, user_application_exec_domain, user_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -115,7 +115,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		ooffice_role(user_r, user_t)
+		ooffice_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -187,7 +187,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		wireshark_role(user_r, user_t)
+		wireshark_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -67,7 +67,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		evolution_role(user_r, user_t)
+		evolution_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -63,7 +63,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		dirmngr_role(user_r, user_t)
+		dirmngr_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -135,7 +135,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		rssh_role(user_r, user_t)
+		rssh_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -175,7 +175,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		uml_role(user_r, user_t)
+		uml_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -179,7 +179,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		userhelper_role_template(user, user_r, user_t)
+		userhelper_role_template(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -155,7 +155,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		sudo_role_template(user, user_r, user_t)
+		sudo_role_template(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -55,7 +55,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		chromium_role(user_r, user_t)
+		chromium_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -103,7 +103,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		mozilla_role(user_r, user_t)
+		mozilla_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -17,8 +17,8 @@ optional_policy(`
 ')
 
 optional_policy(`
-	git_client_role_template(user, user_r, user_t)
-	git_role(user_r, user_t)
+	git_client_role_template(user, user_t, user_application_exec_domain, user_r)
+	git_role(user, user_t, user_application_exec_domain, user_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -26,7 +26,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	screen_role_template(user, user_r, user_t)
+	screen_role_template(user, user_t, user_application_exec_domain, user_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -91,7 +91,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		java_role(user_r, user_t)
+		java_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -59,7 +59,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		cron_role(user_r, user_t)
+		cron_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -167,7 +167,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		thunderbird_role(user_r, user_t)
+		thunderbird_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -131,7 +131,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		razor_role(user_r, user_t)
+		razor_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -163,7 +163,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		telepathy_role_template(user, user_r, user_t)
+		telepathy_role_template(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -127,7 +127,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		pyzor_role(user_r, user_t)
+		pyzor_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -191,6 +191,6 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		wm_role_template(user, user_r, user_t)
+		wm_role_template(user, user_t, user_application_exec_domain, user_r)
 	')
 ')

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -111,7 +111,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		mta_role(user_r, user_t)
+		mta_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -75,7 +75,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		gnome_role_template(user, user_r, user_t)
+		gnome_role_template(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -159,7 +159,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		syncthing_role(user_r, user_t)
+		syncthing_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -147,7 +147,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		ssh_role_template(user, user_r, user_t)
+		ssh_role_template(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -71,7 +71,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		games_role(user_r, user_t)
+		games_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -123,7 +123,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		pulseaudio_role(user_r, user_t)
+		pulseaudio_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -107,7 +107,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		mplayer_role(user_r, user_t)
+		mplayer_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -87,7 +87,7 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		irc_role(user_r, user_t)
+		irc_role(user, user_t, user_application_exec_domain, user_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -34,7 +34,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	xscreensaver_role(user_r, user_t)
+	xscreensaver_role(user, user_t, user_application_exec_domain, user_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/xguest.te
+++ b/policy/modules/roles/xguest.te
@@ -94,7 +94,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	java_role(xguest_r, xguest_t)
+	java_role(xguest, xguest_t, xguest_application_exec_domain, xguest_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/xguest.te
+++ b/policy/modules/roles/xguest.te
@@ -86,10 +86,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	apache_role(xguest, xguest_t, xguest_application_exec_domain, xguest_r)
-')
-
-optional_policy(`
 	gnomeclock_dontaudit_dbus_chat(xguest_t)
 ')
 

--- a/policy/modules/roles/xguest.te
+++ b/policy/modules/roles/xguest.te
@@ -98,7 +98,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	mozilla_role(xguest_r, xguest_t)
+	mozilla_role(xguest, xguest_t, xguest_application_exec_domain, xguest_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/xguest.te
+++ b/policy/modules/roles/xguest.te
@@ -86,7 +86,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	apache_role(xguest_r, xguest_t)
+	apache_role(xguest, xguest_t, xguest_application_exec_domain, xguest_r)
 ')
 
 optional_policy(`

--- a/policy/modules/services/apache.if
+++ b/policy/modules/services/apache.if
@@ -106,18 +106,29 @@ template(`apache_content_template',`
 ## <summary>
 ##	Role access for apache.
 ## </summary>
+## <param name="role_prefix">
+##	<summary>
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
 ## <param name="role">
 ##	<summary>
 ##	Role allowed access
 ##	</summary>
 ## </param>
-## <param name="domain">
-##	<summary>
-##	User domain for the role.
-##	</summary>
-## </param>
 #
-interface(`apache_role',`
+template(`apache_role',`
 	gen_require(`
 		attribute httpdcontent;
 		type httpd_user_content_t, httpd_user_htaccess_t;
@@ -125,7 +136,7 @@ interface(`apache_role',`
 		type httpd_user_ra_content_t, httpd_user_rw_content_t;
 	')
 
-	role $1 types httpd_user_script_t;
+	role $4 types httpd_user_script_t;
 
 	allow $2 httpd_user_htaccess_t:file { manage_file_perms relabel_file_perms };
 
@@ -154,11 +165,15 @@ interface(`apache_role',`
 	filetrans_pattern($2, httpd_user_content_t, httpd_user_ra_content_t, dir, "logs")
 
 	tunable_policy(`httpd_enable_cgi',`
-		domtrans_pattern($2, httpd_user_script_exec_t, httpd_user_script_t)
+		domtrans_pattern($3, httpd_user_script_exec_t, httpd_user_script_t)
 	')
 
 	tunable_policy(`httpd_enable_cgi && httpd_unified',`
-		domtrans_pattern($2, httpdcontent, httpd_user_script_t)
+		domtrans_pattern($3, httpdcontent, httpd_user_script_t)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, httpd_user_script_t)
 	')
 ')
 

--- a/policy/modules/services/bluetooth.if
+++ b/policy/modules/services/bluetooth.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for bluetooth.
 ## </summary>
+## <param name="role_prefix">
+##	<summary>
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
 ## <param name="role">
 ##	<summary>
 ##	Role allowed access
 ##	</summary>
 ## </param>
-## <param name="domain">
-##	<summary>
-##	User domain for the role
-##	</summary>
-## </param>
 #
-interface(`bluetooth_role',`
+template(`bluetooth_role',`
 	gen_require(`
 		attribute_role bluetooth_helper_roles;
 		type bluetooth_t, bluetooth_helper_t, bluetooth_helper_exec_t;
@@ -27,26 +38,30 @@ interface(`bluetooth_role',`
 	# Declarations
 	#
 
-	roleattribute $1 bluetooth_helper_roles;
+	roleattribute $4 bluetooth_helper_roles;
 
 	########################################
 	#
 	# Policy
 	#
 
-	domtrans_pattern($2, bluetooth_helper_exec_t, bluetooth_helper_t)
+	domtrans_pattern($3, bluetooth_helper_exec_t, bluetooth_helper_t)
 
-	ps_process_pattern($2, bluetooth_helper_t)
-	allow $2 bluetooth_helper_t:process { ptrace signal_perms };
+	ps_process_pattern($3, bluetooth_helper_t)
+	allow $3 bluetooth_helper_t:process { ptrace signal_perms };
 
-	allow $2 bluetooth_t:socket rw_socket_perms;
+	allow $3 bluetooth_t:socket rw_socket_perms;
 
 	allow $2 { bluetooth_helper_tmp_t bluetooth_helper_tmpfs_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { bluetooth_helper_tmp_t bluetooth_helper_tmpfs_t }:file { manage_file_perms relabel_file_perms };
 	allow $2 bluetooth_helper_tmp_t:sock_file { manage_sock_file_perms relabel_sock_file_perms };
 
-	stream_connect_pattern($2, bluetooth_runtime_t, bluetooth_runtime_t, bluetooth_t)
-	files_search_runtime($2)
+	stream_connect_pattern($3, bluetooth_runtime_t, bluetooth_runtime_t, bluetooth_t)
+	files_search_runtime($3)
+
+	optional_policy(`
+		systemd_user_app_status($1, bluetooth_helper_t)
+	')
 ')
 
 #####################################

--- a/policy/modules/services/cron.if
+++ b/policy/modules/services/cron.if
@@ -44,19 +44,30 @@ template(`cron_common_crontab_template',`
 ## <summary>
 ##	Role access for cron.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 ## <rolecap/>
 #
-interface(`cron_role',`
+template(`cron_role',`
 	gen_require(`
 		type cronjob_t, crontab_t, crontab_exec_t;
 		type user_cron_spool_t, crond_t;
@@ -68,7 +79,7 @@ interface(`cron_role',`
 	# Declarations
 	#
 
-	role $1 types { cronjob_t crontab_t };
+	role $4 types { cronjob_t crontab_t };
 
 	##############################
 	#
@@ -77,7 +88,7 @@ interface(`cron_role',`
 
 	domtrans_pattern($2, crontab_exec_t, crontab_t)
 
-	dontaudit crond_t $2:process { noatsecure rlimitinh siginh };
+	dontaudit crond_t $3:process { noatsecure rlimitinh siginh };
 	allow $2 crond_t:process sigchld;
 
 	allow $2 user_cron_spool_t:file rw_inherited_file_perms;
@@ -126,18 +137,29 @@ interface(`cron_role',`
 ## <summary>
 ##	Role access for unconfined cron.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`cron_unconfined_role',`
+template(`cron_unconfined_role',`
 	gen_require(`
 		type unconfined_cronjob_t, crontab_t, crontab_exec_t;
 		type crond_t, user_cron_spool_t;
@@ -149,7 +171,7 @@ interface(`cron_unconfined_role',`
 	# Declarations
 	#
 
-	role $1 types { unconfined_cronjob_t crontab_t };
+	role $4 types { unconfined_cronjob_t crontab_t };
 
 	##############################
 	#
@@ -207,18 +229,29 @@ interface(`cron_unconfined_role',`
 ## <summary>
 ##	Role access for admin cron.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`cron_admin_role',`
+template(`cron_admin_role',`
 	gen_require(`
 		type cronjob_t, crontab_exec_t, admin_crontab_t;
 		class passwd crontab;
@@ -231,7 +264,7 @@ interface(`cron_admin_role',`
 	# Declarations
 	#
 
-	role $1 types { cronjob_t admin_crontab_t };
+	role $4 types { cronjob_t admin_crontab_t };
 
 	##############################
 	#

--- a/policy/modules/services/dirmngr.if
+++ b/policy/modules/services/dirmngr.if
@@ -4,34 +4,49 @@
 ## <summary>
 ##	Role access for dirmngr.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`dirmngr_role',`
+template(`dirmngr_role',`
 	gen_require(`
 		type dirmngr_t, dirmngr_exec_t;
 		type dirmngr_tmp_t;
 	')
 
-	role $1 types dirmngr_t;
+	role $4 types dirmngr_t;
 
-	domtrans_pattern($2, dirmngr_exec_t, dirmngr_t)
+	domtrans_pattern($3, dirmngr_exec_t, dirmngr_t)
 
-	allow $2 dirmngr_t:process { ptrace signal_perms };
-	ps_process_pattern($2, dirmngr_t)
+	allow $3 dirmngr_t:process { ptrace signal_perms };
+	ps_process_pattern($3, dirmngr_t)
 
-	allow dirmngr_t $2:fd use;
-	allow dirmngr_t $2:fifo_file rw_inherited_fifo_file_perms;
+	allow dirmngr_t $3:fd use;
+	allow dirmngr_t $3:fifo_file rw_inherited_fifo_file_perms;
 
 	allow $2 dirmngr_tmp_t:sock_file { manage_sock_file_perms relabel_sock_file_perms };
+
+	optional_policy(`
+		systemd_user_app_status($1, dirmngr_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/services/git.if
+++ b/policy/modules/services/git.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for Git session.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`git_role',`
+template(`git_role',`
 	gen_require(`
 		attribute_role git_session_roles;
 		type git_session_t, gitd_exec_t, git_user_content_t;
@@ -26,7 +37,7 @@ interface(`git_role',`
 	# Declarations
 	#
 
-	roleattribute $1 git_session_roles;
+	roleattribute $4 git_session_roles;
 
 	########################################
 	#
@@ -37,13 +48,17 @@ interface(`git_role',`
 	allow $2 git_user_content_t:file { exec_file_perms manage_file_perms relabel_file_perms };
 	userdom_user_home_dir_filetrans($2, git_user_content_t, dir, "public_git")
 
-	allow $2 git_session_t:process { ptrace signal_perms };
-	ps_process_pattern($2, git_session_t)
+	allow $3 git_session_t:process { ptrace signal_perms };
+	ps_process_pattern($3, git_session_t)
 
 	tunable_policy(`git_session_users',`
-		domtrans_pattern($2, gitd_exec_t, git_session_t)
+		domtrans_pattern($3, gitd_exec_t, git_session_t)
 	',`
-		can_exec($2, gitd_exec_t)
+		can_exec($3, gitd_exec_t)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, git_session_t)
 	')
 ')
 
@@ -57,14 +72,19 @@ interface(`git_role',`
 ##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="user_role">
-##	<summary>
-##	The role associated with the user domain.
-##	</summary>
-## </param>
 ## <param name="user_domain">
 ##	<summary>
-##	The type of the user domain.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
@@ -81,7 +101,7 @@ template(`git_client_role_template',`
 
 	type $1_git_t, git_client_domain;
 	userdom_user_application_domain($1_git_t, git_exec_t)
-	role $2 types $1_git_t;
+	role $4 types $1_git_t;
 
 	########################################
 	#
@@ -90,13 +110,13 @@ template(`git_client_role_template',`
 	
 	domtrans_pattern($3, git_exec_t, $1_git_t)
 
-	allow $3 git_home_t:dir { manage_dir_perms relabel_dir_perms };
-	allow $3 git_home_t:file { manage_file_perms relabel_file_perms };
-	userdom_user_home_dir_filetrans($3, git_home_t, dir, ".git")
+	allow $2 git_home_t:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 git_home_t:file { manage_file_perms relabel_file_perms };
+	userdom_user_home_dir_filetrans($2, git_home_t, dir, ".git")
 
-	allow $3 git_home_hook_t:dir { manage_dir_perms relabel_dir_perms };
-	allow $3 git_home_hook_t:file { exec_file_perms manage_file_perms relabel_file_perms };
-	filetrans_pattern($3, git_home_t, git_home_hook_t, dir, "hooks")
+	allow $2 git_home_hook_t:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 git_home_hook_t:file { exec_file_perms manage_file_perms relabel_file_perms };
+	filetrans_pattern($2, git_home_t, git_home_hook_t, dir, "hooks")
 
 	allow $3 $1_git_t:process { ptrace signal_perms };
 	ps_process_pattern($3, $1_git_t)
@@ -106,11 +126,15 @@ template(`git_client_role_template',`
 	# allow userdomains to exec git hooks
 	exec_files_pattern($3, git_home_t, git_home_t)
 	# transition back to the user domain when executing git hooks
-	domtrans_pattern($1_git_t, git_home_t, $3)
+	domtrans_pattern($1_git_t, git_home_t, $2)
 
 	# transition to ssh client domain when performing ssh operations
 	optional_policy(`
 		ssh_client_domtrans($1_git_t)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, $1_git_t)
 	')
 ')
 

--- a/policy/modules/services/hadoop.if
+++ b/policy/modules/services/hadoop.if
@@ -94,37 +94,53 @@ template(`hadoop_domain_template',`
 ## <summary>
 ##	Role access for hadoop.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
-##	Domain allowed access.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 ## <rolecap/>
 #
-interface(`hadoop_role',`
+template(`hadoop_role',`
 	gen_require(`
 		attribute_role hadoop_roles, zookeeper_roles;
 		type hadoop_t, zookeeper_t, hadoop_home_t;
 		type hadoop_tmp_t, hadoop_hsperfdata_t, zookeeper_tmp_t;
 	')
 
-	hadoop_domtrans($2)
-	roleattribute $1 hadoop_roles;
+	hadoop_domtrans($3)
+	roleattribute $4 hadoop_roles;
 
-	hadoop_domtrans_zookeeper_client($2)
-	roleattribute $1 zookeeper_roles;
+	hadoop_domtrans_zookeeper_client($3)
+	roleattribute $4 zookeeper_roles;
 
-	allow $2 { hadoop_t zookeeper_t }:process { ptrace signal_perms };
-	ps_process_pattern($2, { hadoop_t zookeeper_t })
+	allow $3 { hadoop_t zookeeper_t }:process { ptrace signal_perms };
+	ps_process_pattern($3, { hadoop_t zookeeper_t })
 
 	allow $2 { hadoop_home_t hadoop_tmp_t hadoop_hsperfdata_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { hadoop_home_t hadoop_tmp_t zookeeper_tmp_t }:file { manage_file_perms relabel_file_perms };
 	allow $2 hadoop_home_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
+
+	optional_policy(`
+		systemd_user_app_status($1, hadoop_t)
+		systemd_user_app_status($1, zookeeper_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/services/lpd.if
+++ b/policy/modules/services/lpd.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for lpd.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`lpd_role',`
+template(`lpd_role',`
 	gen_require(`
 		attribute_role lpr_roles;
 		type lpr_t, lpr_exec_t;
@@ -26,22 +37,26 @@ interface(`lpd_role',`
 	# Declarations
 	#
 
-	roleattribute $1 lpr_roles;
+	roleattribute $4 lpr_roles;
 
 	########################################
 	#
 	# Policy
 	#
 
-	domtrans_pattern($2, lpr_exec_t, lpr_t)
+	domtrans_pattern($3, lpr_exec_t, lpr_t)
 
-	allow $2 lpr_t:process { ptrace signal_perms };
-	ps_process_pattern($2, lpr_t)
+	allow $3 lpr_t:process { ptrace signal_perms };
+	ps_process_pattern($3, lpr_t)
 
-	dontaudit lpr_t $2:unix_stream_socket { read write };
+	dontaudit lpr_t $3:unix_stream_socket { read write };
 
 	optional_policy(`
-		cups_read_config($2)
+		cups_read_config($3)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, lpr_t)
 	')
 ')
 

--- a/policy/modules/services/mpd.te
+++ b/policy/modules/services/mpd.te
@@ -182,6 +182,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	pulseaudio_client_domain(mpd_t)
 	pulseaudio_domtrans(mpd_t)
 ')
 

--- a/policy/modules/services/mta.if
+++ b/policy/modules/services/mta.if
@@ -63,18 +63,29 @@ template(`mta_base_mail_template',`
 ## <summary>
 ##	Role access for mta.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`mta_role',`
+template(`mta_role',`
 	gen_require(`
 		attribute mta_user_agent;
 		attribute_role user_mail_roles;
@@ -82,18 +93,18 @@ interface(`mta_role',`
 		type user_mail_tmp_t, mail_home_rw_t;
 	')
 
-	roleattribute $1 user_mail_roles;
+	roleattribute $4 user_mail_roles;
 
 	# this is something i need to fix
 	# i dont know if and why it is needed
 	# will role attribute work?
-	role $1 types mta_user_agent;
+	role $4 types mta_user_agent;
 
-	domtrans_pattern($2, sendmail_exec_t, user_mail_t)
-	allow $2 sendmail_exec_t:lnk_file read_lnk_file_perms;
+	domtrans_pattern($3, sendmail_exec_t, user_mail_t)
+	allow $3 sendmail_exec_t:lnk_file read_lnk_file_perms;
 
-	allow $2 { user_mail_t mta_user_agent }:process { ptrace signal_perms };
-	ps_process_pattern($2, { user_mail_t mta_user_agent })
+	allow $3 { user_mail_t mta_user_agent }:process { ptrace signal_perms };
+	ps_process_pattern($3, { user_mail_t mta_user_agent })
 
 	allow $2 mail_home_t:file { manage_file_perms relabel_file_perms };
 	userdom_user_home_dir_filetrans($2, mail_home_t, file, ".esmtp_queue")
@@ -111,11 +122,15 @@ interface(`mta_role',`
 	allow $2 user_mail_tmp_t:file { manage_file_perms relabel_file_perms };
 
 	optional_policy(`
-		exim_run($2, $1)
+		exim_run($3, $4)
 	')
 
 	optional_policy(`
-		mailman_run($2, $1)
+		mailman_run($3, $4)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, user_mail_t)
 	')
 ')
 

--- a/policy/modules/services/postgresql.if
+++ b/policy/modules/services/postgresql.if
@@ -4,18 +4,29 @@
 ## <summary>
 ##	Role access for SE-PostgreSQL.
 ## </summary>
-## <param name="user_role">
+## <param name="role_prefix">
 ##	<summary>
-##	The role associated with the user domain.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
 ## <param name="user_domain">
 ##	<summary>
-##	The type of the user domain.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
-interface(`postgresql_role',`
+template(`postgresql_role',`
 	gen_require(`
 		class db_database all_db_database_perms;
 		class db_schema all_db_schema_perms;
@@ -46,8 +57,8 @@ interface(`postgresql_role',`
 	#
 
 	typeattribute $2 sepgsql_client_type;
-	role $1 types sepgsql_trusted_proc_t;
-	role $1 types sepgsql_ranged_proc_t;
+	role $4 types sepgsql_trusted_proc_t;
+	role $4 types sepgsql_ranged_proc_t;
 
 	##############################
 	#
@@ -94,6 +105,11 @@ interface(`postgresql_role',`
 
 	allow $2 sepgsql_trusted_proc_t:process transition;
 	type_transition $2 sepgsql_trusted_proc_exec_t:process sepgsql_trusted_proc_t;
+
+	optional_policy(`
+		systemd_user_app_status($1, sepgsql_ranged_proc_t)
+		systemd_user_app_status($1, sepgsql_trusted_proc_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/services/pyzor.if
+++ b/policy/modules/services/pyzor.if
@@ -4,36 +4,51 @@
 ## <summary>
 ##	Role access for pyzor.
 ## </summary>
+## <param name="role_prefix">
+##	<summary>
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
 ## <param name="role">
 ##	<summary>
 ##	Role allowed access
 ##	</summary>
 ## </param>
-## <param name="domain">
-##	<summary>
-##	User domain for the role
-##	</summary>
-## </param>
 #
-interface(`pyzor_role',`
+template(`pyzor_role',`
 	gen_require(`
 		attribute_role pyzor_roles;
 		type pyzor_t, pyzor_exec_t, pyzor_home_t;
 		type pyzor_tmp_t;
 	')
 
-	roleattribute $1 pyzor_roles;
+	roleattribute $4 pyzor_roles;
 
-	domtrans_pattern($2, pyzor_exec_t, pyzor_t)
+	domtrans_pattern($3, pyzor_exec_t, pyzor_t)
 
-	allow $2 pyzor_t:process { ptrace signal_perms };
-	ps_process_pattern($2, pyzor_t)
+	allow $3 pyzor_t:process { ptrace signal_perms };
+	ps_process_pattern($3, pyzor_t)
 
 	allow $2 { pyzor_home_t pyzor_tmp_t }:dir { manage_dir_perms relabel_dir_perms };
-	allow $2  { pyzor_home_t pyzor_tmp_t }:file { manage_file_perms relabel_file_perms };
+	allow $2 { pyzor_home_t pyzor_tmp_t }:file { manage_file_perms relabel_file_perms };
 	allow $2 pyzor_home_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
 
 	userdom_user_home_dir_filetrans($2, pyzor_home_t, dir, ".pyzor")
+
+	optional_policy(`
+		systemd_user_app_status($1, pyzor_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/services/razor.if
+++ b/policy/modules/services/razor.if
@@ -37,36 +37,51 @@ template(`razor_common_domain_template',`
 ## <summary>
 ##	Role access for razor.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`razor_role',`
+template(`razor_role',`
 	gen_require(`
 		attribute_role razor_roles;
 		type razor_t, razor_exec_t, razor_home_t;
 		type razor_tmp_t;
 	')
 
-	roleattribute $1 razor_roles;
+	roleattribute $4 razor_roles;
 
-	domtrans_pattern($2, razor_exec_t, razor_t)
+	domtrans_pattern($3, razor_exec_t, razor_t)
 
-	ps_process_pattern($2, razor_t)
-	allow $2 razor_t:process signal;
+	ps_process_pattern($3, razor_t)
+	allow $3 razor_t:process signal;
 
 	allow $2 { razor_home_t razor_tmp_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { razor_home_t razor_tmp_t }:file { manage_file_perms relabel_file_perms };
 	allow $2 razor_home_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
 
 	userdom_user_home_dir_filetrans($2, razor_home_t, dir, ".razor")
+
+	optional_policy(`
+		systemd_user_app_status($1, razor_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/services/spamassassin.if
+++ b/policy/modules/services/spamassassin.if
@@ -4,36 +4,52 @@
 ## <summary>
 ##	Role access for spamassassin.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
 ##	User domain for the role.
 ##	</summary>
 ## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
 #
-interface(`spamassassin_role',`
+template(`spamassassin_role',`
 	gen_require(`
 		type spamc_t, spamc_exec_t, spamc_tmp_t;
 		type spamassassin_t, spamassassin_exec_t, spamd_home_t;
 		type spamassassin_home_t, spamassassin_tmp_t;
 	')
 
-	role $1 types { spamc_t spamassassin_t };
+	role $4 types { spamc_t spamassassin_t };
 
-	domtrans_pattern($2, spamassassin_exec_t, spamassassin_t)
-	domtrans_pattern($2, spamc_exec_t, spamc_t)
+	domtrans_pattern($3, spamassassin_exec_t, spamassassin_t)
+	domtrans_pattern($3, spamc_exec_t, spamc_t)
 
-	admin_process_pattern($2, { spamc_t spamassassin_t })
+	admin_process_pattern($3, { spamc_t spamassassin_t })
 
 	allow $2 { spamc_tmp_t spamd_home_t spamassassin_home_t spamassassin_tmp_t }:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 { spamc_tmp_t spamd_home_t spamassassin_home_t spamassassin_tmp_t }:file { manage_file_perms relabel_file_perms };
 	allow $2 { spamc_tmp_t spamd_home_t spamassassin_home_t spamassassin_tmp_t }:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
 	userdom_user_home_dir_filetrans($2, spamassassin_home_t, dir, ".spamassassin")
 	userdom_user_home_dir_filetrans($2, spamd_home_t, dir, ".spamd")
+
+	optional_policy(`
+		systemd_user_app_status($1, spamassassin_t)
+		systemd_user_app_status($1, spamc_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -143,6 +143,10 @@ template(`ssh_basic_client_template',`
 	optional_policy(`
 		kerberos_use($1_ssh_t)
 	')
+
+	optional_policy(`
+		systemd_user_app_status($1, $1_ssh_t)
+	')
 ')
 
 #######################################
@@ -281,18 +285,23 @@ template(`ssh_server_template', `
 ## </summary>
 ## <param name="role_prefix">
 ##	<summary>
-##	The prefix of the role (e.g., user
+##	The prefix of the user role (e.g., user
 ##	is the prefix for user_r).
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
 ##	</summary>
 ## </param>
 ## <param name="role">
 ##	<summary>
 ##	Role allowed access
-##	</summary>
-## </param>
-## <param name="domain">
-##	<summary>
-##	User domain for the role
 ##	</summary>
 ## </param>
 #
@@ -309,12 +318,12 @@ template(`ssh_role_template',`
 	# Declarations
 	#
 
-	role $2 types ssh_t;
+	role $4 types ssh_t;
 
 	type $1_ssh_agent_t, ssh_agent_type;
 	userdom_user_application_domain($1_ssh_agent_t, ssh_agent_exec_t)
 	domain_interactive_fd($1_ssh_agent_t)
-	role $2 types $1_ssh_agent_t;
+	role $4 types $1_ssh_agent_t;
 
 	##############################
 	#
@@ -338,10 +347,14 @@ template(`ssh_role_template',`
 	allow ssh_t $3:key manage_key_perms;
 
 	# user can manage the keys and config
-	manage_files_pattern($3, ssh_home_t, ssh_home_t)
-	manage_lnk_files_pattern($3, ssh_home_t, ssh_home_t)
-	manage_sock_files_pattern($3, ssh_home_t, ssh_home_t)
+	manage_files_pattern($2, ssh_home_t, ssh_home_t)
+	manage_lnk_files_pattern($2, ssh_home_t, ssh_home_t)
+	manage_sock_files_pattern($2, ssh_home_t, ssh_home_t)
 	userdom_search_user_home_dirs($1_t)
+
+	optional_policy(`
+		systemd_user_app_status($1, ssh_t)
+	')
 
 	##############################
 	#
@@ -379,8 +392,8 @@ template(`ssh_role_template',`
 	fs_search_auto_mountpoints($1_ssh_agent_t)
 
 	# transition back to normal privs upon exec
-	corecmd_shell_domtrans($1_ssh_agent_t, $3)
-	corecmd_bin_domtrans($1_ssh_agent_t, $3)
+	corecmd_shell_domtrans($1_ssh_agent_t, $2)
+	corecmd_bin_domtrans($1_ssh_agent_t, $2)
 
 	domain_use_interactive_fds($1_ssh_agent_t)
 
@@ -402,7 +415,7 @@ template(`ssh_role_template',`
 
 	# for the transition back to normal privs upon exec
 	userdom_search_user_home_content($1_ssh_agent_t)
-	userdom_user_home_domtrans($1_ssh_agent_t, $3)
+	userdom_user_home_domtrans($1_ssh_agent_t, $2)
 	allow $3 $1_ssh_agent_t:fd use;
 	allow $3 $1_ssh_agent_t:fifo_file rw_inherited_fifo_file_perms;
 	allow $3 $1_ssh_agent_t:process sigchld;
@@ -415,18 +428,22 @@ template(`ssh_role_template',`
 		fs_manage_nfs_files($1_ssh_agent_t)
 
 		# transition back to normal privs upon exec
-		fs_nfs_domtrans($1_ssh_agent_t, $3)
+		fs_nfs_domtrans($1_ssh_agent_t, $2)
 	')
 
 	tunable_policy(`use_samba_home_dirs',`
 		fs_manage_cifs_files($1_ssh_agent_t)
 
 		# transition back to normal privs upon exec
-		fs_cifs_domtrans($1_ssh_agent_t, $3)
+		fs_cifs_domtrans($1_ssh_agent_t, $2)
 	')
 
 	optional_policy(`
 		nis_use_ypbind($1_ssh_agent_t)
+	')
+
+	optional_policy(`
+		systemd_user_app_status($1, $1_ssh_agent_t)
 	')
 
 	optional_policy(`

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -5,18 +5,29 @@
 ##	Rules required for using the X Windows server
 ##	and environment, for restricted users.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
-##	Domain allowed access.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
-interface(`xserver_restricted_role',`
+template(`xserver_restricted_role',`
 	gen_require(`
 		type xserver_t, xserver_tmp_t, xserver_tmpfs_t;
 		type user_fonts_t, user_fonts_cache_t, user_fonts_config_t;
@@ -25,7 +36,7 @@ interface(`xserver_restricted_role',`
 		type xdm_t, xdm_tmp_t;
 	')
 
-	role $1 types { xserver_t xauth_t iceauth_t };
+	role $4 types { xserver_t xauth_t iceauth_t };
 
 	# Xserver read/write client shm
 	allow xserver_t $2:fd use;
@@ -119,6 +130,12 @@ interface(`xserver_restricted_role',`
 	tunable_policy(`xserver_allow_dri',`
 		dev_rw_dri($2)
 	')
+
+	optional_policy(`
+		systemd_user_app_status($1, iceauth_t)
+		systemd_user_app_status($1, xauth_t)
+		systemd_user_app_status($1, xserver_t)
+	')
 ')
 
 ########################################
@@ -126,25 +143,36 @@ interface(`xserver_restricted_role',`
 ##	Rules required for using the X Windows server
 ##	and environment.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
-##	Domain allowed access.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
-interface(`xserver_role',`
+template(`xserver_role',`
 	gen_require(`
 		type iceauth_home_t, xserver_t, xserver_tmp_t, xserver_tmpfs_t, xauth_home_t;
 		type user_fonts_t, user_fonts_cache_t, user_fonts_config_t;
 		type mesa_shader_cache_t;
 	')
 
-	xserver_restricted_role($1, $2)
+	xserver_restricted_role($1, $2, $3, $4)
 
 	# Communicate via System V shared memory.
 	allow $2 xserver_t:shm rw_shm_perms;
@@ -183,6 +211,10 @@ interface(`xserver_role',`
 	xserver_user_home_dir_filetrans_user_iceauth($2, ".ICEauthority")
 
 	xserver_read_xkb_libs($2)
+
+	optional_policy(`
+		systemd_user_app_status($1, xserver_t)
+	')
 
 	optional_policy(`
 		xdg_cache_filetrans($2, mesa_shader_cache_t, dir, "mesa_shader_cache")

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -4,23 +4,34 @@
 ## <summary>
 ##	Role access for password authentication.
 ## </summary>
-## <param name="role">
+## <param name="role_prefix">
 ##	<summary>
-##	Role allowed access.
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="user_domain">
 ##	<summary>
-##	Domain allowed access.
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access
 ##	</summary>
 ## </param>
 #
-interface(`auth_role',`
+template(`auth_role',`
 	gen_require(`
 		type chkpwd_t, chkpwd_exec_t, shadow_t;
 	')
 
-	role $1 types chkpwd_t;
+	role $4 types chkpwd_t;
 
 	# Transition from the user domain to this domain.
 	domtrans_pattern($2, chkpwd_exec_t, chkpwd_t)

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -187,7 +187,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	spamassassin_role(unconfined_r, unconfined_t)
+	spamassassin_role(unconfined, unconfined_t, unconfined_application_exec_domain, unconfined_r)
 ')
 
 optional_policy(`

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -165,7 +165,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	pyzor_role(unconfined_r, unconfined_t)
+	pyzor_role(unconfined, unconfined_t, unconfined_application_exec_domain, unconfined_r)
 ')
 
 optional_policy(`

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -113,7 +113,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	java_run_unconfined(unconfined_t, unconfined_r)
+	java_run_unconfined(unconfined_application_exec_domain, unconfined_r)
 ')
 
 optional_policy(`

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -224,7 +224,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	xserver_role(unconfined_r, unconfined_t)
+	xserver_role(unconfined, unconfined_t, unconfined_application_exec_domain, unconfined_r)
 	xserver_dbus_chat_xdm(unconfined_t)
 ')
 

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -84,7 +84,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	cron_unconfined_role(unconfined_r, unconfined_t)
+	cron_unconfined_role(unconfined, unconfined_t, unconfined_application_exec_domain, unconfined_r)
 ')
 
 optional_policy(`

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -137,7 +137,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	mta_role(unconfined_r, unconfined_t)
+	mta_role(unconfined, unconfined_t, unconfined_application_exec_domain, unconfined_r)
 ')
 
 optional_policy(`

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -191,7 +191,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	syncthing_role(unconfined_r, unconfined_t)
+	syncthing_role(unconfined, unconfined_t, unconfined_application_exec_domain, unconfined_r)
 ')
 
 optional_policy(`

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -72,7 +72,7 @@ ifdef(`init_systemd',`
 
 optional_policy(`
 	apache_run_helper(unconfined_t, unconfined_r)
-	apache_role(unconfined_r, unconfined_t)
+	apache_role(unconfined, unconfined_t, unconfined_application_exec_domain, unconfined_r)
 ')
 
 optional_policy(`

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -101,7 +101,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	hadoop_role(unconfined_r, unconfined_t)
+	hadoop_role(unconfined, unconfined_t, unconfined_application_exec_domain, unconfined_r)
 ')
 
 optional_policy(`

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1142,7 +1142,7 @@ template(`userdom_restricted_xwindows_user_template',`
 	')
 
 	optional_policy(`
-		java_role($1_r, $1_t)
+		java_role($1, $1_t, $1_application_exec_domain, $1_r)
 	')
 
 	optional_policy(`

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1133,7 +1133,7 @@ template(`userdom_restricted_xwindows_user_template',`
 		')
 
 		optional_policy(`
-			gnome_role_template($1, $1_r, $1_t)
+			gnome_role_template($1, $1_t, $1_application_exec_domain, $1_r)
 		')
 
 		optional_policy(`

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1137,7 +1137,7 @@ template(`userdom_restricted_xwindows_user_template',`
 		')
 
 		optional_policy(`
-			wm_role_template($1, $1_r, $1_t)
+			wm_role_template($1, $1_t, $1_application_exec_domain, $1_r)
 		')
 	')
 

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1103,7 +1103,7 @@ template(`userdom_restricted_xwindows_user_template',`
 	# Local policy
 	#
 
-	auth_role($1_r, $1_t)
+	auth_role($1, $1_t, $1_application_exec_domain, $1_r)
 	auth_search_pam_console_data($1_t)
 
 	dev_read_sound($1_t)

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1118,7 +1118,7 @@ template(`userdom_restricted_xwindows_user_template',`
 	logging_send_audit_msgs($1_t)
 	selinux_get_enforce_mode($1_t)
 
-	xserver_restricted_role($1_r, $1_t)
+	xserver_restricted_role($1, $1_t, $1_application_exec_domain, $1_r)
 
 	optional_policy(`
 		alsa_read_config($1_t)

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1146,7 +1146,7 @@ template(`userdom_restricted_xwindows_user_template',`
 	')
 
 	optional_policy(`
-		pulseaudio_role($1_r, $1_t)
+		pulseaudio_role($1, $1_t, $1_application_exec_domain, $1_r)
 	')
 
 	optional_policy(`


### PR DESCRIPTION
This is the second part of the effort previously started in #381.

This PR modifies the calls to every `_role()` and `_role_template()` to use the new `$1_application_exec_domain` where appropriate, while still standardizing these role calls to use this format: `myapp_role[_template](user, user_t, user_application_exec_domain, user_r)`. This PR does not touch any role interfaces that do not have any callers.

`$1_application_exec_domain` only gets permissions needed to execute and transition to other applications, as well as using `stream_connect()` on them if it was previously given to userdomains. `$1_application_exec_domain` does not get access to read or modify application data explicitly.

Additionally, `$1_systemd_t` gets the permissions needed to monitor applications started by users in order to capture output to `journald`, check their state, and so on.

Lastly, `sudo`, `su`, and `shutdown` get a new tunable (default off) to control whether `$1_application_exec_domain` should have access to execute these administrative applications.

Fixes #365 