### PR TITLE
Rework conmon rules

### DIFF
--- a/policy/modules/services/podman.fc
+++ b/policy/modules/services/podman.fc
@@ -1,2 +1,4 @@
 /usr/bin/podman	--	gen_context(system_u:object_r:podman_exec_t,s0)
 /usr/bin/conmon	--	gen_context(system_u:object_r:conmon_exec_t,s0)
+
+/usr/libexec/podman/conmon	--	gen_context(system_u:object_r:conmon_exec_t,s0)

--- a/policy/modules/services/podman.fc
+++ b/policy/modules/services/podman.fc
@@ -1,2 +1,2 @@
 /usr/bin/podman	--	gen_context(system_u:object_r:podman_exec_t,s0)
-/usr/bin/conmon	--	gen_context(system_u:object_r:podman_conmon_exec_t,s0)
+/usr/bin/conmon	--	gen_context(system_u:object_r:conmon_exec_t,s0)

--- a/policy/modules/services/podman.if
+++ b/policy/modules/services/podman.if
@@ -2,6 +2,48 @@
 
 ########################################
 ## <summary>
+##	Template for conmon domains.
+## </summary>
+## <param name="prefix">
+##	<summary>
+##	Prefix for generated types.
+##	</summary>
+## </param>
+## <param name="source_domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+template(`podman_conmon_domain_template',`
+	gen_require(`
+		attribute conmon_domain;
+		type conmon_exec_t;
+	')
+
+	type $1_conmon_t, conmon_domain;
+	application_domain($1_conmon_t, conmon_exec_t)
+
+	domtrans_pattern($2, conmon_exec_t, $1_conmon_t)
+
+	allow $2 $1_conmon_t:process signull;
+	allow $2 $1_conmon_t:fifo_file setattr;
+	allow $2 $1_conmon_t:unix_stream_socket { connectto rw_stream_socket_perms };
+
+	allow $1_conmon_t $2:tcp_socket rw_stream_socket_perms;
+	allow $1_conmon_t $2:unix_stream_socket rw_stream_socket_perms;
+	allow $1_conmon_t $2:unix_dgram_socket rw_socket_perms;
+	ps_process_pattern($1_conmon_t, $2)
+
+	corecmd_search_bin($1_conmon_t)
+	# conmon will execute crun/runc to create the container,
+	# so transition back to the source domain when creating it
+	container_generic_engine_domtrans($1_conmon_t, $2)
+	container_engine_executable_entrypoint($2)
+')
+
+########################################
+## <summary>
 ##	Execute podman in the podman domain.
 ## </summary>
 ## <param name="domain">
@@ -96,7 +138,7 @@ interface(`podman_run_user',`
 
 ########################################
 ## <summary>
-##	Execute conmon in the conmon domain.
+##	Execute conmon in the podman conmon domain.
 ## </summary>
 ## <param name="domain">
 ## 	<summary>
@@ -106,18 +148,18 @@ interface(`podman_run_user',`
 #
 interface(`podman_domtrans_conmon',`
 	gen_require(`
-		type podman_conmon_t, podman_conmon_exec_t;
+		type podman_conmon_t, conmon_exec_t;
 	')
 
 	corecmd_search_bin($1)
-	domtrans_pattern($1, podman_conmon_exec_t, podman_conmon_t)
+	domtrans_pattern($1, conmon_exec_t, podman_conmon_t)
 ')
 
 ########################################
 ## <summary>
-##	Execute conmon in the conmon domain,
-##	and allow the specified role the
-##	conmon domain.
+##	Execute conmon in the podman conmon
+##	domain, and allow the specified role
+##	the podman conmon domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -142,8 +184,8 @@ interface(`podman_run_conmon',`
 
 ########################################
 ## <summary>
-##	Execute conmon in the conmon user
-##	domain (rootless podman).
+##	Execute conmon in the podman conmon
+##	user domain (rootless podman).
 ## </summary>
 ## <param name="domain">
 ## 	<summary>
@@ -153,19 +195,19 @@ interface(`podman_run_conmon',`
 #
 interface(`podman_domtrans_conmon_user',`
 	gen_require(`
-		type podman_conmon_user_t, podman_conmon_exec_t;
+		type podman_user_conmon_t, conmon_exec_t;
 	')
 
 	corecmd_search_bin($1)
-	domtrans_pattern($1, podman_conmon_exec_t, podman_conmon_user_t)
+	domtrans_pattern($1, conmon_exec_t, podman_user_conmon_t)
 ')
 
 ########################################
 ## <summary>
-##	Execute conmon in the conmon user
-##	domain, and allow the specified role
-##	the conmon user domain (rootless
-##	podman).
+##	Execute conmon in the podman conmon
+##	user domain, and allow the specified
+##	role the podman conmon user domain
+##	(rootless podman).
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -180,10 +222,10 @@ interface(`podman_domtrans_conmon_user',`
 #
 interface(`podman_run_conmon_user',`
 	gen_require(`
-		type podman_conmon_user_t;
+		type podman_user_conmon_t;
 	')
 
-	role $2 types podman_conmon_user_t;
+	role $2 types podman_user_conmon_t;
 
 	podman_domtrans_conmon_user($1)
 ')
@@ -206,20 +248,20 @@ interface(`podman_run_conmon_user',`
 #
 interface(`podman_spec_rangetrans_conmon',`
 	gen_require(`
-		type podman_conmon_exec_t;
+		type conmon_exec_t;
 	')
 
 	ifdef(`enable_mcs',`
-		range_transition $1 podman_conmon_exec_t:process $2;
+		range_transition $1 conmon_exec_t:process $2;
 	')
 	ifdef(`enable_mls',`
-		range_transition $1 podman_conmon_exec_t:process $2;
+		range_transition $1 conmon_exec_t:process $2;
 	')
 ')
 
 ########################################
 ## <summary>
-##	Read and write conmon unnamed pipes.
+##	Read and write podman conmon unnamed pipes.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -230,17 +272,17 @@ interface(`podman_spec_rangetrans_conmon',`
 interface(`podman_rw_conmon_pipes',`
 	gen_require(`
 		type podman_conmon_t;
-		type podman_conmon_user_t;
+		type podman_user_conmon_t;
 	')
 
 	allow $1 podman_conmon_t:fifo_file rw_fifo_file_perms;
-	allow $1 podman_conmon_user_t:fifo_file rw_fifo_file_perms;
+	allow $1 podman_user_conmon_t:fifo_file rw_fifo_file_perms;
 ')
 
 ########################################
 ## <summary>
 ##	Allow the specified domain to inherit
-##	file descriptors from conmon.
+##	file descriptors from podman conmon.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -251,11 +293,11 @@ interface(`podman_rw_conmon_pipes',`
 interface(`podman_use_conmon_fds',`
 	gen_require(`
 		type podman_conmon_t;
-		type podman_conmon_user_t;
+		type podman_user_conmon_t;
 	')
 
 	allow $1 podman_conmon_t:fd use;
-	allow $1 podman_conmon_user_t:fd use;
+	allow $1 podman_user_conmon_t:fd use;
 ')
 
 ########################################
@@ -288,7 +330,7 @@ interface(`podman_use_conmon_fds',`
 template(`podman_user_role',`
 	gen_require(`
 		type podman_user_t;
-		type podman_conmon_user_t;
+		type podman_user_conmon_t;
 	')
 
 	podman_run_user($3, $4)
@@ -300,7 +342,7 @@ template(`podman_user_role',`
 
 	optional_policy(`
 		systemd_user_app_status($1, podman_user_t)
-		systemd_user_app_status($1, podman_conmon_user_t)
+		systemd_user_app_status($1, podman_user_conmon_t)
 	')
 ')
 

--- a/policy/modules/services/podman.if
+++ b/policy/modules/services/podman.if
@@ -190,6 +190,35 @@ interface(`podman_run_conmon_user',`
 
 ########################################
 ## <summary>
+##	Make the specified domain perform a
+##	range transition when executing conmon.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to transition ranges.
+##	</summary>
+## </param>
+## <param name="range">
+##	<summary>
+##	MLS range to transition to.
+##	</summary>
+## </param>
+#
+interface(`podman_spec_rangetrans_conmon',`
+	gen_require(`
+		type podman_conmon_exec_t;
+	')
+
+	ifdef(`enable_mcs',`
+		range_transition $1 podman_conmon_exec_t:process $2;
+	')
+	ifdef(`enable_mls',`
+		range_transition $1 podman_conmon_exec_t:process $2;
+	')
+')
+
+########################################
+## <summary>
 ##	Read and write conmon unnamed pipes.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -21,30 +21,25 @@ container_user_engine(podman_user_t)
 userdom_user_application_domain(podman_user_t, podman_exec_t)
 mls_trusted_object(podman_user_t)
 
-type podman_conmon_t;
-type podman_conmon_exec_t;
-application_domain(podman_conmon_t, podman_conmon_exec_t)
+attribute conmon_domain;
+type conmon_exec_t;
+
+podman_conmon_domain_template(podman, podman_t)
 role system_r types podman_conmon_t;
 
-type podman_conmon_user_t;
-userdom_user_application_domain(podman_conmon_user_t, podman_conmon_exec_t)
+podman_conmon_domain_template(podman_user, podman_user_t)
+userdom_user_application_domain(podman_user_conmon_t, conmon_exec_t)
 
 ########################################
 #
 # Podman local policy
 #
 
-allow podman_t podman_conmon_t:process { setsched signull };
-allow podman_t podman_conmon_t:fifo_file setattr;
-allow podman_t podman_conmon_t:unix_stream_socket { connectto rw_stream_socket_perms };
-
-container_engine_executable_entrypoint(podman_t)
+allow podman_t podman_conmon_t:process setsched;
 
 # podman 4.0.0 now creates OCI networking configs
 container_create_config_files(podman_t)
 container_write_config_files(podman_t)
-
-domtrans_pattern(podman_t, podman_conmon_exec_t, podman_conmon_t)
 
 logging_send_syslog_msg(podman_t)
 
@@ -85,14 +80,6 @@ ifdef(`init_systemd',`
 #
 # Rootless Podman local policy
 #
-
-allow podman_user_t podman_conmon_user_t:process signull;
-allow podman_user_t podman_conmon_user_t:fifo_file setattr;
-allow podman_user_t podman_conmon_user_t:unix_stream_socket { connectto rw_stream_socket_perms };
-
-container_engine_executable_entrypoint(podman_user_t)
-
-domtrans_pattern(podman_user_t, podman_conmon_exec_t, podman_conmon_user_t)
 
 # required by slirp4netns
 files_mounton_etc_dirs(podman_user_t)
@@ -150,50 +137,58 @@ ifdef(`init_systemd',`
 	systemd_watch_journal_dirs(podman_user_t)
 ')
 
+
 ########################################
 #
-# conmon local policy
+# common conmon local policy
 #
 
-allow podman_conmon_t self:process signal;
+allow conmon_domain self:process signal;
+allow conmon_domain self:cap_userns sys_ptrace;
+allow conmon_domain self:fifo_file { rw_fifo_file_perms setattr };
+allow conmon_domain self:unix_dgram_socket create_socket_perms;
+
+domain_use_interactive_fds(conmon_domain)
+
+fs_getattr_cgroup(conmon_domain)
+fs_search_cgroup_dirs(conmon_domain)
+fs_read_cgroup_files(conmon_domain)
+fs_watch_cgroup_files(conmon_domain)
+
+fs_getattr_tmpfs(conmon_domain)
+fs_getattr_xattr_fs(conmon_domain)
+
+logging_send_syslog_msg(conmon_domain)
+
+miscfiles_read_localization(conmon_domain)
+
+userdom_use_user_ptys(conmon_domain)
+
+# to send/receive data from container ttys
+container_rw_chr_files(conmon_domain)
+
+ifdef(`init_systemd',`
+	# conmon can read logs from containers which are
+	# sent to the system journal
+	logging_search_logs(conmon_domain)
+	systemd_list_journal_dirs(conmon_domain)
+	systemd_read_journal_files(conmon_domain)
+')
+
+########################################
+#
+# podman conmon local policy
+#
+
 allow podman_conmon_t self:capability { dac_override dac_read_search sys_ptrace sys_resource };
-allow podman_conmon_t self:cap_userns sys_ptrace;
-allow podman_conmon_t self:fifo_file { rw_fifo_file_perms setattr };
-allow podman_conmon_t self:unix_dgram_socket create_socket_perms;
 dontaudit podman_conmon_t self:capability net_admin;
 
-# conmon will execute crun/runc to create the container
-container_generic_engine_domtrans(podman_conmon_t, podman_t)
 podman_domtrans(podman_conmon_t)
-
-allow podman_conmon_t podman_t:tcp_socket rw_stream_socket_perms;
-allow podman_conmon_t podman_t:unix_stream_socket rw_stream_socket_perms;
-allow podman_conmon_t podman_t:unix_dgram_socket rw_socket_perms;
-ps_process_pattern(podman_conmon_t, podman_t)
-
-domain_use_interactive_fds(podman_conmon_t)
-
-fs_getattr_cgroup(podman_conmon_t)
-fs_search_cgroup_dirs(podman_conmon_t)
-fs_read_cgroup_files(podman_conmon_t)
-fs_watch_cgroup_files(podman_conmon_t)
-
-fs_getattr_tmpfs(podman_conmon_t)
-fs_getattr_xattr_fs(podman_conmon_t)
 
 init_rw_inherited_stream_socket(podman_conmon_t)
 init_use_fds(podman_conmon_t)
 
-logging_send_syslog_msg(podman_conmon_t)
-
-miscfiles_read_localization(podman_conmon_t)
-
-userdom_use_user_ptys(podman_conmon_t)
-
 container_read_system_container_state(podman_conmon_t)
-
-# to send/receive data from container ttys
-container_rw_chr_files(podman_conmon_t)
 
 container_manage_runtime_files(podman_conmon_t)
 container_manage_runtime_fifo_files(podman_conmon_t)
@@ -213,12 +208,6 @@ ifdef(`init_systemd',`
 	init_start_transient_units(podman_conmon_t)
 	init_start_system(podman_conmon_t)
 	init_stop_system(podman_conmon_t)
-
-	# conmon can read logs from containers which are
-	# sent to the system journal
-	logging_search_logs(podman_conmon_t)
-	systemd_list_journal_dirs(podman_conmon_t)
-	systemd_read_journal_files(podman_conmon_t)
 ')
 
 optional_policy(`
@@ -227,62 +216,23 @@ optional_policy(`
 
 ########################################
 #
-# Rootless conmon local policy
+# Rootless podman conmon local policy
 #
 
-allow podman_conmon_user_t self:process signal;
-allow podman_conmon_user_t self:cap_userns sys_ptrace;
-allow podman_conmon_user_t self:fifo_file { rw_fifo_file_perms setattr };
-allow podman_conmon_user_t self:unix_dgram_socket create_socket_perms;
+podman_domtrans_user(podman_user_conmon_t)
 
-ps_process_pattern(podman_conmon_user_t, podman_user_t)
-allow podman_conmon_user_t podman_user_t:process signal;
-allow podman_conmon_user_t podman_user_t:unix_stream_socket rw_stream_socket_perms;
-allow podman_conmon_user_t podman_user_t:unix_dgram_socket rw_socket_perms;
+container_read_user_container_state(podman_user_conmon_t)
 
-# conmon will execute crun/runc to create the container
-container_generic_engine_domtrans(podman_conmon_user_t, podman_user_t)
-podman_domtrans_user(podman_conmon_user_t)
+userdom_search_user_home_dirs(podman_user_conmon_t)
+xdg_search_data_dirs(podman_user_conmon_t)
+container_manage_home_data_files(podman_user_conmon_t)
+container_manage_home_data_fifo_files(podman_user_conmon_t)
+container_manage_home_data_sock_files(podman_user_conmon_t)
 
-domain_use_interactive_fds(podman_conmon_user_t)
+userdom_search_user_runtime_root(podman_user_conmon_t)
+userdom_search_user_runtime(podman_user_conmon_t)
+container_manage_user_runtime_files(podman_user_conmon_t)
 
-fs_getattr_cgroup(podman_conmon_user_t)
-fs_search_cgroup_dirs(podman_conmon_user_t)
-fs_read_cgroup_files(podman_conmon_user_t)
-fs_watch_cgroup_files(podman_conmon_user_t)
-
-fs_getattr_tmpfs(podman_conmon_user_t)
-fs_getattr_xattr_fs(podman_conmon_user_t)
-
-logging_send_syslog_msg(podman_conmon_user_t)
-
-miscfiles_read_localization(podman_conmon_user_t)
-
-userdom_use_user_ptys(podman_conmon_user_t)
-
-container_read_user_container_state(podman_conmon_user_t)
-
-# to send/receive data from container ttys
-container_rw_chr_files(podman_conmon_user_t)
-
-userdom_search_user_home_dirs(podman_conmon_user_t)
-xdg_search_data_dirs(podman_conmon_user_t)
-container_manage_home_data_files(podman_conmon_user_t)
-container_manage_home_data_fifo_files(podman_conmon_user_t)
-container_manage_home_data_sock_files(podman_conmon_user_t)
-
-userdom_search_user_runtime_root(podman_conmon_user_t)
-userdom_search_user_runtime(podman_conmon_user_t)
-container_manage_user_runtime_files(podman_conmon_user_t)
-
-container_engine_tmp_filetrans(podman_conmon_user_t, { file sock_file })
-container_manage_engine_tmp_files(podman_conmon_user_t)
-container_manage_engine_tmp_sock_files(podman_conmon_user_t)
-
-ifdef(`init_systemd',`
-	# conmon can read logs from containers which are
-	# sent to the system journal
-	logging_search_logs(podman_conmon_user_t)
-	systemd_list_journal_dirs(podman_conmon_user_t)
-	systemd_read_journal_files(podman_conmon_user_t)
-')
+container_engine_tmp_filetrans(podman_user_conmon_t, { file sock_file })
+container_manage_engine_tmp_files(podman_user_conmon_t)
+container_manage_engine_tmp_sock_files(podman_user_conmon_t)

--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -28,6 +28,7 @@ podman_conmon_domain_template(podman, podman_t)
 role system_r types podman_conmon_t;
 
 podman_conmon_domain_template(podman_user, podman_user_t)
+typealias podman_user_conmon_t alias podman_conmon_user_t;
 userdom_user_application_domain(podman_user_conmon_t, conmon_exec_t)
 
 ########################################

--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -61,6 +61,8 @@ container_manage_home_config(podman_t)
 
 container_manage_sock_files(podman_t)
 
+podman_spec_rangetrans_conmon(podman_t, s0)
+
 ifdef(`init_systemd',`
 	init_dbus_chat(podman_t)
 	init_setsched(podman_t)
@@ -124,6 +126,8 @@ storage_rw_fuse(podman_user_t)
 # when run in rootless mode
 userdom_relabel_generic_user_home_dirs(podman_user_t)
 userdom_relabel_generic_user_home_files(podman_user_t)
+
+podman_spec_rangetrans_conmon(podman_user_t, s0)
 
 ifdef(`init_systemd',`
 	# podman queries the cgroup manager (systemd) over the session bus socket
@@ -204,14 +208,6 @@ container_engine_tmp_filetrans(podman_conmon_t, { file sock_file })
 container_manage_engine_tmp_files(podman_conmon_t)
 container_manage_engine_tmp_sock_files(podman_conmon_t)
 
-# Ensure conmon runs in s0 so that it can talk to the container
-ifdef(`enable_mcs',`
-	range_transition podman_t podman_conmon_exec_t:process s0;
-')
-ifdef(`enable_mls',`
-	range_transition podman_t podman_conmon_exec_t:process s0;
-')
-
 ifdef(`init_systemd',`
 	init_get_transient_units_status(podman_conmon_t)
 	init_start_transient_units(podman_conmon_t)
@@ -282,14 +278,6 @@ container_manage_user_runtime_files(podman_conmon_user_t)
 container_engine_tmp_filetrans(podman_conmon_user_t, { file sock_file })
 container_manage_engine_tmp_files(podman_conmon_user_t)
 container_manage_engine_tmp_sock_files(podman_conmon_user_t)
-
-# Ensure conmon runs in s0 so that it can talk to the container
-ifdef(`enable_mcs',`
-	range_transition podman_user_t podman_conmon_exec_t:process s0;
-')
-ifdef(`enable_mls',`
-	range_transition podman_user_t podman_conmon_exec_t:process s0;
-')
 
 ifdef(`init_systemd',`
 	# conmon can read logs from containers which are


### PR DESCRIPTION
This is to lay some groundwork for an upcoming kubernetes policy module, specifically with CRI-O. CRI-O also uses conmon to monitor container processes, but currently this has the side effect of conmon transitioning back to `podman_t` when it executes `runc`, a generic container engine.

To fix this, rework the current conmon policy rules to use a template to generate conmon types. This is so that `podman_t`, `podman_user_t`, and eventually `crio_t` get their own conmon types that transition back to the proper source domain.

This has the side effect of renaming `podman_conmon_user_t` to `podman_user_conmon_t`, ~~but there hasn't been a release with the container module yet so this is OK,~~ and I like the new name better.

Also, add a file context for conmon in `/usr/libexec/conmon` which exists in Gentoo and consolidate the range transition of podman to conmon in an interface. This interface is also being used by the WIP CRI-O module.