### PR TITLE
acpid: allow acpid to watch the directories in /dev

### DIFF
--- a/policy/modules/services/acpi.te
+++ b/policy/modules/services/acpi.te
@@ -103,6 +103,7 @@ dev_read_realtime_clock(acpid_t)
 dev_read_urand(acpid_t)
 dev_rw_acpi_bios(acpid_t)
 dev_rw_sysfs(acpid_t)
+dev_watch_dev_dirs(acpid_t)
 dev_dontaudit_getattr_all_chr_files(acpid_t)
 dev_dontaudit_getattr_all_blk_files(acpid_t)
 


### PR DESCRIPTION
Fixes:
acpid: inotify_add_watch() failed: Permission denied (13)

avc:  denied  { watch } for  pid=269 comm="acpid" path="/dev/input"
dev="devtmpfs" ino=35 scontext=system_u:system_r:acpid_t:s0-s15:c0.c1023
tcontext=system_u:object_r:device_t:s0 tclass=dir permissive=0

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>