### PR TITLE
passwd: allow passwd to map SELinux status page

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -322,6 +322,7 @@ mls_file_write_all_levels(passwd_t)
 mls_file_downgrade(passwd_t)
 
 selinux_get_fs_mount(passwd_t)
+selinux_use_status_page(passwd_t)
 selinux_validate_context(passwd_t)
 selinux_compute_access_vector(passwd_t)
 selinux_compute_create_context(passwd_t)


### PR DESCRIPTION
We encountered a passwd runtime error with selinux 3.3:
$ passwd user1
passwd: avc.c:73: avc_context_to_sid_raw: Assertion `avc_running'
failed.
Aborted

Fixes:
avc: denied { map } for pid=325 comm="passwd"
path="/sys/fs/selinux/status" dev="selinuxfs" ino=19 scontext=root:
sysadm_r:passwd_t tcontext=system_u:object_r:security_t tclass=file
permissive=1

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>