### PR TITLE
git: add missing file contexts

### DIFF
--- a/policy/modules/services/git.fc
+++ b/policy/modules/services/git.fc
@@ -1,6 +1,9 @@
 HOME_DIR/public_git(/.*)?		gen_context(system_u:object_r:git_user_content_t,s0)
 HOME_DIR/\.config/git(/.*)?		gen_context(system_u:object_r:git_xdg_config_t,s0)
 HOME_DIR/\.gitconfig	--	gen_context(system_u:object_r:git_xdg_config_t,s0)
+HOME_DIR/\.git-credentials	--	gen_context(system_u:object_r:git_xdg_config_t,s0)
+
+/usr/bin/git	--	gen_context(system_u:object_r:git_exec_t,s0)
 
 /usr/lib/git-core/git-daemon	--	gen_context(system_u:object_r:gitd_exec_t,s0)
 


### PR DESCRIPTION
Add missing file contexts for `.git-credentials` in the user's home directory and the git client.