### PR TITLE
domain: Allow lockdown for all domains.

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -103,6 +103,11 @@ kernel_dontaudit_link_key(domain)
 # create child processes in the domain
 allow domain self:process { fork sigchld };
 
+# lockdown checks were removed in 5.16.  The class will be removed
+# from the policy in the future. For reference:
+# https://lore.kernel.org/selinux/163243191040.178880.4295195865966623164.stgit@olly
+allow domain self:lockdown { integrity confidentiality };
+
 # glibc get_nprocs requires read access to /sys/devices/system/cpu/online
 dev_read_cpu_online(domain)
 


### PR DESCRIPTION
The checks for this class were removed in 5.16.  This object class will be removed in the future.

For more info:
https://lore.kernel.org/selinux/163243191040.178880.4295195865966623164.stgit@olly
