### PR TITLE
systemd: extend `systemd_tmpfiles_manage_all` tunable policy

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7984,3 +7984,39 @@ interface(`files_unconfined',`
 
 	typeattribute $1 files_unconfined_type;
 ')
+
+########################################
+## <summary>
+##	Relabel all files on the filesystem, except
+##	policy_config_t and exceptions.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="exception_types" optional="true">
+##	<summary>
+##	The types to be excluded.  Each type or attribute
+##	must be negated by the caller.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`files_relabel_all_non_policy_files',`
+	gen_require(`
+		attribute file_type;
+		type policy_config_t;
+	')
+
+	allow $1 { file_type -policy_config_t $2 }:dir list_dir_perms;
+	relabel_dirs_pattern($1, { file_type -policy_config_t $2 }, { file_type -policy_config_t $2 })
+	relabel_files_pattern($1, { file_type -policy_config_t $2 }, { file_type -policy_config_t $2 })
+	relabel_lnk_files_pattern($1, { file_type -policy_config_t $2 }, { file_type -policy_config_t $2 })
+	relabel_fifo_files_pattern($1, { file_type -policy_config_t $2 }, { file_type -policy_config_t $2 })
+	relabel_sock_files_pattern($1, { file_type -policy_config_t $2 }, { file_type -policy_config_t $2 })
+	# this is only relabelfrom since there should be no
+	# device nodes with file types.
+	relabelfrom_blk_files_pattern($1, { file_type -policy_config_t $2 }, { file_type -policy_config_t $2 })
+	relabelfrom_chr_files_pattern($1, { file_type -policy_config_t $2 }, { file_type -policy_config_t $2 })
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1674,6 +1674,7 @@ tunable_policy(`systemd_tmpfiles_manage_all',`
 	files_manage_non_security_files(systemd_tmpfiles_t)
 	files_relabel_non_security_dirs(systemd_tmpfiles_t)
 	files_relabel_non_security_files(systemd_tmpfiles_t)
+	files_relabel_all_non_policy_files(systemd_tmpfiles_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Hi,

In this PR, we're extending the `systemd_tmpfiles_manage_all` tunable policy with a new interface `files_relabel_all_non_policy_files`:

* [files: add interface to relabel all but policy files](https://github.com/SELinuxProject/refpolicy/commit/797c07f9e3cc9c3862ee81abd5c864c01edb508b)

this interface can be use to renaname all files except
`policy_config_t`, it can be seen as an extension to the
`files_relabel_all_files`.

it's required to do that in case one wants to use this interface from a
tunable_policy, otherwise the compiler won't be able to use the
typeattribute statement from a tunable_policy to set the can_relabelto_binary_policy
attribute done by the seutil_relabelto_bin_policy

* [systemd: use the files_relabel_all_non_policy_files](https://github.com/SELinuxProject/refpolicy/commit/8e81b2648119a60878543813c14f526ab7e879f8)

it can be used from the tunable_policy `systemd_tmpfiles_manage_all`
to add the relabel permissions on all files but policy files.

<hr>

It's currently being tested in Flatcar CI: https://github.com/flatcar-linux/coreos-overlay/pull/1993 - test results:
With bool:
```
$ getsebool systemd_tmpfiles_manage_all
systemd_tmpfiles_manage_all --> on
$ journalctl --boot | grep -i avc | grep relabelfrom
Jul 18 05:41:40 localhost audit[621]: AVC avc:  denied  { relabelfrom } for  pid=621 comm="torcx-generator" name="docker" dev="tmpfs" ino=2 scontext=system_u:system_r:systemd_generator_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=dir permissive=1
Jul 18 05:41:40 localhost audit[621]: AVC avc:  denied  { relabelfrom } for  pid=621 comm="torcx-generator" name=".torcx" dev="tmpfs" ino=3 scontext=system_u:system_r:systemd_generator_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
Jul 18 05:41:40 localhost audit[621]: AVC avc:  denied  { relabelfrom } for  pid=621 comm="torcx-generator" name="manifest.json" dev="tmpfs" ino=4 scontext=system_u:system_r:systemd_generator_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1
Jul 18 05:41:44 localhost audit[760]: AVC avc:  denied  { relabelfrom } for  pid=760 comm="systemd-tmpfile" name="core" dev="vda9" ino=99 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=unconfined_u:object_r:user_home_dir_t:s0 tclass=dir permissive=1
Jul 18 05:41:44 localhost audit[760]: AVC avc:  denied  { relabelfrom } for  pid=760 comm="systemd-tmpfile" name=".ssh" dev="vda9" ino=100 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=unconfined_u:object_r:ssh_home_t:s0 tclass=dir permissive=1
```

Without bool:
```
$ getsebool systemd_tmpfiles_manage_all
systemd_tmpfiles_manage_all --> off
$ journalctl --boot | grep -i avc | grep relabelfrom
Jul 18 05:45:49 localhost audit[625]: AVC avc:  denied  { relabelfrom } for  pid=625 comm="torcx-generator" name="docker" dev="tmpfs" ino=2 scontext=system_u:system_r:systemd_generator_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=dir permissive=1
Jul 18 05:45:49 localhost audit[625]: AVC avc:  denied  { relabelfrom } for  pid=625 comm="torcx-generator" name=".torcx" dev="tmpfs" ino=3 scontext=system_u:system_r:systemd_generator_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
Jul 18 05:45:49 localhost audit[625]: AVC avc:  denied  { relabelfrom } for  pid=625 comm="torcx-generator" name="manifest.json" dev="tmpfs" ino=4 scontext=system_u:system_r:systemd_generator_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="audit" dev="vda9" ino=5841 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:auditd_etc_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="auditd.conf" dev="vda9" ino=42 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:auditd_etc_t:s0 tclass=file permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="audit" dev="vda9" ino=5849 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:auditd_log_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="profile.d" dev="vda9" ino=92 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="core" dev="vda9" ino=99 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=unconfined_u:object_r:user_home_dir_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name=".ssh" dev="vda9" ino=100 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=unconfined_u:object_r:ssh_home_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="mnt" dev="vda9" ino=104 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:mnt_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="opt" dev="vda9" ino=96 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="root" dev="vda9" ino=105 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:default_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="ssl" dev="vda9" ino=7005 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="selinux" dev="vda9" ino=7285 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:selinux_config_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="etab" dev="vda9" ino=56 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:var_lib_t:s0 tclass=file permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="sss" dev="vda9" ino=10180 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:sssd_var_lib_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="network" dev="vda9" ino=7511 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:net_conf_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="system" dev="vda9" ino=7512 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:systemd_unit_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="user" dev="vda9" ino=7521 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:systemd_user_unit_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="rules.d" dev="vda9" ino=7506 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:udev_rules_t:s0 tclass=dir permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="xtables.lock" dev="tmpfs" ino=1119 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:iptables_runtime_t:s0 tclass=file permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="mtab" dev="vda9" ino=26 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=lnk_file permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="shadow" dev="vda9" ino=24 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:shadow_t:s0 tclass=file permissive=1
Jul 18 05:45:53 localhost audit[764]: AVC avc:  denied  { relabelfrom } for  pid=764 comm="systemd-tmpfile" name="semanage.conf" dev="vda9" ino=27 scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:object_r:selinux_config_t:s0 tclass=lnk_file permissive=1
```
