### PR TITLE
munin: disk-plugin: transition to fsadm

### DIFF
--- a/policy/modules/services/munin.if
+++ b/policy/modules/services/munin.if
@@ -43,6 +43,23 @@ template(`munin_plugin_template',`
 
 ########################################
 ## <summary>
+##	Permit to read/write Munin TCP sockets
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`munin_rw_tcp_sockets',`
+	gen_require(`
+		type munin_t;
+	')
+	allow $1 munin_t:tcp_socket rw_socket_perms;
+')
+
+########################################
+## <summary>
 ##	Connect to munin over a unix domain
 ##	stream socket.
 ## </summary>
@@ -188,21 +205,4 @@ interface(`munin_admin',`
 	admin_pattern($1, munin_runtime_t)
 
 	admin_pattern($1, httpd_munin_content_t)
-')
-
-########################################
-## <summary>
-##	Permit to read/write Munin TCP sockets
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`munin_rw_tcp_sockets',`
-	gen_require(`
-		type munin_t;
-	')
-	allow $1 munin_t:tcp_socket rw_socket_perms;
 ')

--- a/policy/modules/services/munin.if
+++ b/policy/modules/services/munin.if
@@ -189,3 +189,20 @@ interface(`munin_admin',`
 
 	admin_pattern($1, httpd_munin_content_t)
 ')
+
+########################################
+## <summary>
+##	Permit to read/write Munin TCP sockets
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`munin_rw_tcp_sockets',`
+	gen_require(`
+		type munin_t;
+	')
+	allow $1 munin_t:tcp_socket rw_socket_perms;
+')

--- a/policy/modules/services/munin.te
+++ b/policy/modules/services/munin.te
@@ -52,8 +52,6 @@ munin_plugin_template(unconfined)
 allow munin_plugin_domain self:process signal;
 allow munin_plugin_domain self:fifo_file rw_fifo_file_perms;
 
-allow munin_plugin_domain munin_t:tcp_socket rw_socket_perms;
-
 read_lnk_files_pattern(munin_plugin_domain, munin_etc_t, munin_etc_t)
 
 allow munin_plugin_domain munin_exec_t:file read_file_perms;
@@ -78,6 +76,8 @@ files_search_var_lib(munin_plugin_domain)
 fs_getattr_all_fs(munin_plugin_domain)
 
 miscfiles_read_localization(munin_plugin_domain)
+
+munin_rw_tcp_sockets(munin_plugin_domain)
 
 optional_policy(`
 	nscd_use(munin_plugin_domain)
@@ -260,7 +260,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	fstools_exec(disk_munin_plugin_t)
+	fstools_domtrans(disk_munin_plugin_t)
 ')
 
 ####################################

--- a/policy/modules/system/fstools.te
+++ b/policy/modules/system/fstools.te
@@ -209,6 +209,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	munin_rw_tcp_sockets(fsadm_t)
+')
+
+optional_policy(`
 	nis_use_ypbind(fsadm_t)
 ')
 


### PR DESCRIPTION
smart_ plugin currently execute smartctl on the disk_munin_plugin_t domain. But lot of rules are still missing for a correct smartctl execution. Instead of duplicating most of all fsadm rules, it is easier to transition to the correct domain.

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>