### PR TITLE
Replace "user runtime unit" wording with "user transient unit"

### DIFF
--- a/policy/modules/services/docker.te
+++ b/policy/modules/services/docker.te
@@ -129,9 +129,9 @@ container_use_container_ptys(dockerd_user_t)
 ifdef(`init_systemd',`
 	systemd_search_user_runtime(dockerd_user_t)
 	systemd_write_user_runtime_socket(dockerd_user_t)
-	systemd_start_user_runtime_units(dockerd_user_t)
-	systemd_stop_user_runtime_units(dockerd_user_t)
-	systemd_status_user_runtime_units(dockerd_user_t)
+	systemd_get_user_transient_units_status(dockerd_user_t)
+	systemd_start_user_transient_units(dockerd_user_t)
+	systemd_stop_user_transient_units(dockerd_user_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -133,9 +133,9 @@ ifdef(`init_systemd',`
 	systemd_dbus_chat_logind(podman_user_t)
 
 	# containers are created as transient user units
-	systemd_start_user_runtime_units(podman_user_t)
-	systemd_stop_user_runtime_units(podman_user_t)
-	systemd_status_user_runtime_units(podman_user_t)
+	systemd_get_user_transient_units_status(podman_user_t)
+	systemd_start_user_transient_units(podman_user_t)
+	systemd_stop_user_transient_units(podman_user_t)
 
 	# podman can read logs from containers which are
 	# sent to the user journal

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -84,11 +84,11 @@ HOME_DIR/\.local/share/systemd(/.*)?		gen_context(system_u:object_r:systemd_data
 /run/nologin	--	gen_context(system_u:object_r:systemd_sessions_runtime_t,s0)
 
 /run/user/%{USERID}/systemd	-d	gen_context(system_u:object_r:systemd_user_runtime_t,s0)
-/run/user/%{USERID}/systemd/generator(/.*)?		gen_context(system_u:object_r:systemd_user_runtime_unit_t,s0)
-/run/user/%{USERID}/systemd/generator\.early(/.*)?		gen_context(system_u:object_r:systemd_user_runtime_unit_t,s0)
-/run/user/%{USERID}/systemd/generator\.late(/.*)?		gen_context(system_u:object_r:systemd_user_runtime_unit_t,s0)
-/run/user/%{USERID}/systemd/transient(/.*)?		gen_context(system_u:object_r:systemd_user_runtime_unit_t,s0)
-/run/user/%{USERID}/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_user_runtime_unit_t,s0)
+/run/user/%{USERID}/systemd/generator(/.*)?		gen_context(system_u:object_r:systemd_user_transient_unit_t,s0)
+/run/user/%{USERID}/systemd/generator\.early(/.*)?		gen_context(system_u:object_r:systemd_user_transient_unit_t,s0)
+/run/user/%{USERID}/systemd/generator\.late(/.*)?		gen_context(system_u:object_r:systemd_user_transient_unit_t,s0)
+/run/user/%{USERID}/systemd/transient(/.*)?		gen_context(system_u:object_r:systemd_user_transient_unit_t,s0)
+/run/user/%{USERID}/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_user_transient_unit_t,s0)
 
 /run/systemd/ask-password(/.*)?	gen_context(system_u:object_r:systemd_passwd_runtime_t,s0)
 /run/systemd/ask-password-block(/.*)?	gen_context(system_u:object_r:systemd_passwd_runtime_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -32,7 +32,7 @@ template(`systemd_role_template',`
 		type systemd_run_exec_t, systemd_analyze_exec_t;
 		type systemd_conf_home_t, systemd_data_home_t;
 		type systemd_user_runtime_t, systemd_user_runtime_notify_t;
-		type systemd_user_unit_t, systemd_user_runtime_unit_t;
+		type systemd_user_unit_t, systemd_user_transient_unit_t;
 	')
 
 	#################################
@@ -74,9 +74,9 @@ template(`systemd_role_template',`
 	allow $1_systemd_t systemd_user_runtime_t:lnk_file manage_lnk_file_perms;
 	allow $1_systemd_t systemd_user_runtime_t:sock_file manage_sock_file_perms;
 
-	allow $1_systemd_t systemd_user_runtime_unit_t:dir manage_dir_perms;
-	allow $1_systemd_t systemd_user_runtime_unit_t:file manage_file_perms;
-	allow $1_systemd_t systemd_user_runtime_unit_t:lnk_file manage_lnk_file_perms;
+	allow $1_systemd_t systemd_user_transient_unit_t:dir manage_dir_perms;
+	allow $1_systemd_t systemd_user_transient_unit_t:file manage_file_perms;
+	allow $1_systemd_t systemd_user_transient_unit_t:lnk_file manage_lnk_file_perms;
 
 	allow $1_systemd_t $3:dir search_dir_perms;
 	allow $1_systemd_t $3:file read_file_perms;
@@ -117,9 +117,8 @@ template(`systemd_role_template',`
 	systemd_manage_conf_home_content($1_systemd_t)
 	systemd_manage_data_home_content($1_systemd_t)
 
-	systemd_search_user_runtime_unit_dirs($1_systemd_t)
+	systemd_search_user_transient_unit_dirs($1_systemd_t)
 
-	systemd_search_user_runtime_unit_dirs($1_systemd_t)
 	systemd_read_user_unit_files($1_systemd_t)
 
 	dbus_system_bus_client($1_systemd_t)
@@ -163,13 +162,14 @@ template(`systemd_role_template',`
 	systemd_relabel_data_home_content($3)
 
 	systemd_read_user_unit_files($3)
-	systemd_list_user_runtime_unit_dirs($3)
-	systemd_read_user_runtime_units($3)
+	systemd_list_user_transient_unit_dirs($3)
+	systemd_read_user_transient_units_files($3)
+	systemd_read_user_transient_units_symlinks($3)
 
-	systemd_reload_user_runtime_units($3)
-	systemd_start_user_runtime_units($3)
-	systemd_status_user_runtime_units($3)
-	systemd_stop_user_runtime_units($3)
+	systemd_get_user_transient_units_status($3)
+	systemd_start_user_transient_units($3)
+	systemd_stop_user_transient_units($3)
+	systemd_reload_user_transient_units($3)
 
 	systemd_watch_passwd_runtime_dirs($3)
 
@@ -676,12 +676,9 @@ interface(`systemd_read_user_unit_files',`
 ## </param>
 #
 interface(`systemd_read_user_runtime_units',`
-	gen_require(`
-		type systemd_user_runtime_unit_t;
-	')
-
-	read_files_pattern($1, systemd_user_runtime_unit_t, systemd_user_runtime_unit_t)
-	read_lnk_files_pattern($1, systemd_user_runtime_unit_t, systemd_user_runtime_unit_t)
+	refpolicywarn(`$0($*) has been deprecated, please use systemd_read_user_transient_units_files() and systemd_read_user_transient_units_symlinks() instead.')
+	systemd_read_user_transient_units_files($1)
+	systemd_read_user_transient_units_symlinks($1)
 ')
 
 ######################################
@@ -696,11 +693,8 @@ interface(`systemd_read_user_runtime_units',`
 ## </param>
 #
 interface(`systemd_search_user_runtime_unit_dirs',`
-	gen_require(`
-		type systemd_user_runtime_unit_t;
-	')
-
-	search_dirs_pattern($1, systemd_user_runtime_unit_t, systemd_user_runtime_unit_t)
+	refpolicywarn(`$0($*) has been deprecated, please use systemd_search_user_transient_unit_dirs() instead.')
+	systemd_search_user_transient_unit_dirs($1)
 ')
 
 ######################################
@@ -715,11 +709,8 @@ interface(`systemd_search_user_runtime_unit_dirs',`
 ## </param>
 #
 interface(`systemd_list_user_runtime_unit_dirs',`
-	gen_require(`
-		type systemd_user_runtime_unit_t;
-	')
-
-	list_dirs_pattern($1, systemd_user_runtime_unit_t, systemd_user_runtime_unit_t)
+	refpolicywarn(`$0($*) has been deprecated, please use systemd_list_user_transient_unit_dirs() instead.')
+	systemd_list_user_transient_unit_dirs($1)
 ')
 
 ######################################
@@ -733,12 +724,8 @@ interface(`systemd_list_user_runtime_unit_dirs',`
 ## </param>
 #
 interface(`systemd_status_user_runtime_units',`
-	gen_require(`
-		type systemd_user_runtime_unit_t;
-		class service status;
-	')
-
-	allow $1 systemd_user_runtime_unit_t:service status;
+	refpolicywarn(`$0($*) has been deprecated, please use systemd_get_user_transient_units_status() instead.')
+	systemd_get_user_transient_units_status($1)
 ')
 
 ######################################
@@ -752,12 +739,8 @@ interface(`systemd_status_user_runtime_units',`
 ## </param>
 #
 interface(`systemd_start_user_runtime_units',`
-	gen_require(`
-		type systemd_user_runtime_unit_t;
-		class service start;
-	')
-
-	allow $1 systemd_user_runtime_unit_t:service start;
+	refpolicywarn(`$0($*) has been deprecated, please use systemd_start_user_transient_units() instead.')
+	systemd_start_user_transient_units($1)
 ')
 
 ######################################
@@ -771,12 +754,8 @@ interface(`systemd_start_user_runtime_units',`
 ## </param>
 #
 interface(`systemd_stop_user_runtime_units',`
-	gen_require(`
-		type systemd_user_runtime_unit_t;
-		class service stop;
-	')
-
-	allow $1 systemd_user_runtime_unit_t:service stop;
+	refpolicywarn(`$0($*) has been deprecated, please use systemd_stop_user_transient_units() instead.')
+	systemd_stop_user_transient_units($1)
 ')
 
 ######################################
@@ -790,12 +769,157 @@ interface(`systemd_stop_user_runtime_units',`
 ## </param>
 #
 interface(`systemd_reload_user_runtime_units',`
+	refpolicywarn(`$0($*) has been deprecated, please use systemd_reload_user_transient_units() instead.')
+	systemd_reload_user_transient_units($1)
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to read systemd user transient unit files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_read_user_transient_units_files',`
 	gen_require(`
-		type systemd_user_runtime_unit_t;
+		type systemd_user_transient_unit_t;
+	')
+
+	read_files_pattern($1, systemd_user_transient_unit_t, systemd_user_transient_unit_t)
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to read systemd user transient unit symlinks.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_read_user_transient_units_symlinks',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+	')
+
+	read_files_pattern($1, systemd_user_transient_unit_t, systemd_user_transient_unit_t)
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to search systemd user transient unit directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_search_user_transient_unit_dirs',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+	')
+
+	search_dirs_pattern($1, systemd_user_transient_unit_t, systemd_user_transient_unit_t)
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to list the contents of systemd
+##   user transient unit directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_list_user_transient_unit_dirs',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+	')
+
+	list_dirs_pattern($1, systemd_user_transient_unit_t, systemd_user_transient_unit_t)
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to get the status of systemd user transient units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_get_user_transient_units_status',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+		class service status;
+	')
+
+	allow $1 systemd_user_transient_unit_t:service status;
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to start systemd user transient units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_start_user_transient_units',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+		class service start;
+	')
+
+	allow $1 systemd_user_transient_unit_t:service start;
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to stop systemd user transient units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_stop_user_transient_units',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+		class service stop;
+	')
+
+	allow $1 systemd_user_transient_unit_t:service stop;
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to reload systemd user transient units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_reload_user_transient_units',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
 		class service reload;
 	')
 
-	allow $1 systemd_user_runtime_unit_t:service reload;
+	allow $1 systemd_user_transient_unit_t:service reload;
 ')
 
 ######################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -337,9 +337,9 @@ init_unit_file(systemd_userdbd_unit_t)
 type systemd_user_unit_t;
 init_unit_file(systemd_user_unit_t)
 
-type systemd_user_runtime_unit_t;
-init_unit_file(systemd_user_runtime_unit_t)
-userdom_user_runtime_content(systemd_user_runtime_unit_t)
+type systemd_user_transient_unit_t alias systemd_user_runtime_unit_t;
+init_unit_file(systemd_user_transient_unit_t)
+userdom_user_runtime_content(systemd_user_transient_unit_t)
 
 #
 # Unit file types
@@ -1723,10 +1723,10 @@ userdom_user_runtime_filetrans(systemd_user_session_type, systemd_user_runtime_t
 allow systemd_user_session_type systemd_user_runtime_notify_t:sock_file create;
 type_transition systemd_user_session_type systemd_user_runtime_t:sock_file systemd_user_runtime_notify_t "notify";
 
-filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "generator.early")
-filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "generator.late")
-filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "transient")
-filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "user")
+filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_transient_unit_t, dir, "generator.early")
+filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_transient_unit_t, dir, "generator.late")
+filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_transient_unit_t, dir, "transient")
+filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_transient_unit_t, dir, "user")
 
 allow systemd_user_session_type systemd_user_tmpfs_t:file manage_file_perms;
 fs_tmpfs_filetrans(systemd_user_session_type, systemd_user_tmpfs_t, file)


### PR DESCRIPTION
Deprecate the current interfaces for systemd user transient units in favor of renaming them to be more consistent with the "transient" unit terminology in the `init` module. Alias `systemd_user_runtime_unit_t` to `systemd_user_transient_unit_t`.

Something to consider: systemd user runtime units *do* exist (`/run/systemd/user` and `/run/user/%{USERID}/user`), so if rules specific to these units were to be added later (they do not currently exist), the type should probably still be called `systemd_user_runtime_unit_t`. If we added this now we would be effectively changing the meaning of `systemd_user_runtime_unit_t` and I'm not sure what the best path for communicating this to consumers of refpolicy would be.