### PR TITLE
init_t: fix long delay during shutdown

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1015,6 +1015,8 @@ ifdef(`distro_redhat',`
 
 	fs_read_tmpfs_symlinks(initrc_t)
 	fs_rw_tmpfs_chr_files(initrc_t)
+	fs_manage_tmpfs_dirs(initrc_t)
+	fs_manage_tmpfs_files(initrc_t)
 
 	storage_manage_fixed_disk(initrc_t)
 	storage_dev_filetrans_fixed_disk(initrc_t)


### PR DESCRIPTION
Seeing long delay during shutdown saying: 'A stop job is running for Restore /run/initramfs on shutdown'
These were the denials in audit.log related to this

node=localhost type=AVC msg=audit(1663379349.428:5081): avc:  denied  { write } for  pid=3594 comm="cpio" name="initramfs" dev="tmpfs" ino=18 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=dir permissive=1 node=localhost type=AVC msg=audit(1663379349.428:5081): avc:  denied  { add_name } for  pid=3594 comm="cpio" name="bin" scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=dir permissive=1 node=localhost type=AVC msg=audit(1663379349.429:5083): avc:  denied  { create } for  pid=3594 comm="cpio" name="dev" scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=dir permissive=1 node=localhost type=AVC msg=audit(1663379349.429:5084): avc:  denied  { setattr } for  pid=3594 comm="cpio" name="dev" dev="tmpfs" ino=1356 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=dir permissive=1 node=localhost type=AVC msg=audit(1663379349.430:5087): avc:  denied  { create } for  pid=3594 comm="cpio" name="systemd.conf" scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1 node=localhost type=AVC msg=audit(1663379349.430:5087): avc:  denied  { write open } for pid=3594 comm="cpio" path="/run/initramfs/etc/conf.d/systemd.conf" dev="tmpfs" ino=1365 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1 node=localhost type=AVC msg=audit(1663379349.430:5088): avc:  denied  { setattr } for  pid=3594 comm="cpio" name="systemd.conf" dev="tmpfs" ino=1365 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1 node=localhost type=AVC msg=audit(1663379349.834:5119): avc:  denied  { read } for  pid=3594 comm="cpio" name="gr737d-8x16.psfu.gz" dev="tmpfs" ino=1632 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1 node=localhost type=AVC msg=audit(1663379349.834:5119): avc:  denied  { link } for  pid=3594 comm="cpio" name="gr737d-8x16.psfu.gz" dev="tmpfs" ino=1632 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1

Also seeing the following, but seems to function without related rules:

node=localhost type=AVC msg=audit(1663379349.428:5081): avc:  denied  { create } for  pid=3594 comm="cpio" name="bin" scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=lnk_file permissive=1 node=localhost type=AVC msg=audit(1663379349.428:5082): avc:  denied  { setattr } for  pid=3594 comm="cpio" name="bin" dev="tmpfs" ino=1355 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=lnk_file permissive=1 node=localhost type=AVC msg=audit(1663379349.429:5085): avc:  denied  { create } for  pid=3594 comm="cpio" name="console" scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=chr_file permissive=1 node=localhost type=AVC msg=audit(1663379349.429:5086): avc:  denied  { setattr } for  pid=3594 comm="cpio" name="console" dev="tmpfs" ino=1357 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=chr_file permissive=1

Signed-off-by: Dave Sugar <dsugar100@gmail.com>