### PR TITLE
snmp: Fix typo in /var/net-snmp rule

### DIFF
--- a/policy/modules/services/snmp.fc
+++ b/policy/modules/services/snmp.fc
@@ -11,7 +11,7 @@
 /usr/share/snmp/mibs/\.index	--	gen_context(system_u:object_r:snmpd_var_lib_t,s0)
 
 /var/agentx(/.*)?	gen_context(system_u:object_r:snmpd_var_lib_t,s0)
-/var/net-snmp(/.*)	gen_context(system_u:object_r:snmpd_var_lib_t,s0)
+/var/net-snmp(/.*)?	gen_context(system_u:object_r:snmpd_var_lib_t,s0)
 
 /var/lib/net-snmp(/.*)?	gen_context(system_u:object_r:snmpd_var_lib_t,s0)
 /var/lib/snmp(/.*)?	gen_context(system_u:object_r:snmpd_var_lib_t,s0)


### PR DESCRIPTION
I believe this missing ? in the .fc file must be a bug.