### PR TITLE
wine: fix roleattribute statement

### DIFF
--- a/policy/modules/apps/wine.if
+++ b/policy/modules/apps/wine.if
@@ -33,7 +33,7 @@ template(`wine_role',`
 		type wine_home_t;
 	')
 
-	roleattribute $1 wine_roles;
+	roleattribute $4 wine_roles;
 
 	domtrans_pattern($3, wine_exec_t, wine_t)
 


### PR DESCRIPTION
Missed this in the last PR since this template does not have any callers in refpolicy and so the build problem went unnoticed.

It does, however, have callers in Gentoo's policy which is where a build error was encountered.