### PR TITLE
virt.te: Fixed typo in virtlogd_t manage_files_pattern for virt_common_runtime_t

### DIFF
--- a/policy/modules/services/virt.te
+++ b/policy/modules/services/virt.te
@@ -1376,7 +1376,7 @@ filetrans_pattern(virtlogd_t, virt_runtime_t, virtlogd_run_t, sock_file)
 files_runtime_filetrans(virtlogd_t, virtlogd_run_t, file)
 
 allow virtlogd_t virt_common_runtime_t:file append_file_perms;
-manage_files_pattern(virtlogd_t, virt_runtime_t, virt_common_runtime_t)
+manage_files_pattern(virtlogd_t, virt_common_runtime_t, virt_common_runtime_t)
 
 kernel_read_system_state(virtlogd_t)
 


### PR DESCRIPTION
Noticed this typo I made after I rebased master with my local branch.