### PR TITLE
udev: permit to read hwdb

### DIFF
--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -201,6 +201,9 @@ sysnet_signal_dhcpc(udev_t)
 sysnet_manage_config(udev_t)
 sysnet_etc_filetrans_config(udev_t)
 
+systemd_map_hwdb(udev_t)
+systemd_read_hwdb(udev_t)
+
 userdom_dontaudit_getattr_user_home_dirs(udev_t)
 userdom_dontaudit_search_user_home_content(udev_t)
 
@@ -265,8 +268,6 @@ ifdef(`init_systemd',`
 	init_stream_connect(udev_t)
 	init_start_system(udev_t)
 
-	systemd_map_hwdb(udev_t)
-	systemd_read_hwdb(udev_t)
 	systemd_read_logind_sessions_files(udev_t)
 	systemd_read_logind_runtime_files(udev_t)
 	# udev searches for .link files and applies custom udev rules


### PR DESCRIPTION
On a gentoo with openRC, udev is denied to read hwdb. On current policy, reading hwdb is only allowed for system with systemd.

In fact it is a common action (beyond openrc/systemd) so rules for reading it must be global.