### PR TITLE
Remove MCS categories from default users

### DIFF
--- a/policy/modules/admin/samhain.te
+++ b/policy/modules/admin/samhain.te
@@ -35,10 +35,6 @@ role samhain_roles types samhain_t;
 samhain_service_template(samhaind)
 init_system_domain(samhaind_t, samhain_exec_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_system_domain(samhaind_t, samhain_exec_t, mcs_systemhigh)
-')
-
 ifdef(`enable_mls',`
 	init_ranged_system_domain(samhaind_t, samhain_exec_t, mls_systemhigh)
 ')

--- a/policy/modules/apps/vmware.te
+++ b/policy/modules/apps/vmware.te
@@ -42,10 +42,6 @@ userdom_user_tmp_file(vmware_tmp_t)
 type vmware_tmpfs_t;
 userdom_user_tmpfs_file(vmware_tmpfs_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(vmware_host_t, vmware_host_exec_t, s0 - mcs_systemhigh)
-')
-
 optional_policy(`
 	wm_application_domain(vmware_t, vmware_exec_t)
 ')

--- a/policy/modules/services/abrt.te
+++ b/policy/modules/services/abrt.te
@@ -100,10 +100,6 @@ type abrt_upload_watch_t, abrt_domain;
 type abrt_upload_watch_exec_t;
 init_daemon_domain(abrt_upload_watch_t, abrt_upload_watch_exec_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(abrt_t, abrt_exec_t, s0 - mcs_systemhigh)
-')
-
 ########################################
 #
 # Local policy

--- a/policy/modules/services/cron.te
+++ b/policy/modules/services/cron.te
@@ -113,10 +113,6 @@ type user_cron_spool_log_t;
 logging_log_file(user_cron_spool_log_t)
 ubac_constrained(user_cron_spool_log_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(crond_t, crond_exec_t, s0 - mcs_systemhigh)
-')
-
 optional_policy(`
 	mta_system_content(cron_spool_t)
 	mta_system_content(crond_tmp_t)

--- a/policy/modules/services/cups.te
+++ b/policy/modules/services/cups.te
@@ -96,10 +96,6 @@ files_config_file(ptal_etc_t)
 type ptal_runtime_t alias ptal_var_run_t;
 files_runtime_file(ptal_runtime_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(cupsd_t, cupsd_exec_t, s0 - mcs_systemhigh)
-')
-
 ifdef(`enable_mls',`
 	init_ranged_daemon_domain(cupsd_t, cupsd_exec_t, mls_systemhigh)
 ')

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -58,10 +58,6 @@ files_tmp_file(system_dbusd_tmp_t)
 type system_dbusd_var_lib_t;
 files_type(system_dbusd_var_lib_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_system_domain(system_dbusd_t, dbusd_exec_t, s0 - mcs_systemhigh)
-')
-
 ifdef(`enable_mls',`
 	init_ranged_system_domain(system_dbusd_t, dbusd_exec_t, s0 - mls_systemhigh)
 ')

--- a/policy/modules/services/ftp.te
+++ b/policy/modules/services/ftp.te
@@ -157,10 +157,6 @@ role system_r types sftpd_t;
 type xferlog_t;
 logging_log_file(xferlog_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(ftpd_t, ftpd_exec_t, s0 - mcs_systemhigh)
-')
-
 ifdef(`enable_mls',`
 	init_ranged_daemon_domain(ftpd_t, ftpd_exec_t, mls_systemhigh)
 ')

--- a/policy/modules/services/inetd.te
+++ b/policy/modules/services/inetd.te
@@ -28,10 +28,6 @@ files_runtime_file(inetd_child_runtime_t)
 type inetd_child_tmp_t;
 files_tmp_file(inetd_child_tmp_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(inetd_t, inetd_exec_t, s0 - mcs_systemhigh)
-')
-
 ########################################
 #
 # Local policy

--- a/policy/modules/services/oddjob.te
+++ b/policy/modules/services/oddjob.te
@@ -25,10 +25,6 @@ role oddjob_mkhomedir_roles types oddjob_mkhomedir_t;
 type oddjob_runtime_t alias oddjob_var_run_t;
 files_runtime_file(oddjob_runtime_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(oddjob_t, oddjob_exec_t, s0 - mcs_systemhigh)
-')
-
 ########################################
 #
 # Local policy

--- a/policy/modules/services/sanlock.te
+++ b/policy/modules/services/sanlock.te
@@ -34,10 +34,6 @@ logging_log_file(sanlock_log_t)
 type sanlock_runtime_t alias sanlock_var_run_t;
 files_runtime_file(sanlock_runtime_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(sanlock_t, sanlock_exec_t, s0 - mcs_systemhigh)
-')
-
 ifdef(`enable_mls',`
 	init_ranged_daemon_domain(sanlock_t, sanlock_exec_t, s0 - mls_systemhigh)
 ')

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -53,10 +53,6 @@ init_unit_file(sshd_keygen_unit_t)
 type sshd_unit_t;
 init_unit_file(sshd_unit_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(sshd_t, sshd_exec_t, s0 - mcs_systemhigh)
-')
-
 type ssh_t;
 type ssh_exec_t;
 userdom_user_application_domain(ssh_t, ssh_exec_t)

--- a/policy/modules/services/virt.te
+++ b/policy/modules/services/virt.te
@@ -167,10 +167,6 @@ init_script_file(virtd_initrc_exec_t)
 type virtd_keytab_t;
 files_type(virtd_keytab_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(virtd_t, virtd_exec_t, s0 - mcs_systemhigh)
-')
-
 ifdef(`enable_mls',`
 	init_ranged_daemon_domain(virtd_t, virtd_exec_t, s0 - mls_systemhigh)
 ')
@@ -225,11 +221,6 @@ init_daemon_domain(virtlogd_t, virtlogd_exec_t)
 
 type virtlogd_run_t;
 files_runtime_file(virtlogd_run_t)
-
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(virtlockd_t, virtlockd_exec_t, s0 - mcs_systemhigh)
-	init_ranged_daemon_domain(virtlogd_t, virtlogd_exec_t, s0 - mcs_systemhigh)
-')
 
 ifdef(`enable_mls',`
 	init_ranged_daemon_domain(virtlockd_t, virtlockd_exec_t, s0 - mls_systemhigh)

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -203,11 +203,6 @@ logging_log_file(xserver_log_t)
 type mesa_shader_cache_t;
 xdg_cache_content(mesa_shader_cache_t)
 
-ifdef(`enable_mcs',`
-	init_ranged_domain(xdm_t, xdm_exec_t, s0 - mcs_systemhigh)
-	init_ranged_daemon_domain(xdm_t, xdm_exec_t, s0 - mcs_systemhigh)
-')
-
 optional_policy(`
 	prelink_object_file(xkb_var_lib_t)
 ')

--- a/policy/modules/system/locallogin.if
+++ b/policy/modules/system/locallogin.if
@@ -16,10 +16,6 @@ interface(`locallogin_domtrans',`
 	')
 
 	auth_domtrans_login_program($1, local_login_t)
-
-	ifdef(`enable_mcs',`
-		auth_ranged_domtrans_login_program($1, local_login_t, s0 - mcs_systemhigh)
-	')
 ')
 
 ########################################

--- a/policy/modules/system/setrans.te
+++ b/policy/modules/system/setrans.te
@@ -27,10 +27,6 @@ ifdef(`distro_debian',`
 	init_daemon_runtime_file(setrans_runtime_t, dir, "setrans")
 ')
 
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(setrans_t, setrans_exec_t, s0 - mcs_systemhigh)
-')
-
 ifdef(`enable_mls',`
 	init_ranged_daemon_domain(setrans_t, setrans_exec_t, mls_systemhigh)
 ')

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -30,11 +30,6 @@ type udev_runtime_t alias { udev_tbl_t udev_var_run_t };
 files_runtime_file(udev_runtime_t)
 init_daemon_runtime_file(udev_runtime_t, dir, "udev")
 
-ifdef(`enable_mcs',`
-	kernel_ranged_domtrans_to(udev_t, udev_exec_t, s0 - mcs_systemhigh)
-	init_ranged_daemon_domain(udev_t, udev_exec_t, s0 - mcs_systemhigh)
-')
-
 ########################################
 #
 # udev Local policy

--- a/policy/users
+++ b/policy/users
@@ -15,7 +15,7 @@
 # and a user process should never be assigned the system user
 # identity.
 #
-gen_user(system_u,, system_r, s0, s0 - mls_systemhigh, mcs_allcats)
+gen_user(system_u,, system_r, s0, s0 - mls_systemhigh)
 
 #
 # user_u is a generic user identity for Linux users who have no
@@ -25,14 +25,14 @@ gen_user(system_u,, system_r, s0, s0 - mls_systemhigh, mcs_allcats)
 # permit any access to such users, then remove this entry.
 #
 gen_user(user_u, user, user_r, s0, s0)
-gen_user(staff_u, staff, staff_r sysadm_r ifdef(`enable_mls',`secadm_r auditadm_r'), s0, s0 - mls_systemhigh, mcs_allcats)
-gen_user(sysadm_u, sysadm, sysadm_r, s0, s0 - mls_systemhigh, mcs_allcats)
+gen_user(staff_u, staff, staff_r sysadm_r ifdef(`enable_mls',`secadm_r auditadm_r'), s0, s0 - mls_systemhigh)
+gen_user(sysadm_u, sysadm, sysadm_r, s0, s0 - mls_systemhigh)
 
 # Until order dependence is fixed for users:
 ifdef(`direct_sysadm_daemon',`
-        gen_user(unconfined_u, unconfined, unconfined_r system_r, s0, s0 - mls_systemhigh, mcs_allcats)
+        gen_user(unconfined_u, unconfined, unconfined_r system_r, s0, s0 - mls_systemhigh)
 ',`
-        gen_user(unconfined_u, unconfined, unconfined_r, s0, s0 - mls_systemhigh, mcs_allcats)
+        gen_user(unconfined_u, unconfined, unconfined_r, s0, s0 - mls_systemhigh)
 ')
 
 #
@@ -43,7 +43,7 @@ ifdef(`direct_sysadm_daemon',`
 # not in the sysadm_r.
 #
 ifdef(`direct_sysadm_daemon',`
-	gen_user(root, sysadm, sysadm_r staff_r ifdef(`enable_mls',`secadm_r auditadm_r') system_r, s0, s0 - mls_systemhigh, mcs_allcats)
+	gen_user(root, sysadm, sysadm_r staff_r ifdef(`enable_mls',`secadm_r auditadm_r') system_r, s0, s0 - mls_systemhigh)
 ',`
-	gen_user(root, sysadm, sysadm_r staff_r ifdef(`enable_mls',`secadm_r auditadm_r'), s0, s0 - mls_systemhigh, mcs_allcats)
+	gen_user(root, sysadm, sysadm_r staff_r ifdef(`enable_mls',`secadm_r auditadm_r'), s0, s0 - mls_systemhigh)
 ')


### PR DESCRIPTION
Remove MCS categories from the default users and remove most MCS ranged transitions as a result.

I didn't see any ranged transitions that I think needed to stay, as none of the domains I removed them from are `mcs_constrained()`.

Fixes #453 