### PR TITLE
obj_perm_sets.spt: Fixed typo in rw_netlink_socket_perms.

### DIFF
--- a/policy/support/obj_perm_sets.spt
+++ b/policy/support/obj_perm_sets.spt
@@ -100,7 +100,7 @@ define(`create_netlink_socket_perms', `{ create_socket_perms nlmsg_read nlmsg_wr
 #
 # Permissions for using netlink sockets for operations that modify state.
 #
-define(`rw_netlink_socket_perms', `{ create_socket_perms nlmsg_read nlmsg_write }')
+define(`rw_netlink_socket_perms', `{ rw_socket_perms nlmsg_read nlmsg_write }')
 
 #
 # Permissions for using netlink sockets for operations that observe state.


### PR DESCRIPTION
Untested, but I think I came across this typo whilst writing policy for something else.