### PR TITLE
init: Add tunable for systemd to create all its mountpoints.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,8 +45,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    needs: lint
-
     strategy:
       fail-fast: false
 
@@ -79,7 +77,7 @@ jobs:
           - {type: mls, distro: redhat, monolithic: y, systemd: y, apps-off: unconfined}
           - {type: mls, distro: debian, monolithic: y, systemd: y, apps-off: unconfined}
           - {type: mls, distro: gentoo, monolithic: y, systemd: n, apps-off: unconfined}
-  
+
     steps:
     - uses: actions/checkout@v2
 

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -610,6 +610,24 @@ interface(`files_manage_non_security_dirs',`
 
 ########################################
 ## <summary>
+##	Create non-security directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_create_non_security_dirs',`
+	gen_require(`
+		attribute non_security_file_type;
+	')
+
+	create_dirs_pattern($1, non_security_file_type, non_security_file_type)
+')
+
+########################################
+## <summary>
 ##	Relabel from/to non-security directories.
 ## </summary>
 ## <param name="domain">
@@ -787,6 +805,46 @@ interface(`files_read_non_security_files',`
 	')
 
 	read_files_pattern($1, non_security_file_type, non_security_file_type)
+	read_lnk_files_pattern($1, non_security_file_type, non_security_file_type)
+')
+
+########################################
+## <summary>
+##	Write all non-security files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`files_write_non_security_files',`
+	gen_require(`
+		attribute non_security_file_type;
+	')
+
+	write_files_pattern($1, non_security_file_type, non_security_file_type)
+	read_lnk_files_pattern($1, non_security_file_type, non_security_file_type)
+')
+
+########################################
+## <summary>
+##	Create all non-security files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`files_create_non_security_files',`
+	gen_require(`
+		attribute non_security_file_type;
+	')
+
+	create_files_pattern($1, non_security_file_type, non_security_file_type)
 	read_lnk_files_pattern($1, non_security_file_type, non_security_file_type)
 ')
 

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -1657,6 +1657,42 @@ interface(`kernel_dontaudit_list_all_proc',`
 
 ########################################
 ## <summary>
+##	Write systemd mountpoint files except proc entries.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_write_non_proc_init_mountpoint_files',`
+	gen_require(`
+		attribute proc_type;
+	')
+
+	init_write_mountpoint_files($1, -proc_type)
+')
+
+########################################
+## <summary>
+##	Create systemd mountpoint files except proc entries.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_create_non_proc_init_mountpoint_files',`
+	gen_require(`
+		attribute proc_type;
+	')
+
+	init_create_mountpoint_files($1, -proc_type)
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts by caller to search
 ##	the base directory of sysctls.
 ## </summary>

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -944,6 +944,54 @@ interface(`init_setsched',`
 
 ########################################
 ## <summary>
+##	Write systemd mountpoint files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="exception_types" optional="true">
+##	<summary>
+##	The types to be excluded.  Each type or attribute
+##	must be negated by the caller.
+##	</summary>
+## </param>
+#
+interface(`init_write_mountpoint_files',`
+	gen_require(`
+		attribute init_mountpoint_type;
+	')
+
+	allow $1 { init_mountpoint_type $2 }:file write_file_perms;
+')
+
+########################################
+## <summary>
+##	Create systemd mountpoint files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="exception_types" optional="true">
+##	<summary>
+##	The types to be excluded.  Each type or attribute
+##	must be negated by the caller.
+##	</summary>
+## </param>
+#
+interface(`init_create_mountpoint_files',`
+	gen_require(`
+		attribute init_mountpoint_type;
+	')
+
+	allow $1 { init_mountpoint_type $2 }:file create_file_perms;
+')
+
+########################################
+## <summary>
 ##	Connect to init with a unix socket.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -18,6 +18,13 @@ gen_tunable(init_upstart, false)
 
 ## <desc>
 ## <p>
+## Enable systemd to create mountpoints.
+## </p>
+## </desc>
+gen_tunable(init_create_mountpoints, false)
+
+## <desc>
+## <p>
 ## Allow all daemons the ability to read/write terminals
 ## </p>
 ## </desc>
@@ -536,6 +543,22 @@ ifdef(`init_systemd',`
 	udev_relabel_rules_files(init_t)
 
 	userdom_relabel_user_runtime_root_dirs(init_t)
+
+	tunable_policy(`init_create_mountpoints',`
+		allow init_t init_mountpoint_type:dir { create_dir_perms add_entry_dir_perms };
+                allow init_t init_mountpoint_type:fifo_file create_fifo_file_perms;
+		allow init_t init_mountpoint_type:sock_file create_sock_file_perms;
+		allow init_t init_mountpoint_type:lnk_file create_lnk_file_perms;
+
+		kernel_write_non_proc_init_mountpoint_files(init_t)
+		kernel_create_non_proc_init_mountpoint_files(init_t)
+	')
+
+	tunable_policy(`init_create_mountpoints && init_mounton_non_security',`
+		files_create_non_security_dirs(init_t)
+		files_create_non_security_files(init_t)
+		files_write_non_security_files(init_t)
+	')
 
 	tunable_policy(`init_mounton_non_security',`
 		files_mounton_non_security(init_t)


### PR DESCRIPTION
For non-security mounting, only dir and file access are added, as these are the only ones allowed in the mounton call.
