### PR TITLE
mcs: pull in changes from Fedora policy

### DIFF
--- a/policy/mcs
+++ b/policy/mcs
@@ -69,53 +69,47 @@ gen_levels(1,mcs_num_cats)
 #  - /proc/pid operations are not constrained.
 
 mlsconstrain file { read ioctl lock execute execute_no_trans }
-	(( h1 dom h2 ) or ( t1 == mcsreadall ) or
-	(( t1 != mcs_constrained_type ) and (t2 == domain)));
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain file { write setattr append unlink link rename }
-	(( h1 dom h2 ) or ( t1 == mcswriteall ) or
-	(( t1 != mcs_constrained_type ) and (t2 == domain)));
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain dir { search read ioctl lock }
-	(( h1 dom h2 ) or ( t1 == mcsreadall ) or
-	(( t1 != mcs_constrained_type ) and (t2 == domain)));
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain dir { write setattr append unlink link rename add_name remove_name }
-	(( h1 dom h2 ) or ( t1 == mcswriteall ) or
-	(( t1 != mcs_constrained_type ) and (t2 == domain)));
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain fifo_file { open }
-	(( h1 dom h2 ) or ( t1 == mcsreadall ) or
-	(( t1 != mcs_constrained_type ) and ( t2 == domain )));
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain { lnk_file chr_file blk_file sock_file } { getattr read ioctl }
-	(( h1 dom h2 ) or ( t1 == mcsreadall ) or
-	(( t1 != mcs_constrained_type ) and (t2 == domain)));
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain { lnk_file chr_file blk_file sock_file } { write setattr }
-	(( h1 dom h2 ) or ( t1 == mcswriteall ) or
-	(( t1 != mcs_constrained_type ) and (t2 == domain)));
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 # New filesystem object labels must be dominated by the relabeling subject
 # clearance, also the objects are single-level.
 mlsconstrain file { create relabelto }
-	(( h1 dom h2 ) and ( l2 eq h2 ));
+	((( h1 dom h2 ) and ( l2 eq h2 )) or
+	 ( t1 != mcs_constrained_type ));
 
 # new file labels must be dominated by the relabeling subject clearance
 mlsconstrain { dir file lnk_file chr_file blk_file sock_file fifo_file } { relabelfrom }
-	( h1 dom h2 );
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain { dir file lnk_file chr_file blk_file sock_file fifo_file } { create relabelto }
-	(( h1 dom h2 ) and ( l2 eq h2 ));
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain process { transition dyntransition }
-	(( h1 dom h2 ) or ( t1 == mcssetcats ));
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain process { ptrace }
-	(( h1 dom h2) or ( t1 == mcsptraceall ));
+	(( h1 dom h2) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain process { sigkill sigstop }
-	(( h1 dom h2 ) or ( t1 == mcskillall ));
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain process { signal }
 	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));

--- a/policy/mcs
+++ b/policy/mcs
@@ -123,6 +123,9 @@ mlsconstrain { tcp_socket udp_socket rawip_socket sctp_socket } node_bind
 mlsconstrain key { create link read search setattr view write }
 	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
+mlsconstrain { ipc sem msgq shm } { create destroy setattr write unix_write }
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
+
 #
 # MCS policy for SELinux-enabled databases
 #

--- a/policy/mcs
+++ b/policy/mcs
@@ -173,7 +173,7 @@ mlsconstrain { tcp_socket udp_socket rawip_socket } node_bind
 # because the subject in this particular case is the remote domain which is
 # writing data out the network node which is acting as the object
 mlsconstrain { node } { recvfrom sendto }
-	(( l1 dom l2 ) or ( t1 != msc_constrained_type ));
+	(( l1 dom l2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain { packet peer } { recv }
 	(( l1 dom l2 ) or

--- a/policy/mcs
+++ b/policy/mcs
@@ -99,6 +99,9 @@ mlsconstrain file { create relabelto }
 mlsconstrain { dir file lnk_file chr_file blk_file sock_file fifo_file } { relabelfrom }
 	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
+mlsconstrain { file lnk_file fifo_file } { create relabelto }
+	(( l2 eq h2 ) or ( t1 != mcs_constrained_type ));
+
 mlsconstrain { dir file lnk_file chr_file blk_file sock_file fifo_file } { create relabelto }
 	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 

--- a/policy/mcs
+++ b/policy/mcs
@@ -133,41 +133,41 @@ mlsconstrain context contains
 # Any database object must be dominated by the relabeling subject
 # clearance, also the objects are single-level.
 mlsconstrain { db_database db_schema db_table db_sequence db_view db_procedure db_language db_column db_blob } { create relabelto }
-	(( h1 dom h2 ) and ( l2 eq h2 ));
+	((( h1 dom h2 ) and ( l2 eq h2 )) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain { db_tuple } { insert relabelto }
-	(( h1 dom h2 ) and ( l2 eq h2 ));
+	((( h1 dom h2 ) and ( l2 eq h2 )) or ( t1 != mcs_constrained_type ));
 
 # Access control for any database objects based on MCS rules.
 mlsconstrain db_database { drop getattr setattr relabelfrom access install_module load_module get_param set_param }
-	( h1 dom h2 );
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain db_schema { drop getattr setattr relabelfrom search }
-	( h1 dom h2 );
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain db_table { drop getattr setattr relabelfrom select update insert delete lock }
-	( h1 dom h2 );
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain db_column { drop getattr setattr relabelfrom select update insert }
-	( h1 dom h2 );
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain db_tuple { relabelfrom select update delete use }
-	( h1 dom h2 );
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain db_sequence { drop getattr setattr relabelfrom get_value next_value set_value }
-	( h1 dom h2 );
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain db_view { drop getattr setattr relabelfrom expand }
-	( h1 dom h2 );
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain db_procedure { drop getattr setattr relabelfrom execute install entrypoint }
-	( h1 dom h2 );
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain db_language { drop getattr setattr relabelfrom execute }
-	( h1 dom h2 );
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain db_blob { drop getattr setattr relabelfrom read write import export }
-	( h1 dom h2 );
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain { tcp_socket udp_socket rawip_socket } node_bind
 	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));

--- a/policy/mcs
+++ b/policy/mcs
@@ -91,16 +91,13 @@ mlsconstrain { lnk_file chr_file blk_file sock_file } { write setattr }
 
 # New filesystem object labels must be dominated by the relabeling subject
 # clearance, also the objects are single-level.
-mlsconstrain file { create relabelto }
+mlsconstrain { file lnk_file fifo_file } { create relabelto }
 	((( h1 dom h2 ) and ( l2 eq h2 )) or
 	 ( t1 != mcs_constrained_type ));
 
 # new file labels must be dominated by the relabeling subject clearance
 mlsconstrain { dir file lnk_file chr_file blk_file sock_file fifo_file } { relabelfrom }
 	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
-
-mlsconstrain { file lnk_file fifo_file } { create relabelto }
-	(( l2 eq h2 ) or ( t1 != mcs_constrained_type ));
 
 mlsconstrain { dir file lnk_file chr_file blk_file sock_file fifo_file } { create relabelto }
 	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));

--- a/policy/mcs
+++ b/policy/mcs
@@ -123,6 +123,9 @@ mlsconstrain key { create link read search setattr view write }
 mlsconstrain { ipc sem msgq shm } { create destroy setattr write unix_write }
 	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
 
+mlsconstrain context contains
+	((( h1 dom h2 ) and ( l1 domby l2 )) or ( t1 != mcs_constrained_type ));
+
 #
 # MCS policy for SELinux-enabled databases
 #

--- a/policy/mcs
+++ b/policy/mcs
@@ -166,4 +166,23 @@ mlsconstrain db_language { drop getattr setattr relabelfrom execute }
 mlsconstrain db_blob { drop getattr setattr relabelfrom read write import export }
 	( h1 dom h2 );
 
+mlsconstrain { tcp_socket udp_socket rawip_socket } node_bind
+	(( h1 dom h2 ) or ( t1 != mcs_constrained_type ));
+
+# The node recvfrom/sendto ops, the recvfrom permission is a "write" operation
+# because the subject in this particular case is the remote domain which is
+# writing data out the network node which is acting as the object
+mlsconstrain { node } { recvfrom sendto }
+	(( l1 dom l2 ) or ( t1 != msc_constrained_type ));
+
+mlsconstrain { packet peer } { recv }
+	(( l1 dom l2 ) or
+	 (( t1 != mcs_constrained_type ) and ( t2 != mcs_constrained_type )));
+
+# The netif ingress/egress ops, the ingress permission is a "write" operation
+# because the subject in this particular case is the remote domain which is
+# writing data out the network interface which is acting as the object
+mlsconstrain { netif } { egress ingress }
+	(( l1 dom l2 ) or ( t1 != mcs_constrained_type ));
+
 ') dnl end enable_mcs

--- a/policy/modules/admin/rpm.te
+++ b/policy/modules/admin/rpm.te
@@ -313,8 +313,6 @@ fs_mount_xattr_fs(rpm_script_t)
 fs_unmount_xattr_fs(rpm_script_t)
 fs_search_auto_mountpoints(rpm_script_t)
 
-mcs_killall(rpm_script_t)
-
 mls_file_read_all_levels(rpm_script_t)
 mls_file_write_all_levels(rpm_script_t)
 

--- a/policy/modules/admin/tmpreaper.te
+++ b/policy/modules/admin/tmpreaper.te
@@ -34,8 +34,6 @@ files_read_var_lib_files(tmpreaper_t)
 files_purge_tmp(tmpreaper_t)
 files_setattr_all_tmp_dirs(tmpreaper_t)
 
-mcs_file_read_all(tmpreaper_t)
-mcs_file_write_all(tmpreaper_t)
 mls_file_read_all_levels(tmpreaper_t)
 mls_file_write_all_levels(tmpreaper_t)
 

--- a/policy/modules/kernel/corenetwork.te.in
+++ b/policy/modules/kernel/corenetwork.te.in
@@ -53,6 +53,7 @@ network_packet_simple(icmp)
 #
 type netlabel_peer_t;
 sid netmsg gen_context(system_u:object_r:netlabel_peer_t,mls_systemhigh)
+mcs_constrained(netlabel_peer_t)
 
 #
 # port_t is the default type of INET port numbers.

--- a/policy/modules/kernel/mcs.if
+++ b/policy/modules/kernel/mcs.if
@@ -44,11 +44,7 @@ interface(`mcs_constrained',`
 ## <rolecap/>
 #
 interface(`mcs_file_read_all',`
-	gen_require(`
-		attribute mcsreadall;
-	')
-
-	typeattribute $1 mcsreadall;
+	refpolicywarn(`$0() has been deprecated, please remove mcs_constrained() instead.')
 ')
 
 ########################################
@@ -64,11 +60,7 @@ interface(`mcs_file_read_all',`
 ## <rolecap/>
 #
 interface(`mcs_file_write_all',`
-	gen_require(`
-		attribute mcswriteall;
-	')
-
-	typeattribute $1 mcswriteall;
+	refpolicywarn(`$0() has been deprecated, please remove mcs_constrained() instead.')
 ')
 
 ########################################
@@ -84,11 +76,7 @@ interface(`mcs_file_write_all',`
 ## <rolecap/>
 #
 interface(`mcs_killall',`
-	gen_require(`
-		attribute mcskillall;
-	')
-
-	typeattribute $1 mcskillall;
+	refpolicywarn(`$0() has been deprecated, please remove mcs_constrained() instead.')
 ')
 
 ########################################
@@ -104,11 +92,7 @@ interface(`mcs_killall',`
 ## </param>
 #
 interface(`mcs_ptrace_all',`
-	gen_require(`
-		attribute mcsptraceall;
-	')
-
-	typeattribute $1 mcsptraceall;
+	refpolicywarn(`$0() has been deprecated, please remove mcs_constrained() instead.')
 ')
 
 ########################################

--- a/policy/modules/services/policykit.te
+++ b/policy/modules/services/policykit.te
@@ -265,8 +265,6 @@ can_exec(policykit_resolve_t, policykit_resolve_exec_t)
 
 domtrans_pattern(policykit_resolve_t, policykit_auth_exec_t, policykit_auth_t)
 
-mcs_ptrace_all(policykit_resolve_t)
-
 auth_use_nsswitch(policykit_resolve_t)
 
 userdom_read_all_users_state(policykit_resolve_t)

--- a/policy/modules/services/postfix.te
+++ b/policy/modules/services/postfix.te
@@ -292,8 +292,6 @@ domain_use_interactive_fds(postfix_master_t)
 
 files_search_tmp(postfix_master_t)
 
-mcs_file_read_all(postfix_master_t)
-
 term_dontaudit_search_ptys(postfix_master_t)
 
 hostname_exec(postfix_master_t)
@@ -564,9 +562,6 @@ allow postfix_pickup_t postfix_spool_maildrop_t:dir list_dir_perms;
 read_files_pattern(postfix_pickup_t, postfix_spool_maildrop_t, postfix_spool_maildrop_t)
 delete_files_pattern(postfix_pickup_t, postfix_spool_maildrop_t, postfix_spool_maildrop_t)
 
-mcs_file_read_all(postfix_pickup_t)
-mcs_file_write_all(postfix_pickup_t)
-
 optional_policy(`
 	dbus_system_bus_client(postfix_pickup_t)
 	init_dbus_chat(postfix_pickup_t)
@@ -634,9 +629,6 @@ allow postfix_postdrop_t postfix_local_t:unix_stream_socket { read write };
 
 # for /var/spool/postfix/public/pickup
 stream_connect_pattern(postfix_postdrop_t, postfix_public_t, postfix_public_t, postfix_master_t)
-
-mcs_file_read_all(postfix_postdrop_t)
-mcs_file_write_all(postfix_postdrop_t)
 
 term_dontaudit_use_all_ptys(postfix_postdrop_t)
 term_dontaudit_use_all_ttys(postfix_postdrop_t)
@@ -742,8 +734,6 @@ allow postfix_showq_t postfix_spool_maildrop_t:file read_file_perms;
 allow postfix_showq_t postfix_spool_maildrop_t:lnk_file read_lnk_file_perms;
 
 allow postfix_showq_t postfix_spool_t:file read_file_perms;
-
-mcs_file_read_all(postfix_showq_t)
 
 term_use_all_ptys(postfix_showq_t)
 term_use_all_ttys(postfix_showq_t)

--- a/policy/modules/services/watchdog.te
+++ b/policy/modules/services/watchdog.te
@@ -76,8 +76,6 @@ auth_append_login_records(watchdog_t)
 
 logging_send_syslog_msg(watchdog_t)
 
-mcs_killall(watchdog_t)
-
 miscfiles_read_localization(watchdog_t)
 
 sysnet_dns_name_resolve(watchdog_t)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -212,7 +212,6 @@ fs_list_inotifyfs(init_t)
 fs_write_ramfs_sockets(init_t)
 
 mcs_process_set_categories(init_t)
-mcs_killall(init_t)
 
 mls_file_read_all_levels(init_t)
 mls_file_write_all_levels(init_t)
@@ -790,11 +789,6 @@ fs_getattr_all_fs(initrc_t)
 fs_search_all(initrc_t)
 fs_getattr_nfsd_files(initrc_t)
 
-# initrc_t needs to do a pidof which requires ptrace
-mcs_ptrace_all(initrc_t)
-mcs_file_read_all(initrc_t)
-mcs_file_write_all(initrc_t)
-mcs_killall(initrc_t)
 mcs_process_set_categories(initrc_t)
 
 mls_file_read_all_levels(initrc_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -193,7 +193,6 @@ init_daemon_domain(systemd_notify_t, systemd_notify_exec_t)
 type systemd_nspawn_t;
 type systemd_nspawn_exec_t;
 init_system_domain(systemd_nspawn_t, systemd_nspawn_exec_t)
-mcs_killall(systemd_nspawn_t)
 
 type systemd_nspawn_runtime_t alias systemd_nspawn_var_run_t;
 files_runtime_file(systemd_nspawn_runtime_t)

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -141,8 +141,6 @@ fs_read_cgroup_files(udev_t)
 fs_rw_anon_inodefs_files(udev_t)
 fs_search_tracefs(udev_t)
 
-mcs_ptrace_all(udev_t)
-
 mls_file_read_all_levels(udev_t)
 mls_file_write_all_levels(udev_t)
 mls_file_upgrade(udev_t)

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -30,9 +30,6 @@ domtrans_pattern(unconfined_t, unconfined_execmem_exec_t, unconfined_execmem_t)
 
 files_create_boot_flag(unconfined_t)
 
-mcs_killall(unconfined_t)
-mcs_ptrace_all(unconfined_t)
-
 libs_run_ldconfig(unconfined_t, unconfined_r)
 
 logging_send_syslog_msg(unconfined_t)


### PR DESCRIPTION
Pull in some changes from the Fedora policy's MCS constraints.

Most notably, the MCS override attributes were deprecated in favor of `mcs_constrained_type`. This means that domains will have unchecked access to objects with categories UNLESS the domain is `mcs_constrained_type`. This alleviates confusion between the MCS overrides and `mcs_constrained_type` to imply that a domain must be MCS-constrained to have MCS checks at all.

Other changes include additional constraints to miscellaneous IPC objects, node "write" operations, and netif egress/ingress operations.