### PR TITLE
usbguard: Allow to read fips_enabled sysctl

### DIFF
--- a/policy/modules/admin/usbguard.te
+++ b/policy/modules/admin/usbguard.te
@@ -65,6 +65,7 @@ setattr_files_pattern(usbguard_t, usbguard_log_t, usbguard_log_t)
 
 dev_rw_sysfs(usbguard_t)
 
+kernel_read_crypto_sysctls(usbguard_t)
 kernel_read_kernel_sysctls(usbguard_t)
 kernel_dontaudit_getattr_proc(usbguard_t)
 


### PR DESCRIPTION
node=localhost type=AVC msg=audit(1661391275.238:339): avc:  denied  { search } for  pid=1031 comm="usbguard-daemon" name="crypto" dev="proc" ino=20463 scontext=system_u:system_r:usbguard_t:s0 tcontext=system_u:object_r:sysctl_crypto_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1661391275.238:339): avc:  denied  { read } for  pid=1031 comm="usbguard-daemon" name="fips_enabled" dev="proc" ino=20464 scontext=system_u:system_r:usbguard_t:s0 tcontext=system_u:object_r:sysctl_crypto_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1661391275.238:339): avc:  denied  { open } for  pid=1031 comm="usbguard-daemon" path="/proc/sys/crypto/fips_enabled" dev="proc" ino=20464 scontext=system_u:system_r:usbguard_t:s0 tcontext=system_u:object_r:sysctl_crypto_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1661391275.238:340): avc:  denied  { getattr } for  pid=1031 comm="usbguard-daemon" path="/proc/sys/crypto/fips_enabled" dev="proc" ino=20464 scontext=system_u:system_r:usbguard_t:s0 tcontext=system_u:object_r:sysctl_crypto_t:s0 tclass=file permissive=1

Signed-off-by: Dave Sugar <dsugar100@gmail.com>