### PR TITLE
systemd: add new permissions

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1073,6 +1073,8 @@ dev_read_sysfs(systemd_networkd_t)
 dev_write_kmsg(systemd_networkd_t)
 
 files_read_etc_files(systemd_networkd_t)
+# for /etc/machine-id for example
+files_read_etc_runtime_files(systemd_networkd_t)
 files_watch_runtime_dirs(systemd_networkd_t)
 files_watch_root_dirs(systemd_networkd_t)
 files_list_runtime(systemd_networkd_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1034,6 +1034,8 @@ systemd_log_parse_environment(systemd_modules_load_t)
 
 selinux_getattr_fs(systemd_modules_load_t)
 
+kernel_getattr_proc(systemd_modules_load_t)
+
 ########################################
 #
 # networkd local policy

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1032,6 +1032,8 @@ modutils_read_module_deps(systemd_modules_load_t)
 
 systemd_log_parse_environment(systemd_modules_load_t)
 
+selinux_getattr_fs(systemd_modules_load_t)
+
 ########################################
 #
 # networkd local policy


### PR DESCRIPTION
Hi, in this PR we add new permissions for `systemd-modules` and `systemd-networkd`.

* [systemd: allow systemd-modules to get selinuxfs attributes](https://github.com/SELinuxProject/refpolicy/commit/68e5550aa0497dfe78b99488b07c1db5a4f026c3)

Jul 13 14:40:21 localhost audit[690]: AVC avc:  denied  { getattr } for  pid=690 comm="systemd-modules" name="/" dev="selinuxfs" ino=1 scontext=system_u:system_r:systemd_modules_load_t:s0 tcontext=system_u:object_r:security_t:s0 tclass=filesystem permissive=1

* [systemd: allow systemd-modules to get proc attributes](https://github.com/SELinuxProject/refpolicy/commit/79e4d72098bd5caf95dafc15eeda8287b57616be)

Jul 13 14:40:21 localhost audit[690]: AVC avc:  denied  { getattr } for  pid=690 comm="systemd-modules" name="/" dev="proc" ino=1 scontext=system_u:system_r:systemd_modules_load_t:s0 tcontext=system_u:object_r:proc_t:s0 tclass=filesystem permissive=1


<hr>

It's being tested on Flatcar in https://github.com/flatcar-linux/coreos-overlay/pull/1993