### PR TITLE
selinuxutil: allow semanage to read fips state

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -492,6 +492,7 @@ allow semanage_t semanage_tmp_t:dir manage_dir_perms;
 allow semanage_t semanage_tmp_t:file { manage_file_perms mmap_exec_file_perms };
 files_tmp_filetrans(semanage_t, semanage_tmp_t, { file dir })
 
+kernel_read_crypto_sysctls(semanage_t)
 kernel_read_system_state(semanage_t)
 kernel_read_kernel_sysctls(semanage_t)
 kernel_dontaudit_getattr_proc(semanage_t)


### PR DESCRIPTION
May  9 15:09:48 localhost audispd: node=localhost type=AVC msg=audit(1652108988.025:431): avc:  denied  { read } for  pid=1872 comm="semanage" name="fips_enabled" dev="proc" ino=14036 scontext=system_u:system_r:semanage_t:s0 tcontext=system_u:object_r:sysctl_crypto_t:s0 tclass=file permissive=1
May  9 15:09:48 localhost audispd: node=localhost type=AVC msg=audit(1652108988.025:431): avc:  denied  { open } for  pid=1872 comm="semanage" path="/proc/sys/crypto/fips_enabled" dev="proc" ino=14036 scontext=system_u:system_r:semanage_t:s0 tcontext=system_u:object_r:sysctl_crypto_t:s0 tclass=file permissive=1

Signed-off-by: Dave Sugar <dsugar100@gmail.com>