### PR TITLE
Add udica templates

### DIFF
--- a/udica-templates/base_container.cil
+++ b/udica-templates/base_container.cil
@@ -1,0 +1,77 @@
+;;
+;; Permission sets definitions
+;;
+
+(classpermission search_dir_perms)
+(classpermissionset search_dir_perms (dir (getattr search)))
+
+(classpermission list_dir_perms)
+(classpermissionset list_dir_perms (dir (getattr search open read lock ioctl)))
+
+(classpermission rw_dir_perms)
+(classpermissionset rw_dir_perms (dir (open read getattr lock search ioctl add_name remove_name write)))
+
+(classpermission manage_dir_perms)
+(classpermissionset manage_dir_perms (dir (create open getattr setattr read write link unlink rename search add_name remove_name reparent rmdir lock ioctl)))
+
+(classpermission rw_chr_file_perms)
+(classpermissionset rw_chr_file_perms (chr_file (getattr open read write append ioctl lock)))
+
+(classpermission read_file_perms)
+(classpermissionset read_file_perms (file (getattr open read lock ioctl)))
+
+(classpermission rw_file_perms)
+(classpermissionset rw_file_perms (file (open getattr read write append ioctl lock)))
+
+(classpermission manage_file_perms)
+(classpermissionset manage_file_perms (file (create open getattr setattr read write append rename link unlink ioctl lock)))
+
+(classpermission exec_file_perms)
+(classpermissionset exec_file_perms (file (getattr open map read execute ioctl execute_no_trans)))
+
+(classpermission read_lnk_file_perms)
+(classpermissionset read_lnk_file_perms (lnk_file (getattr read)))
+
+(classpermission rw_lnk_file_perms)
+(classpermissionset rw_lnk_file_perms (lnk_file (getattr read write lock ioctl)))
+
+(classpermission manage_lnk_file_perms)
+(classpermissionset manage_lnk_file_perms (lnk_file (create read write getattr setattr link unlink rename ioctl lock)))
+
+(classpermission write_sock_file_perms)
+(classpermissionset write_sock_file_perms (sock_file (getattr write open append)))
+
+(classpermission manage_sock_file_perms)
+(classpermissionset manage_sock_file_perms (sock_file (create open getattr setattr read write rename link unlink ioctl lock append)))
+
+(classpermission create_tcp_socket_perms)
+(classpermissionset create_tcp_socket_perms (tcp_socket (ioctl read getattr write setattr append bind connect getopt setopt shutdown listen accept)))
+
+(classpermission create_udp_socket_perms)
+(classpermissionset create_udp_socket_perms (udp_socket (ioctl read getattr write setattr append bind connect getopt setopt shutdown)))
+
+(classpermission create_sctp_socket_perms)
+(classpermissionset create_sctp_socket_perms (sctp_socket (ioctl read getattr write setattr append bind connect getopt setopt shutdown)))
+
+(classpermission rw_shm_perms)
+(classpermissionset rw_shm_perms (shm (lock associate getattr read unix_read unix_write write)))
+
+;;
+;; Base container policy
+;;
+
+(block container
+	(blockabstract container)
+
+	(type process)
+	(type socket)
+
+	(roletype system_r process)
+	(typeattributeset domain (process))
+	(typeattributeset container_domain (process))
+	(typeattributeset mcs_constrained_type (process))
+	(typeattributeset file_type (socket))
+
+	(allow process socket manage_sock_file_perms)
+	(allow container_engine_domain process (key (create search setattr view)))
+)

--- a/udica-templates/config_container.cil
+++ b/udica-templates/config_container.cil
@@ -1,0 +1,33 @@
+(block config_container
+	(blockabstract config_container)
+
+	(optional config_container_optional
+		(allow process configfile list_dir_perms)
+		(allow process configfile read_file_perms)
+		(allow process configfile read_lnk_file_perms)
+	)
+)
+
+(block config_rw_container
+	(blockabstract config_rw_container)
+
+	(blockinherit config_container)
+
+	(optional config_rw_container_optional
+		(allow process configfile rw_dir_perms)
+		(allow process configfile rw_file_perms)
+		(allow process configfile rw_lnk_file_perms)
+	)
+)
+
+(block config_manage_container
+	(blockabstract config_manage_container)
+
+	(blockinherit config_rw_container)
+
+	(optional config_manage_container_optional
+		(allow process configfile manage_dir_perms)
+		(allow process configfile manage_file_perms)
+		(allow process configfile manage_lnk_file_perms)
+	)
+)

--- a/udica-templates/home_container.cil
+++ b/udica-templates/home_container.cil
@@ -1,0 +1,45 @@
+(block home_container
+	(blockabstract home_container)
+
+	(optional home_container_optional
+		(allow process process (capability (dac_override)))
+
+		(allow process home_root_t list_dir_perms)
+		(allow process user_home_dir_t list_dir_perms)
+		(allow process user_home_t list_dir_perms)
+
+		(allow process user_home_dir_t read_file_perms)
+		(allow process user_home_t read_file_perms)
+	)
+)
+
+
+(block home_rw_container
+	(blockabstract home_rw_container)
+
+	(blockinherit home_container)
+
+	(optional home_rw_container_optional
+		(allow process home_root_t rw_dir_perms)
+		(allow process user_home_dir_t rw_dir_perms)
+		(allow process user_home_t rw_dir_perms)
+
+		(allow process user_home_dir_t rw_file_perms)
+		(allow process user_home_t rw_file_perms)
+	)
+)
+
+(block home_manage_container
+	(blockabstract home_manage_container)
+
+	(blockinherit home_rw_container)
+
+	(optional home_manage_container_optional
+		(allow process home_root_t manage_dir_perms)
+		(allow process user_home_dir_t manage_dir_perms)
+		(allow process user_home_t manage_dir_perms)
+
+		(allow process user_home_dir_t manage_file_perms)
+		(allow process user_home_t manage_file_perms)
+	)
+)

--- a/udica-templates/log_container.cil
+++ b/udica-templates/log_container.cil
@@ -1,0 +1,41 @@
+(block log_container
+	(blockabstract log_container)
+
+	(optional log_container_optional
+		(allow process var_t search_dir_perms)
+		(allow process logfile list_dir_perms)
+		(allow process logfile read_file_perms)
+		(allow process logfile read_lnk_file_perms)
+		(allow process auditd_log_t list_dir_perms)
+		(allow process auditd_log_t read_file_perms)
+	)
+)
+
+
+(block log_rw_container
+	(blockabstract log_rw_container)
+
+	(blockinherit log_container)
+
+	(optional log_rw_container_optional
+		(allow process logfile rw_dir_perms)
+		(allow process logfile rw_file_perms)
+		(allow process logfile rw_lnk_file_perms)
+		(allow process auditd_log_t rw_dir_perms)
+		(allow process auditd_log_t rw_file_perms)
+	)
+)
+
+(block log_manage_container
+	(blockabstract log_manage_container)
+
+	(blockinherit log_rw_container)
+
+	(optional log_manage_container_optional
+		(allow process logfile manage_dir_perms)
+		(allow process logfile manage_file_perms)
+		(allow process logfile manage_lnk_file_perms)
+		(allow process auditd_log_t manage_dir_perms)
+		(allow process auditd_log_t manage_file_perms)
+	)
+)

--- a/udica-templates/net_container.cil
+++ b/udica-templates/net_container.cil
@@ -1,0 +1,26 @@
+(block net_container
+	(blockabstract net_container)
+
+	(optional net_container_optional
+		(typeattributeset container_net_domain (process))
+	)
+)
+
+(block restricted_net_container
+	(blockabstract restricted_net_container)
+
+	(optional restricted_net_container_optional
+		(allow process self create_tcp_socket_perms)
+		(allow process self create_udp_socket_perms)
+		(allow process self create_sctp_socket_perms)
+
+		(call .read_lnk_files (process proc_t))
+
+		(allow process node_t (node (recvfrom sendto)))
+
+		(allow process node_t (udp_socket (node_bind)))
+		(allow process node_t (tcp_socket (node_bind)))
+
+		(allow process http_port_t (tcp_socket (name_connect)))
+	)
+)

--- a/udica-templates/tmp_container.cil
+++ b/udica-templates/tmp_container.cil
@@ -1,0 +1,19 @@
+(block tmp_container
+	(blockabstract tmp_container)
+
+	(optional tmp_container_optional
+		(allow process tmpfile search_dir_perms)
+		(allow process tmpfile read_file_perms)
+	)
+)
+
+(block tmp_rw_container
+	(blockabstract tmp_rw_container)
+
+	(blockinherit tmp_container)
+
+	(optional tmp_rw_container_optional
+		(allow process tmpfile rw_dir_perms)
+		(allow process tmpfile rw_file_perms)
+	)
+)

--- a/udica-templates/tty_container.cil
+++ b/udica-templates/tty_container.cil
@@ -1,0 +1,10 @@
+(block tty_container
+	(blockabstract tty_container)
+
+	(optional tty_container_optional
+		(allow process device_t list_dir_perms)
+		(allow process device_t read_lnk_file_perms)
+
+		(allow process devtty_t rw_chr_file_perms)
+	)
+)

--- a/udica-templates/virt_container.cil
+++ b/udica-templates/virt_container.cil
@@ -1,0 +1,16 @@
+(block virt_container
+	(blockabstract virt_container)
+
+	(optional virt_container_optional
+		(allow process var_t search_dir_perms)
+		(allow process var_t read_lnk_file_perms)
+
+		(allow process var_run_t search_dir_perms)
+		(allow process var_run_t read_lnk_file_perms)
+
+		(allow process virt_runtime_t search_dir_perms)
+		(allow process virt_runtime_t write_sock_file_perms)
+
+		(allow process virtd_t (unix_stream_socket (connectto)))
+	)
+)

--- a/udica-templates/x_container.cil
+++ b/udica-templates/x_container.cil
@@ -1,0 +1,27 @@
+(block x_container
+	(blockabstract x_container)
+
+	(optional x_container_optional
+		(allow xserver_t process rw_shm_perms)
+
+		(allow process xserver_t (unix_stream_socket (connectto)))
+
+		(allow process device_t search_dir_perms)
+
+		(allow process dri_device_t rw_chr_file_perms)
+
+		(allow process xserver_misc_device_t rw_chr_file_perms)
+
+		(allow process urandom_device_t read_chr_file_perms)
+
+		(allow process tmpfs_t search_dir_perms)
+
+		(allow process tmp_t search_dir_perms)
+		(allow process tmp_t read_lnk_file_perms)
+
+		(allow process xserver_tmp_t search_dir_perms)
+		(allow process xserver_tmp_t write_sock_file_perms)
+
+		(allow process xserver_exec_t exec_file_perms)
+	)
+)


### PR DESCRIPTION
Add CIL templates for usage with [udica](https://github.com/containers/udica) that are compatible with refpolicy.

These templates are based on the ones provided by [container-selinux](https://github.com/containers/container-selinux/tree/main/udica-templates) but I cleaned them up a little ~~and opted to use macros for better readability~~. (cc @doverride for CIL comments).

I'm not super keen on the location for these, so if there are any suggestions on where they should be placed in the refpolicy repository, please comment.