### PR TITLE
Add a separate type for systemd user transient units, rename interfaces

### DIFF
--- a/policy/modules/services/docker.te
+++ b/policy/modules/services/docker.te
@@ -129,9 +129,9 @@ container_use_container_ptys(dockerd_user_t)
 ifdef(`init_systemd',`
 	systemd_search_user_runtime(dockerd_user_t)
 	systemd_write_user_runtime_socket(dockerd_user_t)
+	systemd_get_user_runtime_units_status(dockerd_user_t)
 	systemd_start_user_runtime_units(dockerd_user_t)
 	systemd_stop_user_runtime_units(dockerd_user_t)
-	systemd_status_user_runtime_units(dockerd_user_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -134,9 +134,9 @@ ifdef(`init_systemd',`
 	systemd_dbus_chat_logind(podman_user_t)
 
 	# containers are created as transient user units
+	systemd_get_user_runtime_units_status(podman_user_t)
 	systemd_start_user_runtime_units(podman_user_t)
 	systemd_stop_user_runtime_units(podman_user_t)
-	systemd_status_user_runtime_units(podman_user_t)
 
 	# podman can read logs from containers which are
 	# sent to the user journal

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -87,7 +87,7 @@ HOME_DIR/\.local/share/systemd(/.*)?		gen_context(system_u:object_r:systemd_data
 /run/user/%{USERID}/systemd/generator(/.*)?		gen_context(system_u:object_r:systemd_user_runtime_unit_t,s0)
 /run/user/%{USERID}/systemd/generator\.early(/.*)?		gen_context(system_u:object_r:systemd_user_runtime_unit_t,s0)
 /run/user/%{USERID}/systemd/generator\.late(/.*)?		gen_context(system_u:object_r:systemd_user_runtime_unit_t,s0)
-/run/user/%{USERID}/systemd/transient(/.*)?		gen_context(system_u:object_r:systemd_user_runtime_unit_t,s0)
+/run/user/%{USERID}/systemd/transient(/.*)?		gen_context(system_u:object_r:systemd_user_transient_unit_t,s0)
 /run/user/%{USERID}/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_user_runtime_unit_t,s0)
 
 /run/systemd/ask-password(/.*)?	gen_context(system_u:object_r:systemd_passwd_runtime_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -32,7 +32,8 @@ template(`systemd_role_template',`
 		type systemd_run_exec_t, systemd_analyze_exec_t;
 		type systemd_conf_home_t, systemd_data_home_t;
 		type systemd_user_runtime_t, systemd_user_runtime_notify_t;
-		type systemd_user_unit_t, systemd_user_runtime_unit_t;
+		type systemd_user_unit_t;
+		type systemd_user_runtime_unit_t, systemd_user_transient_unit_t;
 	')
 
 	#################################
@@ -78,6 +79,10 @@ template(`systemd_role_template',`
 	allow $1_systemd_t systemd_user_runtime_unit_t:file manage_file_perms;
 	allow $1_systemd_t systemd_user_runtime_unit_t:lnk_file manage_lnk_file_perms;
 
+	allow $1_systemd_t systemd_user_transient_unit_t:dir manage_dir_perms;
+	allow $1_systemd_t systemd_user_transient_unit_t:file manage_file_perms;
+	allow $1_systemd_t systemd_user_transient_unit_t:lnk_file manage_lnk_file_perms;
+
 	allow $1_systemd_t $3:dir search_dir_perms;
 	allow $1_systemd_t $3:file read_file_perms;
 	allow $1_systemd_t $3:lnk_file read_lnk_file_perms;
@@ -118,8 +123,7 @@ template(`systemd_role_template',`
 	systemd_manage_data_home_content($1_systemd_t)
 
 	systemd_search_user_runtime_unit_dirs($1_systemd_t)
-
-	systemd_search_user_runtime_unit_dirs($1_systemd_t)
+	systemd_search_user_transient_unit_dirs($1_systemd_t)
 	systemd_read_user_unit_files($1_systemd_t)
 
 	dbus_system_bus_client($1_systemd_t)
@@ -165,11 +169,18 @@ template(`systemd_role_template',`
 	systemd_read_user_unit_files($3)
 	systemd_list_user_runtime_unit_dirs($3)
 	systemd_read_user_runtime_units($3)
+	systemd_list_user_transient_unit_dirs($3)
+	systemd_read_user_transient_units_files($3)
 
 	systemd_reload_user_runtime_units($3)
 	systemd_start_user_runtime_units($3)
 	systemd_status_user_runtime_units($3)
 	systemd_stop_user_runtime_units($3)
+
+	systemd_get_user_transient_units_status($3)
+	systemd_reload_user_transient_units($3)
+	systemd_start_user_transient_units($3)
+	systemd_stop_user_transient_units($3)
 
 	systemd_watch_passwd_runtime_dirs($3)
 
@@ -796,6 +807,139 @@ interface(`systemd_reload_user_runtime_units',`
 	')
 
 	allow $1 systemd_user_runtime_unit_t:service reload;
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to read systemd user transient unit files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_read_user_transient_units_files',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+	')
+
+	read_files_pattern($1, systemd_user_transient_unit_t, systemd_user_transient_unit_t)
+	read_lnk_files_pattern($1, systemd_user_transient_unit_t, systemd_user_transient_unit_t)
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to search systemd user transient unit
+##   directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_search_user_transient_unit_dirs',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+	')
+
+	search_dirs_pattern($1, systemd_user_transient_unit_t, systemd_user_transient_unit_t)
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to list the contents of systemd
+##   user transient unit directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_list_user_transient_unit_dirs',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+	')
+
+	list_dirs_pattern($1, systemd_user_transient_unit_t, systemd_user_transient_unit_t)
+')
+
+######################################
+## <summary>
+##	Allow the specified domain to get the status of systemd user transient units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_get_user_transient_units_status',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+		class service status;
+	')
+
+	allow $1 systemd_user_transient_unit_t:service status;
+')
+
+######################################
+## <summary>
+##	Allow the specified domain to start systemd user transient units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_start_user_transient_units',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+		class service start;
+	')
+
+	allow $1 systemd_user_transient_unit_t:service start;
+')
+
+######################################
+## <summary>
+##	Allow the specified domain to stop systemd user transient units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_stop_user_transient_units',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+		class service stop;
+	')
+
+	allow $1 systemd_user_transient_unit_t:service stop;
+')
+
+######################################
+## <summary>
+##	Allow the specified domain to reload systemd user transient units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_reload_user_transient_units',`
+	gen_require(`
+		type systemd_user_transient_unit_t;
+		class service reload;
+	')
+
+	allow $1 systemd_user_transient_unit_t:service reload;
 ')
 
 ######################################

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -124,7 +124,7 @@ template(`systemd_role_template',`
 
 	systemd_search_user_runtime_unit_dirs($1_systemd_t)
 	systemd_search_user_transient_unit_dirs($1_systemd_t)
-	systemd_read_user_unit_files($1_systemd_t)
+	systemd_read_user_units_files($1_systemd_t)
 
 	dbus_system_bus_client($1_systemd_t)
 	dbus_spec_session_bus_client($1, $1_systemd_t)
@@ -166,15 +166,15 @@ template(`systemd_role_template',`
 	systemd_manage_data_home_content($3)
 	systemd_relabel_data_home_content($3)
 
-	systemd_read_user_unit_files($3)
+	systemd_read_user_units_files($3)
 	systemd_list_user_runtime_unit_dirs($3)
-	systemd_read_user_runtime_units($3)
+	systemd_read_user_runtime_units_files($3)
 	systemd_list_user_transient_unit_dirs($3)
 	systemd_read_user_transient_units_files($3)
 
+	systemd_get_user_runtime_units_status($3)
 	systemd_reload_user_runtime_units($3)
 	systemd_start_user_runtime_units($3)
-	systemd_status_user_runtime_units($3)
 	systemd_stop_user_runtime_units($3)
 
 	systemd_get_user_transient_units_status($3)
@@ -658,7 +658,7 @@ interface(`systemd_write_user_runtime_socket',`
 ######################################
 ## <summary>
 ##   Allow the specified domain to read system-wide systemd
-##   user unit files.
+##   user unit files.  (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -667,6 +667,22 @@ interface(`systemd_write_user_runtime_socket',`
 ## </param>
 #
 interface(`systemd_read_user_unit_files',`
+	refpolicywarn(`$0($*) has been deprecated, please use systemd_read_user_runtime_units_files() instead.')
+	systemd_read_user_units_files($1)
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to read system-wide systemd
+##   user unit files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_read_user_units_files',`
 	gen_require(`
 		type systemd_user_unit_t;
 	')
@@ -674,6 +690,21 @@ interface(`systemd_read_user_unit_files',`
 	allow $1 systemd_user_unit_t:dir list_dir_perms;
 	allow $1 systemd_user_unit_t:file read_file_perms;
 	allow $1 systemd_user_unit_t:lnk_file read_lnk_file_perms;
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to read systemd user runtime unit files.  (Deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_read_user_runtime_units',`
+	refpolicywarn(`$0($*) has been deprecated, please use systemd_read_user_runtime_units_files() instead.')
+	systemd_read_user_runtime_units_files($1)
 ')
 
 ######################################
@@ -686,7 +717,7 @@ interface(`systemd_read_user_unit_files',`
 ##	</summary>
 ## </param>
 #
-interface(`systemd_read_user_runtime_units',`
+interface(`systemd_read_user_runtime_units_files',`
 	gen_require(`
 		type systemd_user_runtime_unit_t;
 	')
@@ -735,7 +766,7 @@ interface(`systemd_list_user_runtime_unit_dirs',`
 
 ######################################
 ## <summary>
-##   Allow the specified domain to get the status of systemd user runtime units.
+##   Allow the specified domain to get the status of systemd user runtime units.  (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -744,6 +775,21 @@ interface(`systemd_list_user_runtime_unit_dirs',`
 ## </param>
 #
 interface(`systemd_status_user_runtime_units',`
+	refpolicywarn(`$0($*) has been deprecated, please use systemd_get_user_runtime_units_status() instead.')
+	systemd_get_user_runtime_units_status($1)
+')
+
+######################################
+## <summary>
+##   Allow the specified domain to get the status of systemd user runtime units.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_get_user_runtime_units_status',`
 	gen_require(`
 		type systemd_user_runtime_unit_t;
 		class service status;

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -105,10 +105,10 @@ template(`systemd_role_template',`
 	init_dbus_chat($1_systemd_t)
 
 	# the user@.service unit is restarted when containers are created
+	systemd_get_user_manager_units_status($1_systemd_t)
 	systemd_start_user_manager_units($1_systemd_t)
 	systemd_stop_user_manager_units($1_systemd_t)
 	systemd_reload_user_manager_units($1_systemd_t)
-	systemd_status_user_manager_units($1_systemd_t)
 
 	miscfiles_watch_localization($1_systemd_t)
 
@@ -2097,7 +2097,7 @@ interface(`systemd_reload_user_manager_units',`
 ##	</summary>
 ## </param>
 #
-interface(`systemd_status_user_manager_units',`
+interface(`systemd_get_user_manager_units_status',`
 	gen_require(`
 		type systemd_user_manager_unit_t;
 		class service status;

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -341,6 +341,10 @@ type systemd_user_runtime_unit_t;
 init_unit_file(systemd_user_runtime_unit_t)
 userdom_user_runtime_content(systemd_user_runtime_unit_t)
 
+type systemd_user_transient_unit_t;
+init_unit_file(systemd_user_transient_unit_t)
+userdom_user_runtime_content(systemd_user_transient_unit_t)
+
 #
 # Unit file types
 #
@@ -1725,7 +1729,7 @@ type_transition systemd_user_session_type systemd_user_runtime_t:sock_file syste
 
 filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "generator.early")
 filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "generator.late")
-filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "transient")
+filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_transient_unit_t, dir, "transient")
 filetrans_pattern(systemd_user_session_type, systemd_user_runtime_t, systemd_user_runtime_unit_t, dir, "user")
 
 allow systemd_user_session_type systemd_user_tmpfs_t:file manage_file_perms;


### PR DESCRIPTION
Add a separate type for systemd user transient units and rename the interfaces for working with user runtime units such that they are consistent with the naming in the init module.