### PR TITLE
systemd: resolve error with systemd-sysctl

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1288,7 +1288,10 @@ systemd_log_parse_environment(systemd_sessions_t)
 # sysctl local policy
 #
 
-dontaudit systemd_sysctl_t self:capability sys_ptrace;
+# sys_admin for sysctls such as kernel.kptr_restrict and kernel.dmesg_restrict
+# sys_ptrace for kernel.yama.ptrace_scope
+allow systemd_sysctl_t self:capability { sys_admin sys_ptrace };
+dontaudit systemd_sysctl_t self:capability net_admin;
 
 kernel_read_kernel_sysctls(systemd_sysctl_t)
 kernel_request_load_module(systemd_sysctl_t)


### PR DESCRIPTION
Seeing the following errors (based on what is in /etc/sysctl.d/*)
    
Nov 30 13:38:07 localhost systemd-sysctl: Failed to write '1' to '/proc/sys/kernel/kptr_restrict': Operation not permitted
Nov 30 13:38:07 localhost systemd-sysctl: Failed to write '1' to '/proc/sys/kernel/dmesg_restrict': Operation not permitted
Nov 30 13:38:07 localhost systemd-sysctl: Failed to write '1' to '/proc/sys/kernel/yama/ptrace_scope': Operation not permitted
Nov 30 13:38:07 localhost systemd: systemd-sysctl.service: main process exited, code=exited, status=1/FAILURE

I saw the following denials (didn't save the one for sys_ptrace when setting kenel.yama.ptrace_scope):

2021-11-29T15:26:37-05:00 localhost audispd: node=localhost type=AVC msg=audit(1638199548.807:52): avc:  denied  { sys_admin } for  pid=1038 comm="systemd-sysctl" capability=21  scontext=system_u:system_r:systemd_sysctl_t:s0 tcontext=system_u:system_r:systemd_sysctl_t:s0 tclass=capability permissive=0
type=AVC msg=audit(1638278570.400:593): avc:  denied  { net_admin } for pid=1507 comm="systemd-sysctl" capability=12 scontext=system_u:system_r:systemd_sysctl_t:s0 tcontext=system_u:system_r:systemd_sysctl_t:s0 tclass=capability permissive=0
