### PR TITLE
container: Boolean for ecryptfs

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -1931,6 +1931,84 @@ interface(`fs_cifs_domtrans',`
 	domain_auto_transition_pattern($1, cifs_t, $2)
 ')
 
+########################################
+## <summary>
+##      Create, read, write, and delete directories
+##      on an eCryptfs filesystem.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_manage_ecryptfs_dirs',`
+        gen_require(`
+                type ecryptfs_t;
+        ')
+
+        allow $1 ecryptfs_t:dir manage_dir_perms;
+')
+
+########################################
+## <summary>
+##      Create, read, write, and delete files
+##      on an eCryptfs filesystem.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_manage_ecryptfs_files',`
+        gen_require(`
+                type ecryptfs_t;
+        ')
+
+        manage_files_pattern($1, ecryptfs_t, ecryptfs_t)
+')
+
+########################################
+## <summary>
+##      Create, read, write, and delete named sockets
+##      on an eCryptfs filesystem.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`fs_manage_ecryptfs_named_sockets',`
+        gen_require(`
+                type ecryptfs_t;
+        ')
+
+        manage_sock_files_pattern($1, ecryptfs_t, ecryptfs_t)
+')
+
+########################################
+## <summary>
+##      Read symbolic links on an eCryptfs filesystem.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`fs_list_ecryptfs',`
+        gen_require(`
+                type ecryptfs_t;
+        ')
+
+        allow $1 ecryptfs_t:dir list_dir_perms;
+        read_lnk_files_pattern($1, ecryptfs_t, ecryptfs_t)
+')
+
 #######################################
 ## <summary>
 ##	Create, read, write, and delete dirs

--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -31,6 +31,13 @@ gen_tunable(container_manage_public_content, false)
 gen_tunable(container_read_public_content, false)
 
 ## <desc>
+##      <p>
+##      Allow containers to use eCryptfs filesystems.
+##      </p>
+## </desc>
+gen_tunable(container_use_ecryptfs, false)
+
+## <desc>
 ##	<p>
 ##	Allow containers to use NFS filesystems.
 ##	</p>
@@ -261,6 +268,13 @@ tunable_policy(`container_manage_public_content',`
 tunable_policy(`container_read_public_content',`
 	miscfiles_read_public_files(container_domain)
 	miscfiles_watch_public_dirs(container_domain)
+')
+
+tunable_policy(`container_use_ecryptfs',`
+        fs_manage_ecryptfs_dirs(container_domain)
+        fs_manage_ecryptfs_files(container_domain)
+        fs_manage_ecryptfs_named_sockets(container_domain)
+        fs_list_ecryptfs(container_domain)
 ')
 
 tunable_policy(`container_use_nfs',`


### PR DESCRIPTION
For moving secrets around in various environments, I'm finding ecryptfs to be a workable approach.  This adds a boolean that will permit my containers to access the filesystem if enabled.