### PR TITLE
Further merge policies from containers-selinux

### DIFF
--- a/policy/modules/services/container.fc
+++ b/policy/modules/services/container.fc
@@ -18,18 +18,51 @@ HOME_DIR/\.local/share/docker/init(/.*)?		gen_context(system_u:object_r:containe
 HOME_DIR/\.local/share/docker/fuse-overlayfs(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
 HOME_DIR/\.local/share/docker/volumes(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
 
-/usr/bin/crun	--	gen_context(system_u:object_r:container_engine_exec_t,s0)
-/usr/bin/runc	--	gen_context(system_u:object_r:container_engine_exec_t,s0)
+/root/\.docker	gen_context(system_u:object_r:container_home_t,s0)
 
 /usr/lib/systemd/system/docker.*	--	gen_context(system_u:object_r:container_unit_t,s0)
 /usr/lib/systemd/system/containerd.*	--	gen_context(system_u:object_r:container_unit_t,s0)
 
-/usr/sbin/runc	--	gen_context(system_u:object_r:container_engine_exec_t,s0)
+/usr/libexec/docker/.*	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/libexec/docker/.*	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/libexec/docker/docker.*	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/libexec/docker/docker.*	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/docker.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/kubelet.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/s?bin/kubelet.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/hyperkube.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/s?bin/hyperkube.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/s?bin/docker.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/containerd.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/s?bin/containerd.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/fuidshift		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/bin/podman		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/bin/podman		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/bin/conmon		--	gen_context(system_u:object_r:conmon_exec_t,s0)
+/usr/local/bin/conmon		--	gen_context(system_u:object_r:conmon_exec_t,s0)
+/usr/local/s?bin/runc		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/runc			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/s?bin/crun		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/crun			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/bin/container[^/]*plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/docker-latest		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/docker-current		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/docker-novolume-plugin	--	gen_context(system_u:object_r:container_auth_exec_t,s0)
+/usr/s?bin/crio.*			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/s?bin/crio.*			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/ocid.*			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/lib/docker/docker-novolume-plugin	--	gen_context(system_u:object_r:container_auth_exec_t,s0)
+/usr/lib/docker/[^/]*plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/lib/docker/[^/]*plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 
 /etc/containers(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
 /etc/cni(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
 /etc/docker(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
+/etc/docker-latest(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
 /etc/containerd(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
+/etc/crio(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
+
+/etc/kubernetes(/.*)?		gen_context(system_u:object_r:kubernetes_file_t,s0)
 
 /run/containers(/.*)?		gen_context(system_u:object_r:container_runtime_t,s0)
 /run/libpod(/.*)?		gen_context(system_u:object_r:container_runtime_t,s0)
@@ -42,6 +75,20 @@ HOME_DIR/\.local/share/docker/volumes(/.*)?		gen_context(system_u:object_r:conta
 /run/containerd/[^/]+/sandboxes/[^/]+/shm(/.*)?		gen_context(system_u:object_r:container_engine_tmpfs_t,s0)
 
 /run/user/%{USERID}/netns(/.*)?		gen_context(system_u:object_r:container_runtime_t,s0)
+
+/var/run/containers(/.*)?		gen_context(system_u:object_r:container_var_run_t,s0)
+/var/run/crio(/.*)?		gen_context(system_u:object_r:container_var_run_t,s0)
+/var/run/docker(/.*)?		gen_context(system_u:object_r:container_var_run_t,s0)
+/var/run/containerd(/.*)?	gen_context(system_u:object_r:container_var_run_t,s0)
+/var/run/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?		gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)
+/var/run/docker\.pid		--	gen_context(system_u:object_r:container_var_run_t,s0)
+/var/run/docker\.sock		-s	gen_context(system_u:object_r:container_var_run_t,s0)
+/var/run/docker-client(/.*)?		gen_context(system_u:object_r:container_var_run_t,s0)
+/var/run/docker/plugins(/.*)?		gen_context(system_u:object_r:container_plugin_var_run_t,s0)
+
+/var/run/flannel(/.*)?								gen_context(system_u:object_r:container_var_run_t,s0)
+
+/var/run/kata-containers(/.*)?	gen_context(system_u:object_r:container_kvm_var_run_t,s0)
 
 /var/cache/containers(/.*)?		gen_context(system_u:object_r:container_engine_cache_t,s0)
 
@@ -63,6 +110,7 @@ HOME_DIR/\.local/share/docker/volumes(/.*)?		gen_context(system_u:object_r:conta
 /var/lib/containers/storage/overlay2-images(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/containers/storage/volumes/[^/]+/.*		gen_context(system_u:object_r:container_file_t,s0)
 
+/var/lib/registry(/.*)?	gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/docker(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/docker/.*/config\.env	--	gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/docker/containers/.*/.*\.log	--	gen_context(system_u:object_r:container_log_t,s0)
@@ -73,9 +121,30 @@ HOME_DIR/\.local/share/docker/volumes(/.*)?		gen_context(system_u:object_r:conta
 /var/lib/docker/overlay2(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/docker/volumes/[^/]+/.*		gen_context(system_u:object_r:container_file_t,s0)
 
+/var/lib/docker-latest(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
+/var/lib/docker-latest/.*/config\.env	gen_context(system_u:object_r:container_ro_file_t,s0)
+/var/lib/docker-latest/containers/.*/.*\.log	gen_context(system_u:object_r:container_log_t,s0)
+/var/lib/docker-latest/containers/.*/hostname		gen_context(system_u:object_r:container_ro_file_t,s0)
+/var/lib/docker-latest/containers/.*/hosts		gen_context(system_u:object_r:container_ro_file_t,s0)
+/var/lib/docker-latest/init(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
+/var/lib/docker-latest/overlay(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
+/var/lib/docker-latest/overlay2(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
+
 /var/lib/containerd(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/containerd/[^/]+/sandboxes(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/containerd/[^/]+/snapshots(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
 
+/var/lib/ocid(/.*)?	gen_context(system_u:object_r:container_var_lib_t,s0)
+/var/lib/ocid/sandboxes(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
+/var/cache/kata-containers(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
+/var/lib/kata-containers(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
+
+/var/lib/kubernetes/pods(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
+/var/lib/kubelet(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
+/var/lib/kubelet/pods(/.*)?							gen_context(system_u:object_r:container_file_t,s0)
+
 /var/log/containers(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/pods(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
+
+/srv/containers(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
+/var/srv/containers(/.*)?	gen_context(system_u:object_r:container_file_t,s0)

--- a/policy/modules/services/container.if
+++ b/policy/modules/services/container.if
@@ -752,9 +752,12 @@ interface(`container_mountpoint',`
 interface(`container_manage_config_files',`
 	gen_require(`
 		type container_config_t;
+		type kubernetes_file_t;
 	')
 
 	manage_files_pattern($1, container_config_t, container_config_t)
+	manage_dirs_pattern($1, kubernetes_file_t, kubernetes_file_t)
+	manage_files_pattern($1, kubernetes_file_t, kubernetes_file_t)
 ')
 
 ########################################

--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -143,6 +143,9 @@ container_mountpoint(container_user_runtime_t)
 type container_port_t;
 corenet_port(container_port_t)
 
+type kubernetes_file_t;
+files_config_file(kubernetes_file_t)
+
 ########################################
 #
 # Common container domain local policy
@@ -685,6 +688,8 @@ domtrans_pattern(container_engine_system_domain, container_var_lib_t, spc_t)
 allow container_engine_system_domain spc_t:process { setsched signal_perms };
 
 allow spc_t container_engine_system_domain:fifo_file rw_fifo_file_perms;
+
+admin_pattern(spc_t, kubernetes_file_t)
 
 init_dbus_chat(spc_t)
 


### PR DESCRIPTION
This takes relevant file contexts into use from `containers-selinux`.
Thus enabling CRI-O support and taking some extra kubernetes paths that
are relevant for containerized deployments.

The `kubernetes_file_t` definition was taken into use as well and
containers are allowed to use it.