### PR TITLE
userdomain: allow access of login process state

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -696,6 +696,8 @@ template(`userdom_common_user_template',`
 
 	init_read_utmp($1_t)
 
+	locallogin_read_state($1_t)
+
 	seutil_read_file_contexts($1_t)
 	seutil_read_default_contexts($1_t)
 	seutil_run_newrole($1_t, $1_r)


### PR DESCRIPTION
I'm seeing the following denials:
node=localhost type=AVC msg=audit(1663348441.241:4770): avc:  denied  { getattr } for  pid=3600 comm="ps" path="/proc/3589" dev="proc" ino=24789 scontext=staff_u:staff_r:staff_t:s0 tcontext=system_u:system_r:local_login_t:s0 tclass=dir permissive=0 
node=localhost type=AVC msg=audit(1663348486.100:7436): avc:  denied  { getattr } for  pid=3654 comm="ps" path="/proc/3646" dev="proc" ino=22876 scontext=staff_u:staff_r:staff_t:s0 tcontext=system_u:system_r:local_login_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1663348486.100:7437): avc:  denied  { search } for  pid=3654 comm="ps" name="3646" dev="proc" ino=22876 scontext=staff_u:staff_r:staff_t:s0 tcontext=system_u:system_r:local_login_t:s0 tclass=dir permissive=1 
node=localhost type=AVC msg=audit(1663348486.100:7437): avc:  denied  { read } for  pid=3654 comm="ps" name="stat" dev="proc" ino=22877 scontext=staff_u:staff_r:staff_t:s0 tcontext=system_u:system_r:local_login_t:s0 tclass=file permissive=1 
node=localhost type=AVC msg=audit(1663348486.100:7437): avc:  denied  { open } for  pid=3654 comm="ps" path="/proc/3646/stat" dev="proc" ino=22877 scontext=staff_u:staff_r:staff_t:s0 tcontext=system_u:system_r:local_login_t:s0 tclass=file permissive=1

But, this is happening in a script added for STIG support CCE-90586-9 which requires tmux to be used.  The script uses 'ps' to determine login type and launch tmux in certain cases.  These denials are from the use of 'ps'. I don't know this belongs in refpolicy, but I figure many people using refpolicy will also be required to meet STIG requiremetns so it maybe relvant.

Signed-off-by: Dave Sugar <dsugar100@gmail.com>