### PR TITLE
docker: make rootlesskit optional

### DIFF
--- a/policy/modules/services/docker.if
+++ b/policy/modules/services/docker.if
@@ -178,8 +178,6 @@ template(`docker_user_role',`
 	docker_run_user_daemon($3, $4)
 	docker_run_user_cli($3, $4)
 
-	rootlesskit_role($1, $2, $3, $4)
-
 	ifdef(`init_systemd',`
 		systemd_user_daemon_domain($1, dockerd_exec_t, dockerd_user_t)
 		systemd_user_send_systemd_notify($1, dockerd_user_t)
@@ -187,6 +185,10 @@ template(`docker_user_role',`
 
 	optional_policy(`
 		dbus_spec_session_bus_client($1, dockerd_user_t)
+	')
+
+	optional_policy(`
+		rootlesskit_role($1, $2, $3, $4)
 	')
 ')
 
@@ -229,5 +231,7 @@ interface(`docker_signal_user_daemon',`
 interface(`docker_admin',`
 	docker_run_cli($1, $2)
 
-	rootlesskit_run($1, $2)
+	optional_policy(`
+		rootlesskit_run($1, $2)
+	')
 ')

--- a/policy/modules/services/docker.te
+++ b/policy/modules/services/docker.te
@@ -125,8 +125,6 @@ mount_exec(dockerd_user_t)
 container_setattr_container_ptys(dockerd_user_t)
 container_use_container_ptys(dockerd_user_t)
 
-rootlesskit_exec(dockerd_user_t)
-
 ifdef(`init_systemd',`
 	systemd_search_user_runtime(dockerd_user_t)
 	systemd_write_user_runtime_socket(dockerd_user_t)
@@ -138,6 +136,10 @@ ifdef(`init_systemd',`
 optional_policy(`
 	dbus_getattr_session_runtime_socket(dockerd_user_t)
 	dbus_write_session_runtime_socket(dockerd_user_t)
+')
+
+optional_policy(`
+	rootlesskit_exec(dockerd_user_t)
 ')
 
 ########################################


### PR DESCRIPTION
Avoid a potential build error and circular dependency by making rootlesskit optional. Note that rootlesskit is still required in order for rootless docker to function.