### PR TITLE
Various container fixes

### DIFF
--- a/policy/modules/services/container.if
+++ b/policy/modules/services/container.if
@@ -741,6 +741,44 @@ interface(`container_mountpoint',`
 ########################################
 ## <summary>
 ##	Allow the specified domain to
+##	create container config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_create_config_files',`
+	gen_require(`
+		type container_config_t;
+	')
+
+	create_files_pattern($1, container_config_t, container_config_t)
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to
+##	write container config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_write_config_files',`
+	gen_require(`
+		type container_config_t;
+	')
+
+	write_files_pattern($1, container_config_t, container_config_t)
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to
 ##	manage container config files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/container.if
+++ b/policy/modules/services/container.if
@@ -1102,6 +1102,25 @@ interface(`container_relabel_all_content',`
 ########################################
 ## <summary>
 ##	Allow the specified domain to
+##	remount container filesystems.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_remount_fs',`
+	gen_require(`
+		type container_file_t;
+	')
+
+	allow $1 container_file_t:filesystem remount;
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to
 ##	relabel container filesystems.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -249,6 +249,11 @@ tunable_policy(`container_use_samba',`
 ')
 
 optional_policy(`
+	podman_rw_conmon_pipes(container_domain)
+	podman_use_conmon_fds(container_domain)
+')
+
+optional_policy(`
 	udev_read_runtime_files(container_domain)
 ')
 

--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -163,7 +163,7 @@ corenet_port(container_port_t)
 #
 
 allow container_domain self:capability { dac_override kill setgid setuid sys_boot sys_chroot };
-allow container_domain self:cap_userns { chown dac_override fowner setgid setuid };
+allow container_domain self:cap_userns { chown dac_override dac_read_search fowner kill setgid setuid };
 allow container_domain self:process { execstack execmem getattr getsched getsession setsched setcap setpgid signal_perms };
 allow container_domain self:fifo_file manage_fifo_file_perms;
 allow container_domain self:sem create_sem_perms;
@@ -302,7 +302,7 @@ optional_policy(`
 #
 
 allow container_net_domain self:capability { net_admin net_raw };
-allow container_net_domain self:cap_userns { net_admin net_raw };
+allow container_net_domain self:cap_userns { net_admin net_bind_service net_raw };
 allow container_net_domain self:tcp_socket create_stream_socket_perms;
 allow container_net_domain self:udp_socket create_socket_perms;
 allow container_net_domain self:tun_socket create_socket_perms;

--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -333,6 +333,8 @@ files_read_kernel_modules(container_t)
 fs_mount_cgroup(container_t)
 fs_rw_cgroup_files(container_t)
 
+kernel_read_vm_overcommit_sysctl(container_t)
+
 auth_use_nsswitch(container_t)
 
 logging_send_audit_msgs(container_t)

--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -18,6 +18,20 @@ gen_tunable(container_mounton_non_security, false)
 
 ## <desc>
 ##	<p>
+##	Allow containers to manage all read-writable public content.
+##	</p>
+## </desc>
+gen_tunable(container_manage_public_content, false)
+
+## <desc>
+##	<p>
+##	Allow containers to read all public content.
+##	</p>
+## </desc>
+gen_tunable(container_read_public_content, false)
+
+## <desc>
+##	<p>
 ##	Allow containers to use NFS filesystems.
 ##	</p>
 ## </desc>
@@ -230,6 +244,14 @@ container_use_container_ptys(container_domain)
 tunable_policy(`container_manage_cgroup',`
 	fs_manage_cgroup_dirs(container_domain)
 	fs_manage_cgroup_files(container_domain)
+')
+
+tunable_policy(`container_manage_public_content',`
+	miscfiles_manage_public_files(container_domain)
+')
+
+tunable_policy(`container_read_public_content',`
+	miscfiles_read_public_files(container_domain)
 ')
 
 tunable_policy(`container_use_nfs',`
@@ -513,6 +535,14 @@ allow container_engine_domain container_ro_file_t:sock_file { manage_sock_file_p
 ifdef(`init_systemd',`
 	# needed by runc, which is also invoked by other engines
 	init_run_bpf(container_engine_domain)
+')
+
+tunable_policy(`container_manage_public_content',`
+	miscfiles_read_public_files(container_engine_domain)
+')
+
+tunable_policy(`container_read_public_content',`
+	miscfiles_read_public_files(container_engine_domain)
 ')
 
 tunable_policy(`container_mounton_non_security',`

--- a/policy/modules/services/podman.if
+++ b/policy/modules/services/podman.if
@@ -190,6 +190,47 @@ interface(`podman_run_conmon_user',`
 
 ########################################
 ## <summary>
+##	Read and write conmon unnamed pipes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`podman_rw_conmon_pipes',`
+	gen_require(`
+		type podman_conmon_t;
+		type podman_conmon_user_t;
+	')
+
+	allow $1 podman_conmon_t:fifo_file rw_fifo_file_perms;
+	allow $1 podman_conmon_user_t:fifo_file rw_fifo_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to inherit
+##	file descriptors from conmon.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`podman_use_conmon_fds',`
+	gen_require(`
+		type podman_conmon_t;
+		type podman_conmon_user_t;
+	')
+
+	allow $1 podman_conmon_t:fd use;
+	allow $1 podman_conmon_user_t:fd use;
+')
+
+########################################
+## <summary>
 ##	Role access for rootless podman.
 ## </summary>
 ## <param name="role_prefix">

--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -18,15 +18,16 @@ mls_trusted_object(podman_t)
 
 container_engine_domain_template(podman_user)
 container_user_engine(podman_user_t)
-application_domain(podman_user_t, podman_exec_t)
+userdom_user_application_domain(podman_user_t, podman_exec_t)
 mls_trusted_object(podman_user_t)
 
 type podman_conmon_t;
 type podman_conmon_exec_t;
 application_domain(podman_conmon_t, podman_conmon_exec_t)
+role system_r types podman_conmon_t;
 
 type podman_conmon_user_t;
-application_domain(podman_conmon_user_t, podman_conmon_exec_t)
+userdom_user_application_domain(podman_conmon_user_t, podman_conmon_exec_t)
 
 ########################################
 #

--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -66,6 +66,10 @@ ifdef(`init_systemd',`
 	init_start_system(podman_t)
 	init_stop_system(podman_t)
 
+	# containers get created as systemd transient units
+	init_get_transient_units_status(podman_t)
+	init_start_transient_units(podman_t)
+
 	# podman can read logs from containers which are
 	# sent to the system journal
 	logging_search_logs(podman_t)

--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -175,6 +175,9 @@ fs_watch_cgroup_files(podman_conmon_t)
 fs_getattr_tmpfs(podman_conmon_t)
 fs_getattr_xattr_fs(podman_conmon_t)
 
+init_rw_inherited_stream_socket(podman_conmon_t)
+init_use_fds(podman_conmon_t)
+
 logging_send_syslog_msg(podman_conmon_t)
 
 miscfiles_read_localization(podman_conmon_t)

--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -39,6 +39,10 @@ allow podman_t podman_conmon_t:unix_stream_socket { connectto rw_stream_socket_p
 
 container_engine_executable_entrypoint(podman_t)
 
+# podman 4.0.0 now creates OCI networking configs
+container_create_config_files(podman_t)
+container_write_config_files(podman_t)
+
 domtrans_pattern(podman_t, podman_conmon_exec_t, podman_conmon_t)
 
 logging_send_syslog_msg(podman_t)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -544,6 +544,10 @@ ifdef(`init_systemd',`
 	')
 
 	optional_policy(`
+		container_remount_fs(init_t)
+	')
+
+	optional_policy(`
 		systemd_dbus_chat_logind(init_t)
 		systemd_search_all_user_keys(init_t)
 		systemd_create_all_user_keys(init_t)


### PR DESCRIPTION
A batch of various fixes for the newly added container policies. Of note:
- new tunables to allow containers to access public content
- fixes for containers that request pseudoterminals. There were issues that prevented these from starting up if they were started as systemd units and also issues that prevented them from properly communicating with conmon
- allow podman to create container config files. New behavior in podman 4.0 maintains a lock file in `/etc/cni`.
- fixed role associations. The conmon type was not associated with any roles.

... and a few others. Additional comments can be found in the commit messages.