### PR TITLE
docker: add missing call to init_daemon_domain()

### DIFF
--- a/policy/modules/services/docker.te
+++ b/policy/modules/services/docker.te
@@ -10,6 +10,7 @@ container_system_engine(dockerd_t)
 type dockerd_exec_t;
 container_engine_executable_file(dockerd_exec_t)
 application_domain(dockerd_t, dockerd_exec_t)
+init_daemon_domain(dockerd_t, dockerd_exec_t)
 ifdef(`enable_mls',`
 	init_ranged_daemon_domain(dockerd_t, dockerd_exec_t, s0 - mls_systemhigh)
 ')


### PR DESCRIPTION
Looks like I forgot to add this back at some point while reworking. Oops...