### PR TITLE
Add a policy for OpenSM

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -2406,6 +2406,24 @@ interface(`dev_rw_hyperv_vss',`
 
 ########################################
 ## <summary>
+##	Allow read/write access to InfiniBand devices.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_rw_infiniband',`
+	gen_require(`
+		type device_t, infiniband_device_t;
+	')
+
+	rw_chr_files_pattern($1, device_t, infiniband_device_t)
+')
+
+########################################
+## <summary>
 ##	Read the kernel messages
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -733,6 +733,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	opensm_admin(sysadm_t, sysadm_r)
+')
+
+optional_policy(`
 	openvpn_admin(sysadm_t, sysadm_r)
 ')
 

--- a/policy/modules/services/opensm.fc
+++ b/policy/modules/services/opensm.fc
@@ -1,0 +1,10 @@
+/usr/bin/opensm	--	gen_context(system_u:object_r:opensm_exec_t,s0)
+
+/usr/sbin/opensm	--	gen_context(system_u:object_r:opensm_exec_t,s0)
+
+/etc/opensm(/.*)?		gen_context(system_u:object_r:opensm_conf_t,s0)
+
+/var/cache/opensm(/.*)?		gen_context(system_u:object_r:opensm_cache_t,s0)
+
+/var/log/opensm\.log	--	gen_context(system_u:object_r:opensm_log_t,s0)
+/var/log/opensm-subnet\.lst	--	gen_context(system_u:object_r:opensm_log_t,s0)

--- a/policy/modules/services/opensm.if
+++ b/policy/modules/services/opensm.if
@@ -1,0 +1,86 @@
+## <summary>OpenSM is a software implementation of an InfiniBand subnet manager.</summary>
+
+########################################
+## <summary>
+##	Execute opensm in the opensm domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`opensm_domtrans',`
+	gen_require(`
+		type opensm_t, opensm_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, opensm_exec_t, opensm_t)
+')
+
+########################################
+## <summary>
+##	Execute opensm in the opensm domain, and
+##	allow the specified role the opensm domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`opensm_run',`
+	gen_require(`
+		type opensm_t;
+	')
+
+	opensm_domtrans($1)
+	role $2 types opensm_t;
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an opensm environment.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`opensm_admin',`
+	gen_require(`
+		type opensm_t;
+		type opensm_conf_t, opensm_cache_t;
+		type opensm_log_t;
+	')
+
+	opensm_run($1, $2)
+
+	allow $1 opensm_t:process { ptrace signal_perms };
+	ps_process_pattern($1, opensm_t)
+
+	files_search_etc($1)
+	admin_pattern($1, opensm_conf_t)
+
+	files_search_var($1)
+	admin_pattern($1, opensm_cache_t)
+
+	logging_search_logs($1)
+	admin_pattern($1, opensm_log_t)
+')

--- a/policy/modules/services/opensm.te
+++ b/policy/modules/services/opensm.te
@@ -1,0 +1,45 @@
+policy_module(opensm)
+
+########################################
+#
+# Declarations
+#
+
+type opensm_t;
+type opensm_exec_t;
+init_daemon_domain(opensm_t, opensm_exec_t)
+
+type opensm_conf_t;
+files_config_file(opensm_conf_t)
+
+type opensm_cache_t;
+files_type(opensm_cache_t)
+
+type opensm_log_t;
+logging_log_file(opensm_log_t)
+
+########################################
+#
+# opensm local policy
+#
+
+allow opensm_t self:process { getsched signal };
+allow opensm_t self:unix_dgram_socket create_socket_perms;
+
+read_files_pattern(opensm_t, opensm_conf_t, opensm_conf_t)
+
+manage_dirs_pattern(opensm_t, opensm_cache_t, opensm_cache_t)
+manage_files_pattern(opensm_t, opensm_cache_t, opensm_cache_t)
+files_var_filetrans(opensm_t, opensm_cache_t, dir)
+
+create_files_pattern(opensm_t, opensm_log_t, opensm_log_t)
+append_files_pattern(opensm_t, opensm_log_t, opensm_log_t)
+rw_files_pattern(opensm_t, opensm_log_t, opensm_log_t)
+logging_log_filetrans(opensm_t, opensm_log_t, file)
+
+dev_read_sysfs(opensm_t)
+dev_rw_infiniband(opensm_t)
+
+logging_send_syslog_msg(opensm_t)
+
+miscfiles_read_localization(opensm_t)


### PR DESCRIPTION
Add a policy for [OpenSM](https://github.com/linux-rdma/opensm), a software implementation of an InfiniBand subnet manager.