### PR TITLE
seusers: Remove sddm.

### DIFF
--- a/config/appconfig-mcs/seusers
+++ b/config/appconfig-mcs/seusers
@@ -1,3 +1,2 @@
 root:root:s0-mcs_systemhigh
 __default__:user_u:s0
-sddm:xdm:s0

--- a/config/appconfig-mls/seusers
+++ b/config/appconfig-mls/seusers
@@ -1,3 +1,2 @@
 root:root:s0-mls_systemhigh
 __default__:user_u:s0
-sddm:xdm:s0

--- a/config/appconfig-standard/seusers
+++ b/config/appconfig-standard/seusers
@@ -1,3 +1,2 @@
 root:root
 __default__:user_u
-sddm:xdm:s0


### PR DESCRIPTION
This breaks systems that do not have the xserver module.

This partially reverts 6e5a6bffdb09992f962a6ecb09a0a90fe3e76269.

Fixes #488 