### PR TITLE
Various fixes, mostly systemd-related

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -145,6 +145,12 @@ template(`sudo_role_template',`
 	userdom_dontaudit_search_user_home_content($1_sudo_t)
 	userdom_dontaudit_search_user_home_dirs($1_sudo_t)
 
+	tunable_policy(`allow_polyinstantiation',`
+		allow $1_sudo_t self:capability sys_admin;
+		fs_mount_xattr_fs($1_sudo_t)
+		fs_unmount_xattr_fs($1_sudo_t)
+	')
+
 	tunable_policy(`sudo_allow_user_exec_domains',`
 		allow $1_sudo_t $3:key search;
 

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -2238,6 +2238,24 @@ interface(`files_mounton_root',`
 
 ########################################
 ## <summary>
+##	Remount a filesystem mounted on /boot.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_remount_boot',`
+	gen_require(`
+		type boot_t;
+	')
+
+	allow $1 boot_t:filesystem remount;
+')
+
+########################################
+## <summary>
 ##	Get attributes of the /boot directory.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/networkmanager.te
+++ b/policy/modules/services/networkmanager.te
@@ -160,6 +160,7 @@ storage_getattr_fixed_disk_dev(NetworkManager_t)
 init_read_utmp(NetworkManager_t)
 init_dontaudit_write_utmp(NetworkManager_t)
 init_domtrans_script(NetworkManager_t)
+init_get_system_status(NetworkManager_t)
 
 auth_use_nsswitch(NetworkManager_t)
 

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -109,6 +109,7 @@ optional_policy(`
 allow chkpwd_t self:capability { dac_override setuid };
 dontaudit chkpwd_t self:capability sys_tty_config;
 allow chkpwd_t self:process { getattr signal };
+dontaudit chkpwd_t self:process getcap;
 
 allow chkpwd_t shadow_t:file read_file_perms;
 files_list_etc(chkpwd_t)

--- a/policy/modules/system/getty.te
+++ b/policy/modules/system/getty.te
@@ -70,6 +70,8 @@ files_search_spool(getty_t)
 files_dontaudit_search_var_lib(getty_t)
 
 fs_search_auto_mountpoints(getty_t)
+fs_getattr_cgroup(getty_t)
+fs_search_cgroup_dirs(getty_t)
 # for error condition handling
 fs_getattr_xattr_fs(getty_t)
 

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -376,6 +376,8 @@ interface(`init_daemon_domain',`
 
 		allow $1 init_t:unix_dgram_socket sendto;
 
+		allow init_t $1:process2 { nnp_transition nosuid_transition };
+
 		optional_policy(`
 			systemd_stream_connect_socket_proxyd($1)
 		')

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -416,6 +416,7 @@ ifdef(`init_systemd',`
 	files_mounton_tmp(init_t)
 	files_manage_urandom_seed(init_t)
 	files_read_boot_files(initrc_t)
+	files_remount_boot(init_t)
 	files_relabel_all_lock_dirs(init_t)
 	files_search_all(init_t)
 	files_unmount_all_file_type_fs(init_t)

--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -55,6 +55,10 @@ allow local_login_t local_login_tmp_t:dir manage_dir_perms;
 allow local_login_t local_login_tmp_t:file manage_file_perms;
 files_tmp_filetrans(local_login_t, local_login_tmp_t, { file dir })
 
+fs_getattr_cgroup(local_login_t)
+fs_search_cgroup_dirs(local_login_t)
+fs_getattr_xattr_fs(local_login_t)
+
 kernel_read_system_state(local_login_t)
 kernel_read_kernel_sysctls(local_login_t)
 kernel_search_key(local_login_t)

--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -157,6 +157,10 @@ ifdef(`distro_ubuntu',`
 	')
 ')
 
+tunable_policy(`allow_polyinstantiation',`
+	seutil_domtrans_setfiles(local_login_t)
+')
+
 tunable_policy(`console_login',`
 	# Able to relabel /dev/console to user tty types.
 	term_relabel_console(local_login_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2164,6 +2164,10 @@ interface(`systemd_read_resolved_runtime',`
 		type systemd_resolved_runtime_t;
 	')
 
+	# to read the systemd-resolved stub
+	files_read_etc_symlinks($1)
+
+	init_search_runtime($1)
 	read_files_pattern($1, systemd_resolved_runtime_t, systemd_resolved_runtime_t)
 ')
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -654,6 +654,9 @@ udev_read_runtime_files(systemd_homework_t)
 
 allow systemd_hostnamed_t self:capability sys_admin;
 
+fs_getattr_cgroup(systemd_hostnamed_t)
+fs_getattr_xattr_fs(systemd_hostnamed_t)
+
 kernel_read_kernel_sysctls(systemd_hostnamed_t)
 kernel_dontaudit_getattr_proc(systemd_hostnamed_t)
 
@@ -992,6 +995,9 @@ optional_policy(`
 #
 # modules-load local policy
 #
+
+fs_getattr_cgroup(systemd_modules_load_t)
+fs_getattr_xattr_fs(systemd_modules_load_t)
 
 kernel_load_module(systemd_modules_load_t)
 kernel_read_kernel_sysctls(systemd_modules_load_t)
@@ -1345,6 +1351,10 @@ manage_dirs_pattern(systemd_rfkill_t, systemd_rfkill_var_lib_t, systemd_rfkill_v
 manage_files_pattern(systemd_rfkill_t, systemd_rfkill_var_lib_t, systemd_rfkill_var_lib_t)
 init_var_lib_filetrans(systemd_rfkill_t, systemd_rfkill_var_lib_t, dir)
 
+fs_getattr_cgroup(systemd_rfkill_t)
+fs_getattr_xattr_fs(systemd_rfkill_t)
+
+kernel_getattr_proc(systemd_rfkill_t)
 kernel_read_kernel_sysctls(systemd_rfkill_t)
 
 dev_read_sysfs(systemd_rfkill_t)
@@ -1559,6 +1569,7 @@ dev_setattr_all_sysfs(systemd_tmpfiles_t)
 dev_write_sysfs(systemd_tmpfiles_t)
 
 files_create_lock_dirs(systemd_tmpfiles_t)
+files_dontaudit_getattr_lost_found_dirs(systemd_tmpfiles_t)
 files_manage_all_runtime_dirs(systemd_tmpfiles_t)
 files_delete_usr_files(systemd_tmpfiles_t)
 files_list_home(systemd_tmpfiles_t)
@@ -1826,6 +1837,7 @@ fs_unmount_tmpfs(systemd_user_runtime_dir_t)
 fs_relabelfrom_tmpfs_dirs(systemd_user_runtime_dir_t)
 fs_read_cgroup_files(systemd_user_runtime_dir_t)
 fs_getattr_cgroup(systemd_user_runtime_dir_t)
+fs_search_cgroup_dirs(systemd_user_runtime_dir_t)
 fs_getattr_xattr_fs(systemd_user_runtime_dir_t)
 
 kernel_read_kernel_sysctls(systemd_user_runtime_dir_t)

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -258,6 +258,7 @@ ifdef(`init_systemd',`
 	init_dgram_send(udev_t)
 	init_get_generic_units_status(udev_t)
 	init_stream_connect(udev_t)
+	init_start_system(udev_t)
 
 	systemd_map_hwdb(udev_t)
 	systemd_read_hwdb(udev_t)

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -60,6 +60,7 @@ ifdef(`init_systemd',`
 	init_service_status(unconfined_t)
 	# for systemd --user:
 	init_pgm_spec_user_daemon_domain(unconfined_t)
+	allow unconfined_t self:system { status start stop reload };
 
 	optional_policy(`
 		systemd_dbus_chat_resolved(unconfined_t)
@@ -74,6 +75,10 @@ optional_policy(`
 
 optional_policy(`
 	bind_run_ndc(unconfined_t, unconfined_r)
+')
+
+optional_policy(`
+	bluetooth_dbus_chat(unconfined_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Various scattered fixes, mostly systemd-related.

Some of these are:
- Allow init to `nnp_transition` to any init daemon domain (systemd's `NoNewPrivileges` unit option)
- Allowing domains which can use nsswitch to read resolvconf symlinks (for systemd-resolved's stub configuration)
- Polyinstantiation fixes
- Various dontaudits