### PR TITLE
fix some denials spamming audit log

### DIFF
--- a/policy/modules/services/firewalld.te
+++ b/policy/modules/services/firewalld.te
@@ -39,6 +39,7 @@ allow firewalld_t self:unix_stream_socket { accept listen };
 allow firewalld_t self:netlink_netfilter_socket create_socket_perms;
 allow firewalld_t self:udp_socket create_socket_perms;
 
+allow firewalld_t firewalld_etc_rw_t:dir watch;
 manage_dirs_pattern(firewalld_t, firewalld_etc_rw_t, firewalld_etc_rw_t)
 manage_files_pattern(firewalld_t, firewalld_etc_rw_t, firewalld_etc_rw_t)
 dontaudit firewalld_t firewalld_etc_rw_t:file { relabelfrom relabelto };
@@ -54,7 +55,7 @@ files_tmp_filetrans(firewalld_t, firewalld_tmp_t, file)
 allow firewalld_t firewalld_tmp_t:file mmap_exec_file_perms;
 
 manage_dirs_pattern(firewalld_t, firewalld_runtime_t, firewalld_runtime_t)
-manage_files_pattern(firewalld_t, firewalld_runtime_t, firewalld_runtime_t)
+mmap_manage_files_pattern(firewalld_t, firewalld_runtime_t, firewalld_runtime_t)
 files_runtime_filetrans(firewalld_t, firewalld_runtime_t, { dir file })
 
 manage_dirs_pattern(firewalld_t, firewalld_tmpfs_t, firewalld_tmpfs_t)
@@ -82,6 +83,8 @@ files_dontaudit_list_tmp(firewalld_t)
 fs_getattr_xattr_fs(firewalld_t)
 
 logging_send_syslog_msg(firewalld_t)
+
+libs_watch_lib_dirs(firewalld_t)
 
 miscfiles_read_localization(firewalld_t)
 

--- a/policy/modules/services/networkmanager.te
+++ b/policy/modules/services/networkmanager.te
@@ -145,6 +145,7 @@ files_manage_etc_symlinks(NetworkManager_t)
 files_read_etc_runtime_files(NetworkManager_t)
 files_read_usr_files(NetworkManager_t)
 files_read_usr_src_files(NetworkManager_t)
+files_watch_etc_dirs(NetworkManager_t)
 
 fs_getattr_all_fs(NetworkManager_t)
 fs_search_auto_mountpoints(NetworkManager_t)
@@ -165,6 +166,8 @@ auth_use_nsswitch(NetworkManager_t)
 
 logging_send_audit_msgs(NetworkManager_t)
 logging_send_syslog_msg(NetworkManager_t)
+
+libs_watch_lib_dirs(NetworkManager_t)
 
 miscfiles_read_generic_certs(NetworkManager_t)
 miscfiles_read_localization(NetworkManager_t)

--- a/policy/modules/system/libraries.if
+++ b/policy/modules/system/libraries.if
@@ -278,6 +278,24 @@ interface(`libs_manage_lib_dirs',`
 
 ########################################
 ## <summary>
+##	Watch /usr/lib directories
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`libs_watch_lib_dirs',`
+	gen_require(`
+		type lib_t;
+	')
+
+	allow $1 lib_t:dir watch;
+')
+
+########################################
+## <summary>
 ##	dontaudit attempts to setattr on library files
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Seeing a bunch of dir watch denials from firewalld_t and NetworkManager_t spamming audit log.  