### PR TITLE
Various systemd fixes

### DIFF
--- a/policy/modules/services/ntp.te
+++ b/policy/modules/services/ntp.te
@@ -94,6 +94,7 @@ can_exec(ntpd_t, ntpd_exec_t)
 kernel_read_kernel_sysctls(ntpd_t)
 kernel_read_system_state(ntpd_t)
 kernel_read_network_state(ntpd_t)
+kernel_read_crypto_sysctls(ntpd_t)
 kernel_request_load_module(ntpd_t)
 
 corenet_all_recvfrom_netlabel(ntpd_t)

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -214,6 +214,7 @@ template(`ssh_server_template', `
 
 	kernel_read_kernel_sysctls($1_t)
 	kernel_read_network_state($1_t)
+	kernel_read_crypto_sysctls($1_t)
 
 	corenet_all_recvfrom_netlabel($1_t)
 	corenet_tcp_sendrecv_generic_if($1_t)

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -517,6 +517,7 @@ userdom_dontaudit_search_user_home_dirs(syslogd_t)
 
 ifdef(`init_systemd',`
 	# for systemd-journal
+	allow syslogd_t self:capability audit_control;
 	allow syslogd_t self:netlink_audit_socket connected_socket_perms;
 	allow syslogd_t self:capability2 audit_read;
 	allow syslogd_t self:capability { chown setgid setuid sys_ptrace };

--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -488,6 +488,26 @@ interface(`miscfiles_read_hwdata',`
 
 ########################################
 ## <summary>
+##	Allow process to get the attributes of localization info
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`miscfiles_getattr_localization',`
+	gen_require(`
+		type locale_t;
+	')
+
+	files_search_usr($1)
+	allow $1 locale_t:dir list_dir_perms;
+	allow $1 locale_t:file getattr;
+')
+
+########################################
+## <summary>
 ##	Allow process to setattr localization info
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -438,11 +438,12 @@ allow systemd_generator_t self:capability dac_override;
 allow systemd_generator_t self:process setfscreate;
 
 corecmd_exec_shell(systemd_generator_t)
-corecmd_getattr_bin_files(systemd_generator_t)
+corecmd_exec_bin(systemd_generator_t)
 
 dev_read_sysfs(systemd_generator_t)
 dev_write_kmsg(systemd_generator_t)
 dev_write_sysfs_dirs(systemd_generator_t)
+dev_read_urand(systemd_generator_t)
 
 files_read_etc_files(systemd_generator_t)
 files_search_runtime(systemd_generator_t)
@@ -478,6 +479,8 @@ storage_raw_read_fixed_disk(systemd_generator_t)
 systemd_log_parse_environment(systemd_generator_t)
 
 term_use_unallocated_ttys(systemd_generator_t)
+
+udev_search_runtime(systemd_generator_t)
 
 ifdef(`distro_gentoo',`
 	corecmd_shell_entry_type(systemd_generator_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -45,14 +45,6 @@ gen_tunable(systemd_socket_proxyd_bind_any, false)
 ## </desc>
 gen_tunable(systemd_socket_proxyd_connect_any, false)
 
-## <desc>
-## <p>
-## Allow systemd-tmpfilesd to populate missing configuration files from factory
-## template directory.
-## </p>
-## </desc>
-gen_tunable(systemd_tmpfilesd_factory, false)
-
 attribute systemd_log_parse_env_type;
 attribute systemd_tmpfiles_conf_type;
 attribute systemd_user_session_type;
@@ -1342,6 +1334,9 @@ allow systemd_tmpfiles_t self:process { setfscreate getcap };
 allow systemd_tmpfiles_t systemd_coredump_var_lib_t:dir { manage_dir_perms relabel_dir_perms };
 allow systemd_tmpfiles_t systemd_coredump_var_lib_t:file manage_file_perms;
 
+allow systemd_tmpfiles_t systemd_factory_conf_t:dir list_dir_perms;
+allow systemd_tmpfiles_t systemd_factory_conf_t:file read_file_perms;
+
 allow systemd_tmpfiles_t systemd_pstore_var_lib_t:dir { manage_dir_perms relabel_dir_perms };
 allow systemd_tmpfiles_t systemd_pstore_var_lib_t:file manage_file_perms;
 
@@ -1375,13 +1370,18 @@ files_manage_all_runtime_dirs(systemd_tmpfiles_t)
 files_delete_usr_files(systemd_tmpfiles_t)
 files_list_home(systemd_tmpfiles_t)
 files_list_locks(systemd_tmpfiles_t)
+files_manage_config_dirs(systemd_tmpfiles_t)
+files_manage_config_files(systemd_tmpfiles_t)
 files_manage_generic_tmp_dirs(systemd_tmpfiles_t)
 files_manage_var_dirs(systemd_tmpfiles_t)
 files_manage_var_lib_dirs(systemd_tmpfiles_t)
+files_manage_all_locks(systemd_tmpfiles_t)
 files_purge_tmp(systemd_tmpfiles_t)
 files_read_etc_files(systemd_tmpfiles_t)
 files_read_etc_runtime_files(systemd_tmpfiles_t)
-files_relabel_all_lock_dirs(systemd_tmpfiles_t)
+files_relabel_config_files(systemd_tmpfiles_t)
+files_relabel_config_dirs(systemd_tmpfiles_t)
+files_relabel_all_locks(systemd_tmpfiles_t)
 files_relabel_all_runtime_dirs(systemd_tmpfiles_t)
 files_relabel_all_tmp_dirs(systemd_tmpfiles_t)
 files_relabel_var_dirs(systemd_tmpfiles_t)
@@ -1430,6 +1430,7 @@ logging_setattr_syslogd_tmp_dirs(systemd_tmpfiles_t)
 
 miscfiles_manage_man_pages(systemd_tmpfiles_t)
 miscfiles_relabel_man_cache(systemd_tmpfiles_t)
+miscfiles_getattr_localization(systemd_tmpfiles_t)
 
 seutil_read_config(systemd_tmpfiles_t)
 seutil_read_file_contexts(systemd_tmpfiles_t)
@@ -1449,22 +1450,6 @@ tunable_policy(`systemd_tmpfiles_manage_all',`
 	files_manage_non_security_files(systemd_tmpfiles_t)
 	files_relabel_non_security_dirs(systemd_tmpfiles_t)
 	files_relabel_non_security_files(systemd_tmpfiles_t)
-')
-
-tunable_policy(`systemd_tmpfilesd_factory', `
-	allow systemd_tmpfiles_t systemd_factory_conf_t:dir list_dir_perms;
-	allow systemd_tmpfiles_t systemd_factory_conf_t:file read_file_perms;
-
-	files_manage_etc_files(systemd_tmpfiles_t)
-	files_relabel_config_dirs(systemd_tmpfiles_t)
-	files_relabel_config_files(systemd_tmpfiles_t)
-',`
-	dontaudit systemd_tmpfiles_t systemd_factory_conf_t:dir list_dir_perms;
-	dontaudit systemd_tmpfiles_t systemd_factory_conf_t:file read_file_perms;
-
-	files_dontaudit_manage_etc_files(systemd_tmpfiles_t)
-	files_dontaudit_relabel_config_dirs(systemd_tmpfiles_t)
-	files_dontaudit_relabel_config_files(systemd_tmpfiles_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1587,6 +1587,8 @@ fs_getattr_tmpfs(systemd_user_runtime_dir_t)
 fs_list_tmpfs(systemd_user_runtime_dir_t)
 fs_unmount_tmpfs(systemd_user_runtime_dir_t)
 fs_relabelfrom_tmpfs_dirs(systemd_user_runtime_dir_t)
+fs_read_cgroup_files(systemd_user_runtime_dir_t)
+fs_getattr_cgroup(systemd_user_runtime_dir_t)
 
 kernel_read_kernel_sysctls(systemd_user_runtime_dir_t)
 kernel_dontaudit_getattr_proc(systemd_user_runtime_dir_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -577,6 +577,7 @@ optional_policy(`
 dontaudit systemd_log_parse_env_type self:capability net_admin;
 
 kernel_read_system_state(systemd_log_parse_env_type)
+kernel_read_crypto_sysctls(systemd_log_parse_env_type)
 
 dev_write_kmsg(systemd_log_parse_env_type)
 


### PR DESCRIPTION
* fips_enabled sysctl access
* Unit generator fixes
* Revise tmpfilesd to allow writing of all config files
* User runtime dir reads cgroups
* Journald uses audit_control