### PR TITLE
portage: add misc mising rules

### DIFF
--- a/policy/modules/admin/portage.if
+++ b/policy/modules/admin/portage.if
@@ -262,7 +262,7 @@ interface(`portage_domtrans_gcc_config',`
 	')
 
 	corecmd_search_bin($1)
-	domtrans_pattern($1, gcc_config_exec_t, gcc_config_t)
+	nnp_domtrans_pattern($1, gcc_config_exec_t, gcc_config_t)
 ')
 
 ########################################

--- a/policy/modules/admin/portage.te
+++ b/policy/modules/admin/portage.te
@@ -87,6 +87,7 @@ files_tmpfs_file(portage_tmpfs_t)
 
 allow gcc_config_t self:capability { chown fsetid };
 allow gcc_config_t self:fifo_file rw_fifo_file_perms;
+allow gcc_config_t self:process getsched;
 
 manage_files_pattern(gcc_config_t, portage_cache_t, portage_cache_t)
 
@@ -94,6 +95,8 @@ read_files_pattern(gcc_config_t, portage_conf_t, portage_conf_t)
 
 allow gcc_config_t portage_ebuild_t:dir list_dir_perms;
 read_files_pattern(gcc_config_t, portage_ebuild_t, portage_ebuild_t)
+
+allow gcc_config_t portage_devpts_t:chr_file rw_inherited_term_perms;
 
 allow gcc_config_t portage_exec_t:file mmap_exec_file_perms;
 
@@ -103,6 +106,8 @@ kernel_read_kernel_sysctls(gcc_config_t)
 corecmd_exec_shell(gcc_config_t)
 corecmd_exec_bin(gcc_config_t)
 corecmd_manage_bin_files(gcc_config_t)
+
+dev_read_sysfs(gcc_config_t)
 
 domain_use_interactive_fds(gcc_config_t)
 
@@ -127,6 +132,8 @@ libs_manage_lib_dirs(gcc_config_t)
 logging_send_syslog_msg(gcc_config_t)
 
 miscfiles_read_localization(gcc_config_t)
+
+storage_getattr_fixed_disk_dev(gcc_config_t)
 
 userdom_use_user_terminals(gcc_config_t)
 
@@ -255,7 +262,7 @@ allow portage_fetch_t portage_devpts_t:chr_file { rw_chr_file_perms setattr_chr_
 allow portage_fetch_t portage_gpg_t:dir rw_dir_perms;
 allow portage_fetch_t portage_gpg_t:file manage_file_perms;
 
-allow portage_fetch_t portage_tmp_t:dir manage_dir_perms;
+allow portage_fetch_t portage_tmp_t:dir { manage_dir_perms watch };
 allow portage_fetch_t portage_tmp_t:file manage_file_perms;
 allow portage_fetch_t portage_tmp_t:sock_file manage_sock_file_perms;
 
@@ -348,6 +355,8 @@ dontaudit portage_sandbox_t portage_cache_t:file { setattr_file_perms write };
 
 allow portage_sandbox_t portage_log_t:file { create_file_perms delete_file_perms setattr_file_perms append_file_perms };
 logging_log_filetrans(portage_sandbox_t, portage_log_t, file)
+
+allow portage_sandbox_t portage_tmp_t:dir watch;
 
 portage_compile_domain(portage_sandbox_t)
 


### PR DESCRIPTION
Add missing rules for portage I encountered while emerging or just calling gcc-config

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>