### PR TITLE
fstools: handle gentoo place for drivedb.h

### DIFF
--- a/policy/modules/system/fstools.fc
+++ b/policy/modules/system/fstools.fc
@@ -108,6 +108,10 @@
 /usr/sbin/zstreamdump		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
 /usr/sbin/ztest			--	gen_context(system_u:object_r:fsadm_exec_t,s0)
 
+ifdef(`distro_gentoo',`
+/var/db/smartmontools(/.*)?		gen_context(system_u:object_r:fsadm_db_t,s0)
+')
+
 /var/swap			--	gen_context(system_u:object_r:swapfile_t,s0)
 
 /var/log/fsck(/.*)?		gen_context(system_u:object_r:fsadm_log_t,s0)

--- a/policy/modules/system/fstools.te
+++ b/policy/modules/system/fstools.te
@@ -19,6 +19,11 @@ files_tmp_file(fsadm_tmp_t)
 type fsadm_run_t;
 files_runtime_file(fsadm_run_t)
 
+ifdef(`distro_gentoo',`
+type fsadm_db_t;
+files_type(fsadm_db_t)
+')
+
 type swapfile_t; # customizable
 files_type(swapfile_t)
 
@@ -54,6 +59,10 @@ files_root_filetrans(fsadm_t, fsadm_tmp_t, file)
 allow fsadm_t fsadm_run_t:dir manage_dir_perms;
 allow fsadm_t fsadm_run_t:file manage_file_perms;
 files_runtime_filetrans(fsadm_t, fsadm_run_t, dir)
+
+ifdef(`distro_gentoo',`
+manage_files_pattern(fsadm_t, fsadm_db_t, fsadm_db_t)
+')
 
 # log files
 allow fsadm_t fsadm_log_t:dir setattr;


### PR DESCRIPTION
On a gentoo-hardened+selinux, I got denial from fsadm_t reading var_t. This is due to smartctl trying to read /var/db/smartmontools/drivedb.h

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>