### PR TITLE
Replace deprecated egrep usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ SECHECK ?= $(BINDIR)/sechecker
 
 # interpreters and aux tools
 AWK ?= gawk
-GREP ?= egrep
+GREP ?= grep -E
 INSTALL ?= install
 M4 ?= m4 -E -E
 PYTHON ?= python3 -bb -t -t -E -W error
@@ -324,7 +324,7 @@ off_mods += $(filter-out $(cmdline_off) $(cmdline_base) $(cmdline_mods), $(mod_c
 off_mods += $(filter-out $(base_mods) $(mod_mods) $(off_mods),$(notdir $(detected_mods)))
 
 # filesystems to be used in labeling targets
-filesystems = $(shell mount | grep -v "context=" | egrep -v '\((|.*,)bind(,.*|)\)' | $(AWK) '/(ext[234]|btrfs| xfs| jfs).*rw/{print $$3}';)
+filesystems = $(shell mount | grep -v "context=" | $(GREP) -v '\((|.*,)bind(,.*|)\)' | $(AWK) '/(ext[234]|btrfs| xfs| jfs).*rw/{print $$3}';)
 fs_names := "btrfs ext2 ext3 ext4 xfs jfs"
 
 ########################################


### PR DESCRIPTION
egrep has been deprecated since 2007 and with version 3.8 calling this commands issues a warning.