### PR TITLE
smartmon: handle gentoo place for drivedb.h

### DIFF
--- a/policy/modules/services/smartmon.fc
+++ b/policy/modules/services/smartmon.fc
@@ -7,3 +7,5 @@
 /run/smartd\.pid	--	gen_context(system_u:object_r:fsdaemon_runtime_t,s0)
 
 /var/lib/smartmontools(/.*)?	gen_context(system_u:object_r:fsdaemon_var_lib_t,s0)
+
+/var/db/smartmontools(/.*)?	gen_context(system_u:object_r:fsdaemon_var_lib_t,s0)


### PR DESCRIPTION
On a gentoo-hardened+selinux, I got denial from fsadm_t reading var_t. This is due to smartctl trying to read /var/db/smartmontools/drivedb.h

Solution is to label /var/db/smartmontools/ with fsdaemon_var_lib_t so that it can be read.

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>