### PR TITLE
Add support for static usermode helper config file

### DIFF
--- a/policy/modules/kernel/kernel.fc
+++ b/policy/modules/kernel/kernel.fc
@@ -1,2 +1,3 @@
+/etc/usermode-helper\.conf	--	gen_context(system_u:object_r:usermode_helper_conf_t,s0)
 /sys/kernel/debug	-d	gen_context(system_u:object_r:debugfs_t,s0)
 /sys/kernel/debug/.*		<<none>>

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -207,6 +207,15 @@ sid file gen_context(system_u:object_r:unlabeled_t,s0)
 sid unlabeled gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 neverallow * unlabeled_t:file entrypoint;
 
+# usermode-helper config file type
+# This in in support of CONFIG_STATIC_USERMODEHELPER, where a single
+# binary is used in place of other usermode binaries which when executed
+# will execute the appropriate binary, providing an additional layer of
+# security. This single binary can optionally have a config file to
+# restrict or filter kernel calls into userspace.
+type usermode_helper_conf_t;
+files_config_file(usermode_helper_conf_t)
+
 # These initial sids are no longer used, and can be removed:
 sid any_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 sid file_labels		gen_context(system_u:object_r:unlabeled_t,s0)
@@ -270,6 +279,9 @@ allow kernel_t unlabeled_t:dir mounton;
 # Kernel-generated traffic e.g., TCP resets on
 # connections with invalidated labels:
 allow kernel_t unlabeled_t:packet send;
+
+# allow kernel threads to read the usermode helper config file
+allow kernel_t usermode_helper_conf_t:file read_file_perms;
 
 kernel_mounton_proc_dirs(kernel_t)
 kernel_request_load_module(kernel_t)


### PR DESCRIPTION
Add a config file type for the userspace side of Linux's `CONFIG_STATIC_USERMODEHELPER` and allow kernel threads to read it. This optional config file can be referenced by a usermode binary used for `CONFIG_STATIC_USERMODEHELPER` that may contain options for various settings such as argument filtering. One such example of this is [huldufolk](https://github.com/tych0/huldufolk).