### PR TITLE
Add type for systemd runtime units and add dbus-broker support

### DIFF
--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -55,6 +55,9 @@ init_mountpoint(system_dbusd_runtime_t)
 type system_dbusd_tmp_t;
 files_tmp_file(system_dbusd_tmp_t)
 
+type system_dbusd_tmpfs_t;
+files_tmpfs_file(system_dbusd_tmpfs_t)
+
 type system_dbusd_var_lib_t;
 files_type(system_dbusd_var_lib_t)
 
@@ -83,6 +86,10 @@ read_lnk_files_pattern(system_dbusd_t, dbusd_etc_t, dbusd_etc_t)
 manage_dirs_pattern(system_dbusd_t, system_dbusd_tmp_t, system_dbusd_tmp_t)
 manage_files_pattern(system_dbusd_t, system_dbusd_tmp_t, system_dbusd_tmp_t)
 files_tmp_filetrans(system_dbusd_t, system_dbusd_tmp_t, { dir file })
+
+manage_files_pattern(system_dbusd_t, system_dbusd_tmpfs_t, system_dbusd_tmpfs_t)
+fs_tmpfs_filetrans(system_dbusd_t, system_dbusd_tmpfs_t, file)
+allow system_dbusd_t system_dbusd_tmpfs_t:file map;
 
 read_files_pattern(system_dbusd_t, system_dbusd_var_lib_t, system_dbusd_var_lib_t)
 

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -18,6 +18,23 @@ gen_require(`
 ## </desc>
 gen_tunable(dbus_pass_tuntap_fd, false)
 
+## <desc>
+## <p>
+## Allow dbus-daemon system bus to to run systemd transient
+## units. This is used by dbus-broker for dbus-activated
+## services when the unit file for the service does not exist.
+## </p>
+## </desc>
+gen_tunable(dbus_broker_run_transient_units, false)
+
+## <desc>
+## <p>
+## Enable additional rules to support using dbus-broker
+## as the dbus-daemon system bus.
+## </p>
+## </desc>
+gen_tunable(dbus_broker_system_bus, false)
+
 attribute dbusd_unconfined;
 attribute session_bus_type;
 
@@ -181,10 +198,37 @@ ifdef(`init_systemd', `
 
 	# Recent versions of dbus are started as Type=notify
 	init_write_runtime_socket(system_dbusd_t)
+
+	tunable_policy(`dbus_broker_system_bus',`
+		init_get_system_status(system_dbusd_t)
+	')
 ')
 
 tunable_policy(`dbus_pass_tuntap_fd',`
         corenet_rw_tun_tap_dev(system_dbusd_t)
+')
+
+tunable_policy(`dbus_broker_run_transient_units',`
+	init_start_transient_units(system_dbusd_t)
+	init_stop_transient_units(system_dbusd_t)
+')
+
+# the below duplicated tunable blocks are due to
+# optionals within tunables not being supported
+optional_policy(`
+	tunable_policy(`dbus_broker_system_bus',`
+		policykit_get_unit_status(system_dbusd_t)
+		policykit_start_unit(system_dbusd_t)
+		policykit_stop_unit(system_dbusd_t)
+		policykit_reload_unit(system_dbusd_t)
+	')
+')
+
+optional_policy(`
+	tunable_policy(`dbus_broker_system_bus',`
+		networkmanager_startstop(system_dbusd_t)
+		networkmanager_status(system_dbusd_t)
+	')
 ')
 
 optional_policy(`

--- a/policy/modules/services/docker.te
+++ b/policy/modules/services/docker.te
@@ -65,8 +65,8 @@ container_unlabeled_var_lib_filetrans(dockerd_t, dir)
 
 ifdef(`init_systemd',`
 	init_dbus_chat(dockerd_t)
-	init_get_generic_units_status(dockerd_t)
-	init_start_generic_units(dockerd_t)
+	init_get_transient_units_status(dockerd_t)
+	init_start_transient_units(dockerd_t)
 	init_start_system(dockerd_t)
 	init_stop_system(dockerd_t)
 ')

--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -191,8 +191,8 @@ container_manage_engine_tmp_files(podman_conmon_t)
 container_manage_engine_tmp_sock_files(podman_conmon_t)
 
 ifdef(`init_systemd',`
-	init_get_generic_units_status(podman_conmon_t)
-	init_start_generic_units(podman_conmon_t)
+	init_get_transient_units_status(podman_conmon_t)
+	init_start_transient_units(podman_conmon_t)
 	init_start_system(podman_conmon_t)
 	init_stop_system(podman_conmon_t)
 

--- a/policy/modules/services/policykit.if
+++ b/policy/modules/services/policykit.if
@@ -246,3 +246,79 @@ interface(`policykit_read_lib',`
 	files_search_var_lib($1)
 	read_files_pattern($1, policykit_var_lib_t, policykit_var_lib_t)
 ')
+
+########################################
+## <summary>
+##	Get the status of the polkit systemd unit.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`policykit_get_unit_status',`
+	gen_require(`
+		type policykit_unit_t;
+		class service status;
+	')
+
+	allow $1 policykit_unit_t:service status;
+')
+
+########################################
+## <summary>
+##	Start the polkit systemd unit.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`policykit_start_unit',`
+	gen_require(`
+		type policykit_unit_t;
+		class service start;
+	')
+
+	allow $1 policykit_unit_t:service start;
+')
+
+########################################
+## <summary>
+##	Stop the polkit systemd unit.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`policykit_stop_unit',`
+	gen_require(`
+		type policykit_unit_t;
+		class service stop;
+	')
+
+	allow $1 policykit_unit_t:service stop;
+')
+
+########################################
+## <summary>
+##	Reload the polkit systemd unit.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`policykit_reload_unit',`
+	gen_require(`
+		type policykit_unit_t;
+		class service reload;
+	')
+
+	allow $1 policykit_unit_t:service reload;
+')

--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -34,7 +34,7 @@ ifdef(`distro_gentoo',`
 /usr/lib/systemd/user-preset(/.*)? gen_context(system_u:object_r:systemd_unit_t,s0)
 /usr/lib/systemd/ntp-units\.d -d gen_context(system_u:object_r:systemd_unit_t,s0)
 /usr/lib/systemd/system(/.*)?	gen_context(system_u:object_r:systemd_unit_t,s0)
-/run/systemd/transient(/.*)?	gen_context(system_u:object_r:systemd_unit_t,s0)
+/run/systemd/transient(/.*)?	gen_context(system_u:object_r:systemd_transient_unit_t,s0)
 
 /usr/libexec/dcc/start-.* --	gen_context(system_u:object_r:initrc_exec_t,s0)
 /usr/libexec/dcc/stop-.* --	gen_context(system_u:object_r:initrc_exec_t,s0)

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -3475,6 +3475,83 @@ interface(`init_reload_generic_units',`
 
 ########################################
 ## <summary>
+##	Get status of transient systemd units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_get_transient_units_status',`
+	gen_require(`
+		type systemd_transient_unit_t;
+		class service status;
+	')
+
+	allow $1 systemd_transient_unit_t:service status;
+')
+
+########################################
+## <summary>
+##	Start transient systemd units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_start_transient_units',`
+	gen_require(`
+		type systemd_transient_unit_t;
+		class service start;
+	')
+
+	allow $1 systemd_transient_unit_t:service start;
+')
+
+########################################
+## <summary>
+##	Stop transient systemd units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`init_stop_transient_units',`
+	gen_require(`
+		type systemd_transient_unit_t;
+		class service stop;
+	')
+
+	allow $1 systemd_transient_unit_t:service stop;
+')
+
+#######################################
+## <summary>
+##	Reload transient systemd units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_reload_transient_units',`
+	gen_require(`
+		type systemd_transient_unit_t;
+		class service reload;
+	')
+
+	allow $1 systemd_transient_unit_t:service reload;
+')
+
+
+########################################
+## <summary>
 ##	Get status of all systemd units.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -121,6 +121,9 @@ logging_log_file(initrc_var_log_t)
 type systemd_unit_t;
 init_unit_file(systemd_unit_t)
 
+type systemd_transient_unit_t;
+init_unit_file(systemd_transient_unit_t)
+
 ifdef(`distro_gentoo',`
 	type rc_exec_t;
 	domain_entry_file(initrc_t, rc_exec_t)
@@ -311,11 +314,11 @@ ifdef(`init_systemd',`
 	allow init_t init_var_lib_t:file manage_file_perms;
 	allow init_t init_var_lib_t:lnk_file manage_lnk_file_perms;
 
-	manage_files_pattern(init_t, systemd_unit_t, systemdunit)
+	manage_files_pattern(init_t, systemd_transient_unit_t, systemdunit)
 
-	manage_dirs_pattern(init_t, systemd_unit_t, systemd_unit_t)
-	manage_lnk_files_pattern(init_t, systemd_unit_t, systemd_unit_t)
-	allow init_t systemd_unit_t:dir relabel_dir_perms;
+	manage_dirs_pattern(init_t, systemd_transient_unit_t, systemd_transient_unit_t)
+	manage_lnk_files_pattern(init_t, systemd_transient_unit_t, systemd_transient_unit_t)
+	allow init_t systemd_transient_unit_t:dir relabel_dir_perms;
 
 	kernel_dyntrans_to(init_t)
 	kernel_read_network_state(init_t)
@@ -1055,8 +1058,8 @@ ifdef(`init_systemd',`
 	manage_lnk_files_pattern(initrc_t, initrc_runtime_t, initrc_runtime_t)
 	files_runtime_filetrans(initrc_t, initrc_runtime_t, dir_file_class_set)
 
-	create_dirs_pattern(initrc_t, systemd_unit_t, systemd_unit_t)
-	allow initrc_t systemd_unit_t:service reload;
+	create_dirs_pattern(initrc_t, systemd_transient_unit_t, systemd_transient_unit_t)
+	allow initrc_t systemd_transient_unit_t:service reload;
 
 	manage_files_pattern(initrc_t, systemdunit, systemdunit)
 	manage_lnk_files_pattern(initrc_t, systemdunit, systemdunit)


### PR DESCRIPTION
Add a separate type for systemd runtime units and add tunables to control access to using dbus-broker as the systemd dbus daemon.

The `dbus_broker_system_bus` tunable adds the rules necessary to allow dbus-broker to be used as the system dbus daemon, and `dbus_broker_run_runtime_units` controls whether dbus-broker is allowed to run systemd runtime units. The latter tunable was added to address dbus-broker's default behavior of creating and running arbitrary units itself (instead of asking systemd) if the requested service doesn't exist.