### PR TITLE
munin: add file context for common functions file

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -209,6 +209,8 @@ HOME_ROOT/lost\+found/.*	<<none>>
 /usr/share/doc(/.*)?/README.*		gen_context(system_u:object_r:usr_t,s0)
 /usr/share/docbook2X/xslt/man(/.*)?	gen_context(system_u:object_r:usr_t,s0)
 
+/usr/share/munin/plugins/plugin\.sh	--	gen_context(system_u:object_r:usr_t,s0)
+
 /usr/tmp		-d	gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
 /usr/tmp/.*			<<none>>
 


### PR DESCRIPTION
Some Munin plugins need to read the plugin.sh file providing common functions.

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>