### PR TITLE
secadm: allow secadm to read selinux policy

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1488,6 +1488,7 @@ interface(`userdom_security_admin_template',`
 	selinux_set_enforce_mode($1)
 	selinux_set_all_booleans($1)
 	selinux_set_parameters($1)
+	selinux_read_policy($1)
 
 	files_relabel_non_auth_files($1)
 	auth_relabel_shadow($1)


### PR DESCRIPTION
Fixes:
$ newrole -r secadm_r -- -c "sesearch -A -s mount_t -t shell_exec_t -c file"
[Errno 13] Permission denied: '/sys/fs/selinux/policy'

avc:  denied  { read_policy } for  pid=575 comm="python3"
scontext=root:secadm_r:secadm_t:s0-s15:c0.c1023
tcontext=system_u:object_r:security_t:s15:c0.c1023 tclass=security
permissive=0

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>