### PR TITLE
rng-tools updated to 6.15 (on RHEL9) seeing the following denials:

### DIFF
--- a/policy/modules/services/rngd.te
+++ b/policy/modules/services/rngd.te
@@ -20,8 +20,8 @@ files_runtime_file(rngd_runtime_t)
 # Local policy
 #
 
-allow rngd_t self:capability { ipc_lock sys_admin };
-allow rngd_t self:process { setsched getsched signal };
+allow rngd_t self:capability { ipc_lock setgid setuid sys_admin };
+allow rngd_t self:process { getsched setcap setsched signal };
 allow rngd_t self:fifo_file rw_fifo_file_perms;
 allow rngd_t self:unix_stream_socket { accept listen };
 
@@ -37,6 +37,7 @@ dev_rw_tpm(rngd_t)
 dev_write_rand(rngd_t)
 
 files_read_etc_files(rngd_t)
+files_read_usr_files(rngd_t)
 
 logging_send_syslog_msg(rngd_t)
 


### PR DESCRIPTION
node=localhost type=AVC msg=audit(1669206851.792:438): avc:  denied  { getattr } for  pid=1008 comm="rngd" path="/usr/share/crypto-policies/FIPS/opensslcnf.txt" dev="dm-0" ino=401368 scontext=system_u:system_r:rngd_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1669206851.792:439): avc:  denied  { read } for  pid=1008 comm="rngd" name="opensslcnf.config" dev="dm-0" ino=401368 scontext=system_u:system_r:rngd_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1669206851.792:439): avc:  denied  { open } for  pid=1008 comm="rngd" path="/usr/share/crypto-policies/FIPS/opensslcnf.txt" dev="dm-0" ino=401368 scontext=system_u:system_r:rngd_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1

rngd now sets user/group rather than having user/group set in .service file:
node=localhost type=AVC msg=audit(1669206851.856:440): avc:  denied  { setgid } for  pid=1008 comm="rngd" capability=6 scontext=system_u:system_r:rngd_t:s0 tcontext=system_u:system_r:rngd_t:s0 tclass=capability permissive=1
node=localhost type=AVC msg=audit(1669206851.881:441): avc:  denied  { setuid } for  pid=1008 comm="rngd" capability=7 scontext=system_u:system_r:rngd_t:s0 tcontext=system_u:system_r:rngd_t:s0 tclass=capability permissive=1
node=localhost type=AVC msg=audit(1669206851.910:442): avc:  denied  { setcap } for  pid=1008 comm="rngd" scontext=system_u:system_r:rngd_t:s0 tcontext=system_u:system_r:rngd_t:s0 tclass=process permissive=1

Signed-off-by: Dave Sugar <dsugar100@gmail.com>