### PR TITLE
ssh: allow ssh_keygen to read /usr/share/crypto-policies/

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -354,6 +354,7 @@ term_dontaudit_use_console(ssh_keygen_t)
 domain_use_interactive_fds(ssh_keygen_t)
 
 files_read_etc_files(ssh_keygen_t)
+files_read_usr_files(ssh_keygen_t)
 
 init_use_fds(ssh_keygen_t)
 init_use_script_ptys(ssh_keygen_t)


### PR DESCRIPTION
With RHEL9 /etc/crypto-policies/back-ends are symlinks to /usr/share/crypto-policies/*/*

node=localhost type=AVC msg=audit(1661303919.946:335): avc:  denied  { getattr } for  pid=1025 comm="ssh-keygen" path="/usr/share/crypto-policies/FIPS/opensslcnf.txt" dev="dm-0" ino=396589 scontext=system_u:system_r:ssh_keygen_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1661303919.946:336): avc:  denied  { read } for  pid=1025 comm="ssh-keygen" name="opensslcnf.txt" dev="dm-0" ino=396589 scontext=system_u:system_r:ssh_keygen_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1661303919.946:336): avc:  denied  { open } for  pid=1025 comm="ssh-keygen" path="/usr/share/crypto-policies/FIPS/opensslcnf.txt" dev="dm-0" ino=396589 scontext=system_u:system_r:ssh_keygen_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1