### PR TITLE
iscsid fix denials

### DIFF
--- a/policy/modules/system/iscsi.te
+++ b/policy/modules/system/iscsi.te
@@ -66,6 +66,7 @@ files_runtime_filetrans(iscsid_t, iscsi_runtime_t, file)
 
 can_exec(iscsid_t, iscsid_exec_t)
 
+kernel_read_crypto_sysctls(iscsid_t)
 kernel_read_network_state(iscsid_t)
 kernel_read_system_state(iscsid_t)
 kernel_request_load_module(iscsid_t)


### PR DESCRIPTION
Allow iscsid to request kernel load modules and check FIPS state.

Signed-off-by: Dave Sugar <dsugar100@gmail.com>