### PR TITLE
bind: fixes for bind

### DIFF
--- a/policy/modules/services/bind.fc
+++ b/policy/modules/services/bind.fc
@@ -1,8 +1,10 @@
 /etc/rc\.d/init\.d/named	--	gen_context(system_u:object_r:named_initrc_exec_t,s0)
+/etc/rc\.d/init\.d/bind	--	gen_context(system_u:object_r:named_initrc_exec_t,s0)
 /etc/rc\.d/init\.d/unbound	--	gen_context(system_u:object_r:named_initrc_exec_t,s0)
 
 /etc/bind(/.*)?	gen_context(system_u:object_r:named_zone_t,s0)
 /etc/bind/named\.conf.*	--	gen_context(system_u:object_r:named_conf_t,s0)
+/etc/bind/rndc\.conf.*	--	gen_context(system_u:object_r:named_conf_t,s0)
 /etc/bind/rndc\.key	--	gen_context(system_u:object_r:dnssec_t,s0)
 /etc/dnssec-trigger/dnssec_trigger_server\.key	--	gen_context(system_u:object_r:dnssec_t,s0)
 /etc/named\.rfc1912\.zones	--	gen_context(system_u:object_r:named_conf_t,s0)

--- a/policy/modules/services/bind.te
+++ b/policy/modules/services/bind.te
@@ -76,7 +76,7 @@ role ndc_roles types ndc_t;
 
 allow named_t self:capability { chown dac_override fowner setgid setuid sys_chroot sys_nice sys_resource };
 dontaudit named_t self:capability sys_tty_config;
-allow named_t self:process { setsched getcap setcap setrlimit signal_perms };
+allow named_t self:process { setsched getsched getcap setcap setrlimit signal_perms };
 allow named_t self:fifo_file rw_fifo_file_perms;
 allow named_t self:unix_stream_socket { accept listen };
 allow named_t self:tcp_socket { accept listen };


### PR DESCRIPTION
* add fcontext for /etc/rc.d/init.d/bind and /etc/bind/rndc.conf
* add getsched for named process

Fixes:
avc: denied { getsched } for pid=418 comm="named"
scontext=system_u:system_r:named_t tcontext=system_u:system_r:named_t
tclass=process permissive=0

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>