### PR TITLE
sshd: allow to run /usr/bin/fipscheck (to check fips state)

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -248,8 +248,12 @@ manage_files_pattern(sshd_t, sshd_tmp_t, sshd_tmp_t)
 manage_sock_files_pattern(sshd_t, sshd_tmp_t, sshd_tmp_t)
 files_tmp_filetrans(sshd_t, sshd_tmp_t, { dir file sock_file })
 
-kernel_search_key(sshd_t)
+# to exec /usr/bin/fipscheck
+corecmd_exec_bin(sshd_t)
+
 kernel_link_key(sshd_t)
+kernel_read_crypto_sysctls(sshd_t)
+kernel_search_key(sshd_t)
 
 term_use_all_ptys(sshd_t)
 term_setattr_all_ptys(sshd_t)


### PR DESCRIPTION
type=AVC msg=audit(1634644085.903:245): avc:  denied  { search } for pid=1825 comm="sshd" name="crypto" dev="proc" ino=1386 scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_crypto_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1634644085.903:245): avc:  denied  { read } for pid=1825 comm="sshd" name="fips_enabled" dev="proc" ino=1387 scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_crypto_t:s0 tclass=file permissive=1
type=AVC msg=audit(1634644085.903:245): avc:  denied  { open } for pid=1825 comm="sshd" path="/proc/sys/crypto/fips_enabled" dev="proc" ino=1387 scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_crypto_t:s0 tclass=file permissive=1
type=SYSCALL msg=audit(1634644085.903:245): arch=c000003e syscall=2 success=yes exit=3 a0=7f905129f682 a1=0 a2=1 a3=7ffdda768660 items=0 ppid=1 pid=1825 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="sshd" exe="/usr/sbin/sshd" subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(1634644085.905:247): avc:  denied  { getattr } for pid=1825 comm="sshd" path="/proc/sys/crypto/fips_enabled" dev="proc" ino=1387 scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_crypto_t:s0 tclass=file permissive=1
type=SYSCALL msg=audit(1634644085.905:247): arch=c000003e syscall=5 success=yes exit=0 a0=3 a1=7ffdda768fc0 a2=7ffdda768fc0 a3=0 items=0 ppid=1 pid=1825 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="sshd" exe="/usr/sbin/sshd" subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(1634644085.944:258): avc:  denied  { execute } for pid=1913 comm="sshd" name="fipscheck" dev="dm-2" ino=283611 scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1
type=AVC msg=audit(1634644085.944:258): avc:  denied  { read open } for pid=1913 comm="sshd" path="/usr/bin/fipscheck" dev="dm-2" ino=283611 scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1
type=AVC msg=audit(1634644085.944:258): avc:  denied  { execute_no_trans } for  pid=1913 comm="sshd" path="/usr/bin/fipscheck" dev="dm-2" ino=283611 scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1
type=AVC msg=audit(1634644085.944:258): avc:  denied  { map } for pid=1913 comm="fipscheck" path="/usr/bin/fipscheck" dev="dm-2" ino=283611 scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1
type=SYSCALL msg=audit(1634644085.944:258): arch=c000003e syscall=59 success=yes exit=0 a0=7f9051ff76ba a1=55ce27ee83c0 a2=7f90521f8118 a3=7ffdda766ca0 items=0 ppid=1825 pid=1913 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="fipscheck" exe="/usr/bin/fipscheck" subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 key=(null)

Signed-off-by: Dave Sugar <dsugar100@gmail.com>