### PR TITLE
systemd.if: Allowed reading symlinks in systemd_stream_connect_userdb()

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1250,6 +1250,7 @@ interface(`systemd_stream_connect_userdb', `
 
 	init_search_runtime($1)
 	allow $1 systemd_userdbd_runtime_t:dir list_dir_perms;
+	allow $1 systemd_userdbd_runtime_t:lnk_file read_lnk_file_perms;
 	stream_connect_pattern($1, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t, systemd_userdbd_t)
 	init_unix_stream_socket_connectto($1)
 ')


### PR DESCRIPTION
Some objects in the `/run/systemd/userdb/` directory are symlinks and `sudo` does not function without this access.

```
audit[438]: AVC avc:  denied  { read } for  pid=438 comm="sudo" name="io.systemd.DropIn" dev="tmpfs" ino=450 scontext=staff_u:staff_r:staff_sudo_t tcontext=system_u:object_r:systemd_userdbd_runtime_t tclass=lnk_file permissive=0
```