### PR TITLE
ipsec: fixes for strongswan

### DIFF
--- a/policy/modules/system/ipsec.fc
+++ b/policy/modules/system/ipsec.fc
@@ -45,6 +45,7 @@
 /usr/libexec/ipsec/stroke	--	gen_context(system_u:object_r:ipsec_exec_t,s0)
 /usr/libexec/nm-openswan-service -- 	gen_context(system_u:object_r:ipsec_mgmt_exec_t,s0)
 
+/usr/sbin/charon-systemd	--	gen_context(system_u:object_r:ipsec_exec_t,s0)
 /usr/sbin/ipsec			-- 	gen_context(system_u:object_r:ipsec_mgmt_exec_t,s0)
 /usr/sbin/racoon		--	gen_context(system_u:object_r:racoon_exec_t,s0)
 /usr/sbin/setkey		--	gen_context(system_u:object_r:setkey_exec_t,s0)

--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -210,6 +210,7 @@ domtrans_pattern(ipsec_mgmt_t, ipsec_exec_t, ipsec_t)
 read_files_pattern(ipsec_mgmt_t, ipsec_t, ipsec_t)
 read_lnk_files_pattern(ipsec_mgmt_t, ipsec_t, ipsec_t)
 
+allow ipsec_mgmt_t ipsec_conf_file_t:dir list_dir_perms;
 allow ipsec_mgmt_t ipsec_conf_file_t:file read_file_perms;
 
 manage_files_pattern(ipsec_mgmt_t, ipsec_key_file_t, ipsec_key_file_t)
@@ -300,6 +301,7 @@ init_labeled_script_domtrans(ipsec_mgmt_t, ipsec_initrc_exec_t)
 logging_send_syslog_msg(ipsec_mgmt_t)
 
 miscfiles_read_localization(ipsec_mgmt_t)
+miscfiles_read_generic_certs(ipsec_mgmt_t)
 
 seutil_dontaudit_search_config(ipsec_mgmt_t)
 


### PR DESCRIPTION
* Add fcontext for charon-systemd
* Allow ipsec_mgmt_t to list ipsec_conf_file_t dir
* Allow ipsec_mgmt_t to read cert files

Fixes:
avc:  denied  { search } for  pid=372 comm="swanctl" name="strongswan.d"
dev="vda" ino=1461
scontext=system_u:system_r:ipsec_mgmt_t:s0-s15:c0.c1023
tcontext=system_u:object_r:ipsec_conf_file_t:s0 tclass=dir permissive=0

avc:  denied  { read } for  pid=372 comm="swanctl" name="strongswan.d"
dev="vda" ino=1461
scontext=system_u:system_r:ipsec_mgmt_t:s0-s15:c0.c1023
tcontext=system_u:object_r:ipsec_conf_file_t:s0 tclass=dir permissive=0

avc:  denied  { getattr } for  pid=323 comm="swanctl"
path="/etc/ssl/openssl.cnf" dev="vda" ino=1463
scontext=system_u:system_r:ipsec_mgmt_t
tcontext=system_u:object_r:cert_t tclass=file permissive=0

avc:  denied  { open } for  pid=323 comm="swanctl"
path="/etc/ssl/openssl.cnf" dev="vda" ino=1463
scontext=system_u:system_r:ipsec_mgmt_t
tcontext=system_u:object_r:cert_t tclass=file permissive=0

avc:  denied  { read } for  pid=323 comm="swanctl" name="openssl.cnf"
dev="vda" ino=1463 scontext=system_u:system_r:ipsec_mgmt_t
tcontext=system_u:object_r:cert_t tclass=file permissive=0

avc:  denied  { search } for  pid=323 comm="swanctl" name="ssl"
dev="vda" ino=1202 scontext=system_u:system_r:ipsec_mgmt_t
tcontext=system_u:object_r:cert_t tclass=dir permissive=0

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>