### PR TITLE
rsyslog: add label for /var/empty/dev/log

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -236,3 +236,7 @@ ifdef(`distro_redhat',`
 /var/named/chroot/dev/random -c	gen_context(system_u:object_r:random_device_t,s0)
 /var/named/chroot/dev/zero -c	gen_context(system_u:object_r:zero_device_t,s0)
 ')
+
+ifdef(`distro_gentoo',`
+/var/empty/dev		-d	gen_context(system_u:object_r:device_t,s0)
+')

--- a/policy/modules/system/logging.fc
+++ b/policy/modules/system/logging.fc
@@ -68,6 +68,10 @@ ifdef(`distro_redhat',`
 /var/named/chroot/dev/log -s	gen_context(system_u:object_r:devlog_t,s0)
 ')
 
+ifdef(`distro_gentoo',`
+/var/empty/dev/log	-s	gen_context(system_u:object_r:devlog_t,s0)
+')
+
 /run/audit_events	-s	gen_context(system_u:object_r:auditd_runtime_t,mls_systemhigh)
 /run/audispd_events	-s	gen_context(system_u:object_r:audisp_runtime_t,mls_systemhigh)
 /run/auditd\.pid	--	gen_context(system_u:object_r:auditd_runtime_t,mls_systemhigh)


### PR DESCRIPTION
On gentoo, starting rsyslog give this:
allow syslogd_t var_t:dir { add_name remove_name }; allow syslogd_t var_t:sock_file { create setattr unlink };

This is due to the following piece of code in configuration: """
 Create an additional socket for the default chroot location
 (used by net-misc/openssh[hpn], see https://bugs.gentoo.org/490744)
 input(type="imuxsock" Socket="/var/empty/dev/log")
"""

So let's add correct label for this file

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>