### PR TITLE
mcelog: add missing file context for triggers

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -54,7 +54,7 @@ ifdef(`distro_redhat',`
 
 /etc/mail/make			--	gen_context(system_u:object_r:bin_t,s0)
 
-/etc/mcelog/.*-error-trigger	--	gen_context(system_u:object_r:bin_t,s0)
+/etc/mcelog/.*-trigger		--	gen_context(system_u:object_r:bin_t,s0)
 /etc/mcelog/.*\.local		--	gen_context(system_u:object_r:bin_t,s0)
 
 ifdef(`distro_redhat',`


### PR DESCRIPTION
I got the following AVC:
allow mcelog_t mcelog_etc_t:file execute;

This is due do some trigger, not being set as bin_t
-rwxr-xr-x. 1 root root system_u:object_r:bin_t         801 nov.   1 19:11 bus-error-trigger
-rwxr-xr-x. 1 root root system_u:object_r:bin_t        1035 nov.   1 19:11 cache-error-trigger
-rwxr-xr-x. 1 root root system_u:object_r:bin_t        1213 nov.   1 19:11 dimm-error-trigger
-rwxr-xr-x. 1 root root system_u:object_r:bin_t         742 nov.   1 19:11 iomca-error-trigger
-rw-r-----. 1 root root system_u:object_r:mcelog_etc_t 7415 nov.   1 19:11 mcelog.conf
-rwxr-xr-x. 1 root root system_u:object_r:mcelog_etc_t 1209 nov.   1 19:11 page-error-counter-replacement-trigger
-rwxr-xr-x. 1 root root system_u:object_r:mcelog_etc_t 1656 nov.   1 19:11 page-error-post-sync-soft-trigger
-rwxr-xr-x. 1 root root system_u:object_r:mcelog_etc_t 1640 nov.   1 19:11 page-error-pre-sync-soft-trigger
-rwxr-xr-x. 1 root root system_u:object_r:bin_t        1308 nov.   1 19:11 page-error-trigger
-rwxr-xr-x. 1 root root system_u:object_r:bin_t        1057 nov.   1 19:11 socket-memory-error-trigger
-rwxr-xr-x. 1 root root system_u:object_r:bin_t         947 nov.   1 19:11 unknown-error-trigger

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>