### PR TITLE
mount: dbus interface must be optional

### DIFF
--- a/policy/modules/system/mount.te
+++ b/policy/modules/system/mount.te
@@ -145,8 +145,6 @@ selinux_getattr_fs(mount_t)
 
 userdom_use_all_users_fds(mount_t)
 
-dbus_dontaudit_write_system_bus_runtime_named_sockets(mount_t)
-
 ifdef(`distro_redhat',`
 	optional_policy(`
 		auth_read_pam_console_data(mount_t)
@@ -199,6 +197,10 @@ optional_policy(`
 
 optional_policy(`
 	container_getattr_fs(mount_t)
+')
+
+optional_policy(`
+	dbus_dontaudit_write_system_bus_runtime_named_sockets(mount_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
On gentoo, when emerging selinux-base-policy, the post install (loading policy) fail due to a missing type. This is due to mount.te using a dbus interface and the dbus module is not present. Fix this by setting the dbus interface as optional;