### PR TITLE
Fix templates parsing in gentemplates.sh

### DIFF
--- a/support/gentemplates.sh
+++ b/support/gentemplates.sh
@@ -57,6 +57,6 @@ fi
 for ifile in $(find ${SOURCEDIR} -type f -name '*.if'); do
   for interface in $(grep -E '^template\(' ${ifile} | sed -e 's:^template(`\([^'\'']*\)'\''\s*,\s*`:\1:g'); do
     # Generate the interface
-    sed -n "/^template(\`${interface}',\`/,/^')/p" ${ifile} | grep -v "^template" | grep -v "^')" > ${TARGETDIR}/${interface}.iftemplate;
+    sed -n "/^template(\`${interface}',\s*\`/,/^')/p" ${ifile} | grep -v "^template" | grep -v "^')" > ${TARGETDIR}/${interface}.iftemplate;
   done
 done


### PR DESCRIPTION
Template definitions might have a whitespace after the comma, e.g. su_restricted_domain_template
in /policy/modules/admin/su.if

template(\`su_restricted_domain_template', `
  ...
')

gentemplates.sh silently fails to parse it. This works unless 'set -e' is set, in which case the script fails non-silently.

This commit adds support of whitespace after comma, which is a valid syntax.