### PR TITLE
systemd: Change journal file context to MLS system high.

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -98,4 +98,4 @@ HOME_DIR/\.local/share/systemd(/.*)?		gen_context(system_u:object_r:systemd_data
 /run/tmpfiles\.d	-d	gen_context(system_u:object_r:systemd_tmpfiles_conf_t,s0)
 /run/tmpfiles\.d/.*		<<none>>
 
-/var/log/journal(/.*)?		gen_context(system_u:object_r:systemd_journal_t,s0)
+/var/log/journal(/.*)?		gen_context(system_u:object_r:systemd_journal_t,mls_systemhigh)


### PR DESCRIPTION
Fixes issues like this: audit(1640354247.630:3): op=security_validate_transition seresult=denied oldcontext=system_u:object_r:systemd_journal_t:s15:c0.c1023 newcontext=system_u:object_r:systemd_journal_t:s0 taskcontext=system_u:system_r:systemd_tmpfiles_t:s0-s15:c0.c1023 tclass=file


Fixes #460 