### PR TITLE
watchdog: allow watchdog to create /var/log/watchdog directory

### DIFF
--- a/policy/modules/services/watchdog.te
+++ b/policy/modules/services/watchdog.te
@@ -31,7 +31,8 @@ allow watchdog_t self:rawip_socket create_socket_perms;
 allow watchdog_t self:tcp_socket { accept listen };
 
 allow watchdog_t watchdog_log_t:file { append_file_perms create_file_perms setattr_file_perms };
-logging_log_filetrans(watchdog_t, watchdog_log_t, file)
+manage_dirs_pattern(watchdog_t, watchdog_log_t, watchdog_log_t)
+logging_log_filetrans(watchdog_t, watchdog_log_t, {dir file})
 
 manage_files_pattern(watchdog_t, watchdog_runtime_t, watchdog_runtime_t)
 files_runtime_filetrans(watchdog_t, watchdog_runtime_t, file)


### PR DESCRIPTION
Allow watchdog to create log directory with correct label.

Fixes:
avc: denied { create } for pid=315 comm="watchdog" name="watchdog" scontext=system_u:system_r:watchdog_t tcontext=system_u:object_r:var_log_t tclass=dir permissive=1

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>