### PR TITLE
git: fix typo in git hook exec access

### DIFF
--- a/policy/modules/services/git.if
+++ b/policy/modules/services/git.if
@@ -104,7 +104,7 @@ template(`git_client_role_template',`
 	auth_use_nsswitch($1_git_t)
 
 	# allow userdomains to exec git hooks
-	exec_files_pattern($3, git_home_t, git_home_t)
+	exec_files_pattern($3, git_home_hook_t, git_home_hook_t)
 	# transition back to the user domain when executing git hooks
 	domtrans_pattern($1_git_t, git_home_t, $3)
 


### PR DESCRIPTION
I missed this in my original PR for the git private type. This ensures that userdomains can execute git hooks instead of `git_home_t` files.