### PR TITLE
fapolicyd: Initial SELinux policy

### DIFF
--- a/policy/modules/admin/fapolicyd.fc
+++ b/policy/modules/admin/fapolicyd.fc
@@ -1,0 +1,15 @@
+/etc/fapolicyd(/.*)?				gen_context(system_u:object_r:fapolicyd_config_t,s0)
+/etc/fapolicyd/compiled\.rules	--	gen_context(system_u:object_r:fapolicyd_compiled_rules_t,mls_systemhigh)
+
+/usr/lib/systemd/system/[^/]*fapolicyd.*   --	gen_context(system_u:object_r:fapolicyd_unit_t,s0)
+
+/usr/sbin/fapolicyd				--	gen_context(system_u:object_r:fapolicyd_exec_t,s0)
+/usr/sbin/fapolicyd-cli			--	gen_context(system_u:object_r:fapolicyc_exec_t,s0)
+/usr/sbin/fagenrules			--	gen_context(system_u:object_r:fagenrules_exec_t,s0)
+
+/var/lib/fapolicyd(/.*)?			gen_context(system_u:object_r:fapolicyd_var_lib_t,s0)
+
+/var/log/fapolicyd-access\.log	--	gen_context(system_u:object_r:fapolicyd_log_t,s0)
+
+/var/run/fapolicyd(/.*)?			gen_context(system_u:object_r:fapolicyd_runtime_t,s0)
+/var/run/fapolicyd\.pid			--	gen_context(system_u:object_r:fapolicyd_runtime_t,s0)

--- a/policy/modules/admin/fapolicyd.if
+++ b/policy/modules/admin/fapolicyd.if
@@ -1,0 +1,157 @@
+## <summary>
+## The fapolicyd software framework controls the execution of applications based
+## on a user-defined policy. This is one of the most efficient ways to prevent
+## running untrusted and possibly malicious applications on the system.
+## </summary>
+
+########################################
+## <summary>
+##	Read fapolicyd config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fapolicyd_mmap_read_config_files',`
+	gen_require(`
+		type fapolicyd_config_t;
+	')
+
+	mmap_read_files_pattern($1, fapolicyd_config_t, fapolicyd_config_t)
+')
+
+######################################
+## <summary>
+##	Execute fagenrules in the fagenrules_t domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`fapolicyd_domtrans_fagenrules',`
+	gen_require(`
+		type fagenrules_t, fagenrules_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, fagenrules_exec_t, fagenrules_t)
+')
+
+########################################
+## <summary>
+##	Execute fagenrules in the fagenrules domain,
+##	and allow the specified roles the
+##	fagenurles domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`fapolicyd_run_fagenrules',`
+	gen_require(`
+		attribute_role fagenrules_roles;
+	')
+
+	fapolicyd_domtrans_fagenrules($1)
+	roleattribute $2 fagenrules_roles;
+')
+
+
+#####################################
+## <summary>
+##	Execute fapolicyd-cli in the fapolicyc domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`fapolicyd_domtrans_cli',`
+	gen_require(`
+		type fapolicyc_t, fapolicyc_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, fapolicyc_exec_t, fapolicyc_t)
+')
+
+########################################
+## <summary>
+##	Execute fapoliyd-cli in the fapolicyc domain,
+##	and allow the specified roles the
+##	fapolicyc domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`fapolicyd_run_cli',`
+	gen_require(`
+		attribute_role fapolicyc_roles;
+	')
+
+	fapolicyd_domtrans_cli($1)
+	roleattribute $2 fapolicyc_roles;
+')
+
+########################################
+## <summary>
+##	All of the rules required to
+##	administrate an fapolicyd environment.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`fapolicyd_admin',`
+	gen_require(`
+		type fagenrules_tmp_t;
+		type fapolicyd_config_t;
+		type fapolicyd_log_t;
+		type fapolicyd_runtime_t;
+	')
+
+	files_search_tmp($1)
+	admin_pattern($1, fagenrules_tmp_t)
+
+	files_search_etc($1)
+	admin_pattern($1, fapolicyd_config_t)
+
+	logging_search_logs($1)
+	admin_pattern($1, fapolicyd_log_t)
+
+	files_search_runtime($1)
+	admin_pattern($1, fapolicyd_runtime_t)
+
+	fapolicyd_run_fagenrules($1, $2)
+	fapolicyd_run_cli($1, $2)
+')

--- a/policy/modules/admin/fapolicyd.te
+++ b/policy/modules/admin/fapolicyd.te
@@ -1,0 +1,170 @@
+policy_module(fapolicyd)
+
+########################################
+#
+# Declarations
+#
+
+attribute_role fapolicyc_roles;
+attribute_role fagenrules_roles;
+
+# for the fapolicyd daemon - long running process
+type fapolicyd_t;
+type fapolicyd_exec_t;
+init_daemon_domain(fapolicyd_t, fapolicyd_exec_t)
+
+# for the fapolicyd-cli process - interact with daemon
+type fapolicyc_t;
+type fapolicyc_exec_t;
+application_domain(fapolicyc_t, fapolicyc_exec_t)
+role fapolicyc_roles types fapolicyc_t;
+
+# for the fagenrules script - compile rules
+type fagenrules_t;
+type fagenrules_exec_t;
+application_domain(fagenrules_t, fagenrules_exec_t)
+init_script_domain(fagenrules_t, fagenrules_exec_t)
+role fagenrules_roles types fagenrules_t;
+
+type fapolicyd_config_t;
+files_config_file(fapolicyd_config_t)
+
+type fapolicyd_compiled_rules_t;
+files_security_file(fapolicyd_compiled_rules_t)
+
+type fapolicyd_log_t;
+logging_log_file(fapolicyd_log_t)
+
+type fapolicyd_runtime_t;
+files_runtime_file(fapolicyd_runtime_t)
+
+type fagenrules_tmp_t;
+files_tmp_file(fagenrules_tmp_t)
+
+type fapolicyd_unit_t;
+init_unit_file(fapolicyd_unit_t)
+
+type fapolicyd_var_lib_t;
+files_type(fapolicyd_var_lib_t)
+
+########################################
+#
+# fapolicyd (daemon) local policy
+#
+
+allow fapolicyd_t self:capability { audit_write chown dac_override setgid setuid sys_admin sys_nice sys_ptrace };
+allow fapolicyd_t self:process { setcap setsched };
+
+allow fapolicyd_t fapolicyd_log_t:file { create_file_perms write_file_perms };
+
+manage_fifo_files_pattern(fapolicyd_t, fapolicyd_runtime_t, fapolicyd_runtime_t)
+manage_files_pattern(fapolicyd_t, fapolicyd_runtime_t, fapolicyd_runtime_t)
+
+# compiled rules, compiled by /sbin/fagenrules and copied into place, then restorecon
+read_files_pattern(fapolicyd_t, fapolicyd_config_t, fapolicyd_compiled_rules_t)
+
+mmap_manage_files_pattern(fapolicyd_t, fapolicyd_var_lib_t, fapolicyd_var_lib_t)
+
+kernel_getattr_proc(fapolicyd_t)
+kernel_read_kernel_sysctls(fapolicyd_t)
+
+domain_read_all_domains_state(fapolicyd_t)
+
+files_read_all_files(fapolicyd_t)
+files_read_all_symlinks(fapolicyd_t)
+files_runtime_filetrans(fapolicyd_t, fapolicyd_runtime_t, { file fifo_file })
+files_map_usr_files(fapolicyd_t)
+files_watch_all_mountpoints(fapolicyd_t)
+files_watch_all_mount_perm(fapolicyd_t)
+
+fs_getattr_xattr_fs(fapolicyd_t)
+
+logging_log_filetrans(fapolicyd_t, fapolicyd_log_t, file)
+logging_send_syslog_msg(fapolicyd_t)
+
+fapolicyd_mmap_read_config_files(fapolicyd_t)
+
+optional_policy(`
+	rpm_manage_db(fapolicyd_t)
+')
+
+########################################
+#
+# fagenrules local policy
+#
+
+allow fagenrules_t self:capability { fsetid kill };
+allow fagenrules_t self:fifo_file rw_inherited_fifo_file_perms;
+
+
+# fagenpolicy finds running fapolicyd and sighup after generating rules
+allow fagenrules_t fapolicyd_t:process signal;
+ps_process_pattern(fagenrules_t, fapolicyd_t)
+
+# /sbin/fagenrules copies compiled rules into /etc/faplicyd then calls restorecon
+# on new /etc/fapolicy/compiled.rules
+allow fagenrules_t fapolicyd_compiled_rules_t:file { relabelfrom relabelto };
+filetrans_pattern(fagenrules_t, fapolicyd_config_t, fapolicyd_compiled_rules_t, file)
+manage_files_pattern(fagenrules_t, fapolicyd_config_t, fapolicyd_compiled_rules_t)
+
+manage_files_pattern(fagenrules_t, fapolicyd_var_lib_t, fapolicyd_var_lib_t)
+
+kernel_getattr_proc(fagenrules_t)
+kernel_read_kernel_sysctls(fagenrules_t)
+kernel_read_system_state(fagenrules_t)
+
+corecmd_exec_bin(fagenrules_t)
+corecmd_exec_shell(fagenrules_t)
+
+# fagenpolicy uses 'pidof' to find running fapolicyd
+domain_dontaudit_read_all_domains_state(fagenrules_t)
+domain_use_interactive_fds(fagenrules_t)
+
+files_list_runtime(fagenrules_t)
+files_read_etc_files(fagenrules_t)
+files_read_usr_files(fagenrules_t)
+files_search_var_lib(fagenrules_t)
+
+files_tmp_filetrans(fagenrules_t, fagenrules_tmp_t, { dir file })
+manage_files_pattern(fagenrules_t, fagenrules_tmp_t, fagenrules_tmp_t)
+
+init_rw_stream_sockets(fagenrules_t)
+
+logging_send_syslog_msg(fagenrules_t)
+
+miscfiles_read_localization(fagenrules_t)
+
+seutil_exec_setfiles(fagenrules_t)
+seutil_read_file_contexts(fagenrules_t)
+
+userdom_use_inherited_user_terminals(fagenrules_t)
+
+fapolicyd_mmap_read_config_files(fagenrules_t)
+
+########################################
+#
+# fapolicyc (fapolicyd-cli) local policy
+#
+
+allow fapolicyc_t fapolicyd_runtime_t:fifo_file write_fifo_file_perms;
+mmap_manage_files_pattern(fapolicyc_t, fapolicyd_var_lib_t, fapolicyd_var_lib_t)
+mmap_read_files_pattern(fapolicyc_t, fapolicyd_config_t, fapolicyd_compiled_rules_t)
+
+kernel_getattr_proc(fapolicyc_t)
+kernel_list_proc(fapolicyc_t)
+kernel_read_kernel_sysctls(fapolicyc_t)
+
+corecmd_search_bin(fapolicyc_t)
+
+domain_use_interactive_fds(fapolicyc_t)
+
+files_list_runtime(fapolicyc_t)
+files_read_all_files(fapolicyc_t)
+files_read_etc_files(fapolicyc_t)
+
+logging_send_syslog_msg(fapolicyc_t)
+
+userdom_use_inherited_user_terminals(fapolicyc_t)
+
+fapolicyd_mmap_read_config_files(fapolicyc_t)
+

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1904,6 +1904,42 @@ interface(`files_dontaudit_list_all_mountpoints',`
 
 ########################################
 ## <summary>
+##	Watch all mountpoints.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_all_mountpoints',`
+	gen_require(`
+		attribute mountpoint;
+	')
+
+	allow $1 mountpoint:dir watch_mount;
+')
+
+########################################
+## <summary>
+##	Watch all mountpoints.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_all_mount_perm',`
+	gen_require(`
+		attribute mountpoint;
+	')
+
+	allow $1 mountpoint:dir watch_with_perm;
+')
+
+########################################
+## <summary>
 ##	Check if all mountpoints are writable.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -400,6 +400,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	fapolicyd_admin(sysadm_t, sysadm_r)
+')
+
+optional_policy(`
 	fcoe_admin(sysadm_t, sysadm_r)
 ')
 


### PR DESCRIPTION
Initial policy for fapolicyd running on RHEL9.  Looked a bit at the RHEL9 policy, but here I have setup different domains for the fapolicyd daemon vs. the fapolicyd-cli vs. fagenpolicy (tool to regen the policy)

I'm sure there will be comments and if there are specific rules in question I'm happy to gather denials.  This was a bit of work and lots of denials while making progress.

Signed-off-by: Dave Sugar <dsugar100@gmail.com>