### PR TITLE
ssh: do not audit attempts by ssh-keygen to read proc

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -344,6 +344,7 @@ files_etc_filetrans(ssh_keygen_t, sshd_key_t, file)
 
 kernel_read_kernel_sysctls(ssh_keygen_t)
 kernel_dontaudit_getattr_proc(ssh_keygen_t)
+kernel_dontaudit_read_system_state(ssh_keygen_t)
 
 fs_search_auto_mountpoints(ssh_keygen_t)
 


### PR DESCRIPTION
Fixes:
avc:  denied  { read } for  pid=353 comm="ssh-keygen" name="filesystems"
dev="proc" ino=4026532078 scontext=system_u:system_r:ssh_keygen_t
tcontext=system_u:object_r:proc_t tclass=file permissive=0

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>