### PR TITLE
adding rule to allow svirt_t to dac_override dac_read_search ipc_lock

### DIFF
--- a/policy/modules/services/virt.te
+++ b/policy/modules/services/virt.te
@@ -403,6 +403,8 @@ optional_policy(`
 # svirt local policy
 #
 
+allow svirt_t self:capability { dac_override dac_read_search ipc_lock };
+
 list_dirs_pattern(svirt_t, virt_content_t, virt_content_t)
 read_files_pattern(svirt_t, virt_content_t, virt_content_t)
 


### PR DESCRIPTION
I have tested the module on my system, and it seems to fix the issue.  I am open to feedback and changes. 