### PR TITLE
Split noxattrfs access

### DIFF
--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -306,7 +306,7 @@ dev_node(urandom_device_t)
 #
 type usbfs_t;
 files_mountpoint(usbfs_t)
-fs_noxattr_type(usbfs_t)
+fs_pseudo_type(usbfs_t)
 genfscon usbfs / gen_context(system_u:object_r:usbfs_t,s0)
 genfscon usbdevfs / gen_context(system_u:object_r:usbfs_t,s0)
 

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -46,6 +46,27 @@ interface(`fs_noxattr_type',`
 ########################################
 ## <summary>
 ##	Transform specified type into a filesystem
+##	type which is a pseudo filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_pseudo_type',`
+	gen_require(`
+		attribute pseudofs;
+	')
+
+	fs_type($1)
+
+	typeattribute $1 pseudofs;
+')
+
+########################################
+## <summary>
+##	Transform specified type into a filesystem
 ##	image file type.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -9,6 +9,7 @@ attribute filesystem_image_file_type;
 attribute filesystem_type;
 attribute filesystem_unconfined_type;
 attribute noxattrfs;
+attribute pseudofs;
 attribute xattrfs;
 
 ##############################
@@ -103,7 +104,7 @@ files_mountpoint(ecryptfs_t)
 genfscon ecryptfs / gen_context(system_u:object_r:ecryptfs_t,s0)
 
 type efivarfs_t;
-fs_noxattr_type(efivarfs_t)
+fs_pseudo_type(efivarfs_t)
 files_mountpoint(efivarfs_t)
 genfscon efivarfs / gen_context(system_u:object_r:efivarfs_t,s0)
 


### PR DESCRIPTION
<del>`noxattrfs` is an attribute given to filesystems and mountpoints that do not or should not support/have extended attributes. Unfortunately, the interfaces that grant access to these types of files are way too permissive and can result in, for example, unprivileged users having complete read access to things such as the EFI variable filesystem or container files.</del>

<del>This PR adds corresponding interfaces to manage access to each of these types of filesystems and splits calls to them, where appropriate. The result is mostly unchanged from the previous behavior, with the only noticeable effect being that some domains no longer have access to VM files, container files, or the EFI variable filesystem.</del>

Split noxattrfs out into filesystems which are pseudo filesystems and actual filesystems intended for storing files. This stops unprivileged users from having blanket access to `efivarfs` and `usbfs`.