### PR TITLE
logging: allow systemd-journal to write syslogd_runtime_t sock_file

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -437,7 +437,7 @@ files_search_var_lib(syslogd_t)
 
 # manage runtime files
 allow syslogd_t syslogd_runtime_t:dir create_dir_perms;
-allow syslogd_t syslogd_runtime_t:sock_file { create setattr unlink };
+allow syslogd_t syslogd_runtime_t:sock_file manage_sock_file_perms;
 allow syslogd_t syslogd_runtime_t:file map;
 manage_files_pattern(syslogd_t, syslogd_runtime_t, syslogd_runtime_t)
 files_runtime_filetrans(syslogd_t, syslogd_runtime_t, file)


### PR DESCRIPTION
Fixes:
avc:  denied  { write } for  pid=165 comm="systemd-journal" name="syslog" dev="tmpfs" ino=545 scontext=system_u:system_r:syslogd_t tcontext=system_u:object_r:syslogd_runtime_t tclass=sock_file permissive=0

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>