### PR TITLE
A few minor fixes

### DIFF
--- a/policy/modules/admin/usbguard.fc
+++ b/policy/modules/admin/usbguard.fc
@@ -5,6 +5,8 @@
 /run/usbguard(/.*)?					gen_context(system_u:object_r:usbguard_runtime_t,s0)
 /run/usbguard\.pid					gen_context(system_u:object_r:usbguard_runtime_t,s0)
 
+/usr/bin/usbguard-daemon			--	gen_context(system_u:object_r:usbguard_daemon_exec_t,s0)
+
 /usr/sbin/usbguard-daemon			--	gen_context(system_u:object_r:usbguard_daemon_exec_t,s0)
 
 /var/log/usbguard(/.*)?					gen_context(system_u:object_r:usbguard_log_t,s0)

--- a/policy/modules/admin/usermanage.fc
+++ b/policy/modules/admin/usermanage.fc
@@ -4,6 +4,7 @@ ifdef(`distro_debian',`
 
 /usr/bin/chage		--	gen_context(system_u:object_r:passwd_exec_t,s0)
 /usr/bin/chfn		--	gen_context(system_u:object_r:chfn_exec_t,s0)
+/usr/bin/chpasswd	--	gen_context(system_u:object_r:passwd_exec_t,s0)
 /usr/bin/chsh		--	gen_context(system_u:object_r:chfn_exec_t,s0)
 /usr/bin/crack_[a-z]*	--	gen_context(system_u:object_r:crack_exec_t,s0)
 /usr/bin/cracklib-[a-z]* --	gen_context(system_u:object_r:crack_exec_t,s0)

--- a/policy/modules/services/dbus.if
+++ b/policy/modules/services/dbus.if
@@ -709,6 +709,25 @@ interface(`dbus_read_system_bus_runtime_named_sockets',`
 	allow $1 system_dbusd_runtime_t:sock_file read;
 ')
 
+#######################################
+## <summary>
+##	Do not audit attempts to write to
+##	system bus runtime named sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`dbus_dontaudit_write_system_bus_runtime_named_sockets',`
+	gen_require(`
+		type system_dbusd_runtime_t;
+	')
+
+	dontaudit $1 system_dbusd_runtime_t:sock_file write;
+')
+
 ########################################
 ## <summary>
 ##	Unconfined access to DBUS.

--- a/policy/modules/services/git.fc
+++ b/policy/modules/services/git.fc
@@ -4,9 +4,12 @@ HOME_DIR/\.gitconfig	--	gen_context(system_u:object_r:git_xdg_config_t,s0)
 HOME_DIR/\.git-credentials	--	gen_context(system_u:object_r:git_xdg_config_t,s0)
 
 /usr/bin/git	--	gen_context(system_u:object_r:git_exec_t,s0)
+/usr/bin/git-[^/]+	--	gen_context(system_u:object_r:git_exec_t,s0)
+/usr/bin/git2_cli	--	gen_context(system_u:object_r:git_exec_t,s0)
 
 /usr/lib/git-core/git-daemon	--	gen_context(system_u:object_r:gitd_exec_t,s0)
 
+/usr/libexec/git-core/git-[^/]+ --	gen_context(system_u:object_r:git_exec_t,s0)
 /usr/libexec/git-core/git-daemon --	gen_context(system_u:object_r:gitd_exec_t,s0)
 
 /usr/share/gitweb/gitweb\.cgi	--	gen_context(system_u:object_r:httpd_git_script_exec_t,s0)

--- a/policy/modules/services/node_exporter.fc
+++ b/policy/modules/services/node_exporter.fc
@@ -1,5 +1,7 @@
 /run/node_exporter\.pid	--	gen_context(system_u:object_r:node_exporter_runtime_t,s0)
 
+/usr/bin/node_exporter	--	gen_context(system_u:object_r:node_exporter_exec_t,s0)
+
 /usr/sbin/node_exporter	--	gen_context(system_u:object_r:node_exporter_exec_t,s0)
 
 /var/lib/node_exporter(/.*)?	gen_context(system_u:object_r:node_exporter_var_lib_t,s0)

--- a/policy/modules/services/rpc.if
+++ b/policy/modules/services/rpc.if
@@ -425,5 +425,5 @@ interface(`rpc_admin',`
 	files_list_tmp($1)
 	admin_pattern($1, gssd_tmp_t)
 
-	fs_search_nfsd_fs($1)
+	fs_rw_nfsd_fs($1)
 ')

--- a/policy/modules/services/rpc.te
+++ b/policy/modules/services/rpc.te
@@ -264,6 +264,7 @@ fs_watch_rpc_pipefs_dirs(rpcd_t)
 fs_get_all_fs_quotas(rpcd_t)
 fs_set_xattr_fs_quotas(rpcd_t)
 fs_getattr_all_fs(rpcd_t)
+fs_ioctl_cgroup_dirs(rpcd_t)
 
 storage_getattr_fixed_disk_dev(rpcd_t)
 
@@ -271,6 +272,9 @@ selinux_dontaudit_read_fs(rpcd_t)
 
 miscfiles_read_generic_certs(rpcd_t)
 miscfiles_read_generic_tls_privkey(rpcd_t)
+
+# for mount.nfs
+mount_rw_runtime_files(rpcd_t)
 
 seutil_dontaudit_search_config(rpcd_t)
 

--- a/policy/modules/services/zfs.te
+++ b/policy/modules/services/zfs.te
@@ -111,6 +111,7 @@ fs_rw_nfsd_fs(zfs_t)
 
 kernel_read_fs_sysctls(zfs_t)
 kernel_read_kernel_sysctls(zfs_t)
+kernel_read_system_state(zfs_t)
 
 storage_raw_rw_fixed_disk(zfs_t)
 

--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -28,7 +28,8 @@ ifdef(`distro_gentoo',`
 /usr/bin/systemd	--	gen_context(system_u:object_r:init_exec_t,s0)
 /usr/bin/upstart	--	gen_context(system_u:object_r:init_exec_t,s0)
 
-/usr/lib/systemd/systemd --	gen_context(system_u:object_r:init_exec_t,s0)
+/usr/lib/dracut/modules\.d/[^/]+/.*\.service	--	gen_context(system_u:object_r:systemd_unit_t,s0)
+/usr/lib/systemd/systemd -- gen_context(system_u:object_r:init_exec_t,s0)
 /usr/lib/systemd/systemd-shutdown	--	gen_context(system_u:object_r:init_exec_t,s0)
 /usr/lib/systemd/system-preset(/.*)? gen_context(system_u:object_r:systemd_unit_t,s0)
 /usr/lib/systemd/user-preset(/.*)? gen_context(system_u:object_r:systemd_unit_t,s0)

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -3314,6 +3314,25 @@ interface(`init_write_runtime_socket',`
 	allow $1 init_runtime_t:sock_file write;
 ')
 
+#######################################
+## <summary>
+##  Do not audit attempts to write to
+##	init sock files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`init_dontaudit_write_runtime_socket',`
+	gen_require(`
+		type init_runtime_t;
+	')
+
+	dontaudit $1 init_runtime_t:sock_file write;
+')
+
 ########################################
 ## <summary>
 ##	Read init unnamed pipes.

--- a/policy/modules/system/mount.te
+++ b/policy/modules/system/mount.te
@@ -42,6 +42,8 @@ application_domain(unconfined_mount_t, mount_exec_t)
 
 # setuid/setgid needed to mount cifs
 allow mount_t self:capability { chown dac_override dac_read_search ipc_lock setgid setuid sys_admin sys_rawio sys_tty_config };
+dontaudit mount_t self:capability { kill net_admin };
+dontaudit mount_t self:process setrlimit;
 
 allow mount_t mount_tmp_t:file manage_file_perms;
 allow mount_t mount_tmp_t:dir manage_dir_perms;
@@ -129,6 +131,8 @@ auth_use_nsswitch(mount_t)
 init_use_fds(mount_t)
 init_use_script_ptys(mount_t)
 init_dontaudit_getattr_initctl(mount_t)
+init_dontaudit_read_state(mount_t)
+init_dontaudit_write_runtime_socket(mount_t)
 
 logging_send_syslog_msg(mount_t)
 
@@ -140,6 +144,8 @@ seutil_read_config(mount_t)
 selinux_getattr_fs(mount_t)
 
 userdom_use_all_users_fds(mount_t)
+
+dbus_dontaudit_write_system_bus_runtime_named_sockets(mount_t)
 
 ifdef(`distro_redhat',`
 	optional_policy(`
@@ -208,6 +214,10 @@ optional_policy(`
 
 optional_policy(`
 	puppet_rw_tmp(mount_t)
+')
+
+optional_policy(`
+	rpc_domtrans_rpcd(mount_t)
 ')
 
 # for kernel package installation

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -516,6 +516,9 @@ kernel_dontaudit_search_unlabeled(systemd_generator_t)
 storage_raw_read_fixed_disk(systemd_generator_t)
 storage_raw_read_removable_device(systemd_generator_t)
 
+# needed to resolve hostnames for NFS mounts
+sysnet_dns_name_resolve(systemd_generator_t)
+
 systemd_log_parse_environment(systemd_generator_t)
 
 term_use_unallocated_ttys(systemd_generator_t)


### PR DESCRIPTION
A small batch of minor fixes. Notably:
- add file contexts for systemd units in `/lib/dracut/modules.d` so that the resulting services are `systemd_unit_t` instead of `bin_t`
- add file contexts for `git`'s subcommands. This fixes conflicting type specifications between `/usr/bin/git` and its many hardlinks.
- add a couple file contexts for some programs in `/usr/bin` or `/usr/sbin` as they appear in Gentoo
- minor fixes for `rpc` in support of NFS
- allow `systemd-generator` to perform DNS resolution in order to resolve hostnames in `/etc/fstab` for NFS mounts

A couple of these commits are split out from #511 since they are not strictly related.