### PR TITLE
Allow systemd as `init_t` to make `root_t` and `syslogd_var_run_t` files

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -304,6 +304,8 @@ ifdef(`init_systemd',`
 	domain_setpriority_all_domains(init_t)
 
 	allow init_t init_runtime_t:{ dir file } watch;
+	allow init_t root_t:file create;
+	allow init_t syslogd_var_run_t:file create;
 	manage_files_pattern(init_t, init_runtime_t, init_runtime_t)
 	manage_lnk_files_pattern(init_t, init_runtime_t, init_runtime_t)
 	manage_sock_files_pattern(init_t, init_runtime_t, init_runtime_t)


### PR DESCRIPTION
When using `TemporaryFileSystem=/:ro` and then the suggested
`BindReadOnlyPaths=/dev/log /run/systemd/journal/socket /run/systemd/journal/stdout`
to generate an isolated runtime with logging, selinux needs to permit
`init_t` to create files under the `root_t` and `syslogd_var_run_t` type.
This allows systemd to spin up a mount namespace for service isolation.

Signed-off-by: Pat Riehecky <riehecky@fnal.gov>