### PR TITLE
radius: fixes for freeradius

### DIFF
--- a/policy/modules/services/radius.te
+++ b/policy/modules/services/radius.te
@@ -32,9 +32,9 @@ files_type(radiusd_var_lib_t)
 # Local policy
 #
 
-allow radiusd_t self:capability { chown dac_override fsetid kill setgid setuid sys_resource sys_tty_config };
+allow radiusd_t self:capability { chown dac_override dac_read_search fsetid kill setgid setuid sys_resource sys_tty_config };
 dontaudit radiusd_t self:capability sys_tty_config;
-allow radiusd_t self:process { getsched setrlimit setsched sigkill signal };
+allow radiusd_t self:process { getcap getsched setrlimit setsched sigkill signal };
 allow radiusd_t self:fifo_file rw_fifo_file_perms;
 allow radiusd_t self:unix_stream_socket { accept listen };
 allow radiusd_t self:tcp_socket { accept listen };


### PR DESCRIPTION
* Add dac_read_search capability to radiusd_t
* Add getcap, ptrace and execmem to radiusd_t process

Fixes:
avc: denied { dac_read_search } for pid=473 comm="radiusd" capability=2 scontext=system_u:system_r:radiusd_t
tcontext=system_u:system_r:radiusd_t tclass=capability permissive=1

avc: denied { getcap } for pid=473 comm="radiusd"
scontext=system_u:system_r:radiusd_t
tcontext=system_u:system_r:radiusd_t tclass=process permissive=1

avc: denied { ptrace } for pid=474 comm="radiusd"
scontext=system_u:system_r:radiusd_t
tcontext=system_u:system_r:radiusd_t tclass=process permissive=1

avc: denied { execmem } for pid=475 comm="radiusd" scontext=system_u:system_r:radiusd_t
tcontext=system_u:system_r:radiusd_t tclass=process permissive=1

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>