### PR TITLE
podman: add alias for conmon executable

### DIFF
--- a/policy/modules/services/podman.te
+++ b/policy/modules/services/podman.te
@@ -23,6 +23,7 @@ mls_trusted_object(podman_user_t)
 
 attribute conmon_domain;
 type conmon_exec_t;
+typealias conmon_exec_t alias podman_conmon_exec_t;
 
 podman_conmon_domain_template(podman, podman_t)
 role system_r types podman_conmon_t;


### PR DESCRIPTION
Missed this one in #504. `podman_conmon_exec_t` was renamed to `conmon_exec_t`. Add a typealias for this definition.