### PR TITLE
sysadm: move systemd_dbus_chat_hostnamed to init_systemd block

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -93,6 +93,9 @@ ifdef(`init_systemd',`
 	systemd_dbus_chat_networkd(sysadm_t)
 	fs_read_nsfs_files(sysadm_t)
 
+	# Allow sysadm to run hostnamectl
+	systemd_dbus_chat_hostnamed(sysadm_t)
+
 	# Allow sysadm to follow logs in the journal, i.e. with podman logs -f
 	systemd_watch_journal_dirs(sysadm_t)
 ')
@@ -1037,10 +1040,6 @@ optional_policy(`
 
 optional_policy(`
 	sysstat_admin(sysadm_t, sysadm_r)
-')
-
-optional_policy(`
-	systemd_dbus_chat_hostnamed(sysadm_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Signed-off-by: Yi Zhao <yi.zhao@windriver.com>