### PR TITLE
Remove unused role argument from userdom interfaces

### DIFF
--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -9,9 +9,9 @@ policy_module(unconfined)
 # calls is not correct, however we dont currently
 # have another method to add access to these types
 userdom_base_user_template(unconfined)
-userdom_manage_home_role(unconfined_r, unconfined_t)
-userdom_manage_tmp_role(unconfined_r, unconfined_t)
-userdom_manage_tmpfs_role(unconfined_r, unconfined_t)
+userdom_manage_home(unconfined_t)
+userdom_manage_tmp(unconfined_t)
+userdom_manage_tmpfs(unconfined_t)
 
 type unconfined_exec_t;
 init_system_domain(unconfined_t, unconfined_exec_t)

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -350,23 +350,16 @@ interface(`userdom_ro_home_role',`
 
 #######################################
 ## <summary>
-##	Allow a home directory for which the
-##	role has full access.
+##      Manage a users home directory
 ## </summary>
 ## <desc>
 ##	<p>
-##	Allow a home directory for which the
-##	role has full access.
+##      Allows home directory access
 ##	</p>
 ##	<p>
 ##	This does not allow execute access.
 ##	</p>
 ## </desc>
-## <param name="role" unused="true">
-##	<summary>
-##	The user role
-##	</summary>
-## </param>
 ## <param name="userdomain">
 ##	<summary>
 ##	The user domain
@@ -374,7 +367,7 @@ interface(`userdom_ro_home_role',`
 ## </param>
 ## <rolebase/>
 #
-interface(`userdom_manage_home_role',`
+interface(`userdom_manage_home',`
 	gen_require(`
 		type user_home_t, user_home_dir_t;
 		type user_bin_t, user_cert_t;
@@ -385,63 +378,63 @@ interface(`userdom_manage_home_role',`
 	# Domain access to home dir
 	#
 
-	type_member $2 user_home_dir_t:dir user_home_dir_t;
+	type_member $1 user_home_dir_t:dir user_home_dir_t;
 
 	# full control of the home directory
-	allow $2 user_home_t:file entrypoint;
-	manage_dirs_pattern($2, { user_home_dir_t user_home_t }, user_home_t)
-	manage_files_pattern($2, { user_home_dir_t user_home_t }, user_home_t)
-	manage_lnk_files_pattern($2, { user_home_dir_t user_home_t }, user_home_t)
-	manage_sock_files_pattern($2, { user_home_dir_t user_home_t }, user_home_t)
-	manage_fifo_files_pattern($2, { user_home_dir_t user_home_t }, user_home_t)
-	relabel_dirs_pattern($2, { user_home_dir_t user_home_t }, user_home_t)
-	relabel_files_pattern($2, { user_home_dir_t user_home_t }, user_home_t)
-	relabel_lnk_files_pattern($2, { user_home_dir_t user_home_t }, user_home_t)
-	relabel_sock_files_pattern($2, { user_home_dir_t user_home_t }, user_home_t)
-	relabel_fifo_files_pattern($2, { user_home_dir_t user_home_t }, user_home_t)
-	filetrans_pattern($2, user_home_dir_t, user_home_t, { dir file lnk_file sock_file fifo_file })
-	files_list_home($2)
+	allow $1 user_home_t:file entrypoint;
+	manage_dirs_pattern($1, { user_home_dir_t user_home_t }, user_home_t)
+	manage_files_pattern($1, { user_home_dir_t user_home_t }, user_home_t)
+	manage_lnk_files_pattern($1, { user_home_dir_t user_home_t }, user_home_t)
+	manage_sock_files_pattern($1, { user_home_dir_t user_home_t }, user_home_t)
+	manage_fifo_files_pattern($1, { user_home_dir_t user_home_t }, user_home_t)
+	relabel_dirs_pattern($1, { user_home_dir_t user_home_t }, user_home_t)
+	relabel_files_pattern($1, { user_home_dir_t user_home_t }, user_home_t)
+	relabel_lnk_files_pattern($1, { user_home_dir_t user_home_t }, user_home_t)
+	relabel_sock_files_pattern($1, { user_home_dir_t user_home_t }, user_home_t)
+	relabel_fifo_files_pattern($1, { user_home_dir_t user_home_t }, user_home_t)
+	filetrans_pattern($1, user_home_dir_t, user_home_t, { dir file lnk_file sock_file fifo_file })
+	files_list_home($1)
 
 	# cjp: this should probably be removed:
-	allow $2 user_home_dir_t:dir { manage_dir_perms relabel_dir_perms };
+	allow $1 user_home_dir_t:dir { manage_dir_perms relabel_dir_perms };
 
-	allow $2 { user_home_t user_home_dir_t }:dir { watch watch_mount watch_sb watch_with_perm watch_reads };
-	allow $2 user_home_t:file { watch watch_mount watch_sb watch_with_perm watch_reads };
-	allow $2 user_home_t:lnk_file { watch watch_mount watch_sb watch_with_perm watch_reads };
-	allow $2 user_home_t:sock_file { watch watch_mount watch_sb watch_with_perm watch_reads };
-	allow $2 user_home_t:fifo_file { watch watch_mount watch_sb watch_with_perm watch_reads };
+	allow $1 { user_home_t user_home_dir_t }:dir { watch watch_mount watch_sb watch_with_perm watch_reads };
+	allow $1 user_home_t:file { watch watch_mount watch_sb watch_with_perm watch_reads };
+	allow $1 user_home_t:lnk_file { watch watch_mount watch_sb watch_with_perm watch_reads };
+	allow $1 user_home_t:sock_file { watch watch_mount watch_sb watch_with_perm watch_reads };
+	allow $1 user_home_t:fifo_file { watch watch_mount watch_sb watch_with_perm watch_reads };
 
-	userdom_manage_user_bin($2)
-	userdom_exec_user_bin_files($2)
-	userdom_user_home_dir_filetrans($2, user_bin_t, dir, "bin")
+	userdom_manage_user_bin($1)
+	userdom_exec_user_bin_files($1)
+	userdom_user_home_dir_filetrans($1, user_bin_t, dir, "bin")
 
-	userdom_manage_user_certs($2)
-	userdom_user_home_dir_filetrans($2, user_cert_t, dir, ".pki")
+	userdom_manage_user_certs($1)
+	userdom_user_home_dir_filetrans($1, user_cert_t, dir, ".pki")
 
 	tunable_policy(`use_nfs_home_dirs',`
-		fs_manage_nfs_dirs($2)
-		fs_manage_nfs_files($2)
-		fs_manage_nfs_symlinks($2)
-		fs_manage_nfs_named_sockets($2)
-		fs_manage_nfs_named_pipes($2)
+		fs_manage_nfs_dirs($1)
+		fs_manage_nfs_files($1)
+		fs_manage_nfs_symlinks($1)
+		fs_manage_nfs_named_sockets($1)
+		fs_manage_nfs_named_pipes($1)
 	',`
-		fs_dontaudit_manage_nfs_dirs($2)
-		fs_dontaudit_manage_nfs_files($2)
+		fs_dontaudit_manage_nfs_dirs($1)
+		fs_dontaudit_manage_nfs_files($1)
 	')
 
 	tunable_policy(`use_samba_home_dirs',`
-		fs_manage_cifs_dirs($2)
-		fs_manage_cifs_files($2)
-		fs_manage_cifs_symlinks($2)
-		fs_manage_cifs_named_sockets($2)
-		fs_manage_cifs_named_pipes($2)
+		fs_manage_cifs_dirs($1)
+		fs_manage_cifs_files($1)
+		fs_manage_cifs_symlinks($1)
+		fs_manage_cifs_named_sockets($1)
+		fs_manage_cifs_named_pipes($1)
 	',`
-		fs_dontaudit_manage_cifs_dirs($2)
-		fs_dontaudit_manage_cifs_files($2)
+		fs_dontaudit_manage_cifs_dirs($1)
+		fs_dontaudit_manage_cifs_files($1)
 	')
 
 	optional_policy(`
-		xdg_data_filetrans($2, user_bin_t, dir, "bin")
+		xdg_data_filetrans($1, user_bin_t, dir, "bin")
 	')
 ')
 
@@ -449,11 +442,6 @@ interface(`userdom_manage_home_role',`
 ## <summary>
 ##	Manage user temporary files
 ## </summary>
-## <param name="role" unused="true">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.
@@ -461,20 +449,20 @@ interface(`userdom_manage_home_role',`
 ## </param>
 ## <rolebase/>
 #
-interface(`userdom_manage_tmp_role',`
+interface(`userdom_manage_tmp',`
 	gen_require(`
 		type user_tmp_t;
 	')
 
-	files_poly_member_tmp($2, user_tmp_t)
+	files_poly_member_tmp($1, user_tmp_t)
 
-	manage_dirs_pattern($2, user_tmp_t, user_tmp_t)
-	manage_files_pattern($2, user_tmp_t, user_tmp_t)
-	manage_lnk_files_pattern($2, user_tmp_t, user_tmp_t)
-	manage_sock_files_pattern($2, user_tmp_t, user_tmp_t)
-	manage_fifo_files_pattern($2, user_tmp_t, user_tmp_t)
-	files_tmp_filetrans($2, user_tmp_t, { dir file lnk_file sock_file fifo_file })
-	userdom_user_runtime_filetrans_user_tmp($2, { dir file lnk_file sock_file fifo_file })
+	manage_dirs_pattern($1, user_tmp_t, user_tmp_t)
+	manage_files_pattern($1, user_tmp_t, user_tmp_t)
+	manage_lnk_files_pattern($1, user_tmp_t, user_tmp_t)
+	manage_sock_files_pattern($1, user_tmp_t, user_tmp_t)
+	manage_fifo_files_pattern($1, user_tmp_t, user_tmp_t)
+	files_tmp_filetrans($1, user_tmp_t, { dir file lnk_file sock_file fifo_file })
+	userdom_user_runtime_filetrans_user_tmp($1, { dir file lnk_file sock_file fifo_file })
 ')
 
 #######################################
@@ -500,23 +488,8 @@ interface(`userdom_exec_user_tmp_files',`
 
 #######################################
 ## <summary>
-##	Role access for the user tmpfs type
-##	that the user has full access.
+##	Manage usertmpfs files
 ## </summary>
-## <desc>
-##	<p>
-##	Role access for the user tmpfs type
-##	that the user has full access.
-##	</p>
-##	<p>
-##	This does not allow execute access.
-##	</p>
-## </desc>
-## <param name="role" unused="true">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.
@@ -524,17 +497,17 @@ interface(`userdom_exec_user_tmp_files',`
 ## </param>
 ## <rolecap/>
 #
-interface(`userdom_manage_tmpfs_role',`
+interface(`userdom_manage_tmpfs',`
 	gen_require(`
 		type user_tmpfs_t;
 	')
 
-	manage_dirs_pattern($2, user_tmpfs_t, user_tmpfs_t)
-	manage_files_pattern($2, user_tmpfs_t, user_tmpfs_t)
-	manage_lnk_files_pattern($2, user_tmpfs_t, user_tmpfs_t)
-	manage_sock_files_pattern($2, user_tmpfs_t, user_tmpfs_t)
-	manage_fifo_files_pattern($2, user_tmpfs_t, user_tmpfs_t)
-	fs_tmpfs_filetrans($2, user_tmpfs_t, { dir file lnk_file sock_file fifo_file })
+	manage_dirs_pattern($1, user_tmpfs_t, user_tmpfs_t)
+	manage_files_pattern($1, user_tmpfs_t, user_tmpfs_t)
+	manage_lnk_files_pattern($1, user_tmpfs_t, user_tmpfs_t)
+	manage_sock_files_pattern($1, user_tmpfs_t, user_tmpfs_t)
+	manage_fifo_files_pattern($1, user_tmpfs_t, user_tmpfs_t)
+	fs_tmpfs_filetrans($1, user_tmpfs_t, { dir file lnk_file sock_file fifo_file })
 ')
 
 #######################################
@@ -950,10 +923,10 @@ template(`userdom_login_user_template', `
 
 	userdom_base_user_template($1)
 
-	userdom_manage_home_role($1_r, $1_t)
+	userdom_manage_home($1_t)
 
-	userdom_manage_tmp_role($1_r, $1_t)
-	userdom_manage_tmpfs_role($1_r, $1_t)
+	userdom_manage_tmp($1_t)
+	userdom_manage_tmpfs($1_t)
 
 	userdom_exec_user_tmp_files($1_t)
 	userdom_exec_user_home_content_files($1_t)


### PR DESCRIPTION
Three userdom interfaces appear to have previously used role support
which has since been refactored out.  Rename this interfaces to remove
the role mention and drop the unused roll argument.

Signed-off-by: Daniel Burgener <dburgener@linux.microsoft.com>