### PR TITLE
tests.yml: Pin ubuntu 20.04.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3
@@ -56,7 +56,7 @@ jobs:
         selint --source --recursive --summary --fail --disable C-005 --disable C-008 --disable W-005 policy
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fix this issue:

Version 3.5 was not found in the local cache
Error: The version '3.5' with architecture 'x64' was not found for Ubuntu 22.04.
