### PR TITLE
Revert "tests.yml: Disable policy_module() selint checks."

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,12 +36,11 @@ jobs:
     - name: Run file context checker
       run: python3 -t -t -E -W error testing/check_fc_files.py
 
-# Disable selint until it can handle a single parameter policy_module().
-#    - name: Run SELint
-#      run: |
-#        # disable C-005 (Permissions in av rule or class declaration not ordered) for now: needs fixing
-#        # disable W-005 (Interface call from module not in optional_policy block): refpolicy does not follow this rule
-#        #selint --source --recursive --summary --fail --disable C-005 --disable W-005 policy
+    - name: Run SELint
+      run: |
+        # disable C-005 (Permissions in av rule or class declaration not ordered) for now: needs fixing
+        # disable W-005 (Interface call from module not in optional_policy block): refpolicy does not follow this rule
+        selint --source --recursive --summary --fail --disable C-005 --disable W-005 policy
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit 5781a2393cfbc6592cf52abff1eda08afb15c898.

SELint 1.2.1 supports the new policy_module syntax.

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>