### PR TITLE
sysadm: allow sysadm to run rpcinfo

### DIFF
--- a/policy/modules/services/rpcbind.if
+++ b/policy/modules/services/rpcbind.if
@@ -162,4 +162,6 @@ interface(`rpcbind_admin',`
 
 	files_search_var_lib($1)
 	admin_pattern($1, rpcbind_var_lib_t)
+
+	rpcbind_stream_connect($1)
 ')


### PR DESCRIPTION
Fixes:
$ rpcinfo
rpcinfo: can't contact rpcbind: RPC: Remote system error - Permission denied

avc:  denied  { connectto } for  pid=543 comm="rpcinfo"
path="/run/rpcbind.sock" scontext=root:sysadm_r:sysadm_t t
context=system_u:system_r:rpcbind_t tclass=unix_stream_socket
permissive=0

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>