### PR TITLE
container: minor additions

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -92,6 +92,9 @@ ifdef(`init_systemd',`
 	# Allow sysadm to query and set networking settings on the system.
 	systemd_dbus_chat_networkd(sysadm_t)
 	fs_read_nsfs_files(sysadm_t)
+
+	# Allow sysadm to follow logs in the journal, i.e. with podman logs -f
+	systemd_watch_journal_dirs(sysadm_t)
 ')
 
 tunable_policy(`allow_ptrace',`

--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -248,10 +248,12 @@ tunable_policy(`container_manage_cgroup',`
 
 tunable_policy(`container_manage_public_content',`
 	miscfiles_manage_public_files(container_domain)
+	miscfiles_watch_public_dirs(container_domain)
 ')
 
 tunable_policy(`container_read_public_content',`
 	miscfiles_read_public_files(container_domain)
+	miscfiles_watch_public_dirs(container_domain)
 ')
 
 tunable_policy(`container_use_nfs',`

--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -76,6 +76,7 @@ ifdef(`init_systemd',`
 	logging_search_logs(podman_t)
 	systemd_list_journal_dirs(podman_t)
 	systemd_read_journal_files(podman_t)
+	systemd_watch_journal_dirs(podman_t)
 ')
 
 ########################################
@@ -142,6 +143,7 @@ ifdef(`init_systemd',`
 	logging_search_logs(podman_user_t)
 	systemd_list_journal_dirs(podman_user_t)
 	systemd_read_journal_files(podman_user_t)
+	systemd_watch_journal_dirs(podman_user_t)
 ')
 
 ########################################


### PR DESCRIPTION
Missed this in my last PR. If the tunables for containers to access public content are enabled, also allow adding a watch on public content directories.