### PR TITLE
podman: add explicit range transition for conmon

### DIFF
--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -190,6 +190,14 @@ container_engine_tmp_filetrans(podman_conmon_t, { file sock_file })
 container_manage_engine_tmp_files(podman_conmon_t)
 container_manage_engine_tmp_sock_files(podman_conmon_t)
 
+# Ensure conmon runs in s0 so that it can talk to the container
+ifdef(`enable_mcs',`
+	range_transition podman_t podman_conmon_exec_t:process s0;
+')
+ifdef(`enable_mls',`
+	range_transition podman_t podman_conmon_exec_t:process s0;
+')
+
 ifdef(`init_systemd',`
 	init_get_generic_units_status(podman_conmon_t)
 	init_start_generic_units(podman_conmon_t)
@@ -260,6 +268,14 @@ container_manage_user_runtime_files(podman_conmon_user_t)
 container_engine_tmp_filetrans(podman_conmon_user_t, { file sock_file })
 container_manage_engine_tmp_files(podman_conmon_user_t)
 container_manage_engine_tmp_sock_files(podman_conmon_user_t)
+
+# Ensure conmon runs in s0 so that it can talk to the container
+ifdef(`enable_mcs',`
+	range_transition podman_user_t podman_conmon_exec_t:process s0;
+')
+ifdef(`enable_mls',`
+	range_transition podman_user_t podman_conmon_exec_t:process s0;
+')
 
 ifdef(`init_systemd',`
 	# conmon can read logs from containers which are


### PR DESCRIPTION
Ensure that when conmon is started, it runs in s0 and is able to
communicate with the container.

This is in support of https://github.com/containers/podman/pull/13093