### PR TITLE
systemd: allow systemd user to watch /etc directories

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -90,6 +90,7 @@ template(`systemd_role_template',`
 	dev_read_urand($1_systemd_t)
 
 	files_search_home($1_systemd_t)
+	files_watch_etc_dirs($1_systemd_t)
 
 	fs_getattr_xattr_fs($1_systemd_t)
 	fs_manage_cgroup_files($1_systemd_t)


### PR DESCRIPTION
Fixes:
avc:  denied  { watch } for  pid=329 comm="systemd" path="/etc"
dev="vda" ino=176 scontext=root:sysadm_r:sysadm_systemd_t
tcontext=system_u:object_r:etc_t tclass=dir permissive=0

systemd[329]: Failed to create timezone change event source: Permission denied

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>