### PR TITLE
testing: accept '@' as a valid ending character in filecon checker

### DIFF
--- a/testing/check_fc_files.py
+++ b/testing/check_fc_files.py
@@ -246,7 +246,7 @@ def analyze_fc_file(fc_path):
 
             # If the reduced path still ends with a special character, something went wrong.
             # Instead of guessing the possible buggy characters, list the allowed ones.
-            if reduced_path and not re.match(r'[-0-9A-Za-z_\]~·†∞]', reduced_path[-1]):
+            if reduced_path and not re.match(r'[-0-9A-Za-z_@\]~·†∞]', reduced_path[-1]):
                 if path != '/':
                     if reduced_path == path:
                         print(f"{prefix}unexpected end of file pattern for {path}")


### PR DESCRIPTION
Allow '@' to be a valid ending character in the file context checker. This allows the usage of `/path/to/myservice@.*` instead of only `/path/to/myservice@\.service` and similar.