### PR TITLE
udev: allow udev_read_runtime_files to read link files

### DIFF
--- a/policy/modules/system/udev.if
+++ b/policy/modules/system/udev.if
@@ -504,6 +504,7 @@ interface(`udev_read_runtime_files',`
 
 	files_search_runtime($1)
 	read_files_pattern($1, udev_runtime_t, udev_runtime_t)
+	read_lnk_files_pattern($1, udev_runtime_t, udev_runtime_t)
 ')
 
 ########################################


### PR DESCRIPTION
There are some link files under /run/udev directory: $ ls -lZ /run/udev/static_node-tags/uaccess/
total 0
lrwxrwxrwx. 1 root root system_u:object_r:udev_runtime_t:SystemLow 12 Oct 16 08:32 'snd\x2fseq' -> /dev/snd/seq lrwxrwxrwx. 1 root root system_u:object_r:udev_runtime_t:SystemLow 14 Oct 16 08:32 'snd\x2ftimer' -> /dev/snd/timer

Fixes:
avc:  denied  { read } for  pid=297 comm="systemd-logind" name="snd\x2fseq" dev="tmpfs" ino=125
scontext=system_u:system_r:systemd_logind_t:s0-s15:c0.c1023 tcontext=system_u:object_r:udev_runtime_t:s0 tclass=lnk_file permissive=1

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>