### PR TITLE
munin: add fc for munin-node plugin state

### DIFF
--- a/policy/modules/services/munin.fc
+++ b/policy/modules/services/munin.fc
@@ -68,6 +68,7 @@
 
 /var/lib/munin(/.*)?	gen_context(system_u:object_r:munin_var_lib_t,s0)
 /var/lib/munin/plugin-state(/.*)?	gen_context(system_u:object_r:munin_plugin_state_t,s0)
+
 ifdef(`distro_gentoo',`
 /var/lib/munin-node(/.*)?	gen_context(system_u:object_r:munin_var_lib_t,s0)
 /var/lib/munin-node/plugin-state(/.*)?	gen_context(system_u:object_r:munin_plugin_state_t,s0)

--- a/policy/modules/services/munin.fc
+++ b/policy/modules/services/munin.fc
@@ -68,6 +68,10 @@
 
 /var/lib/munin(/.*)?	gen_context(system_u:object_r:munin_var_lib_t,s0)
 /var/lib/munin/plugin-state(/.*)?	gen_context(system_u:object_r:munin_plugin_state_t,s0)
+ifdef(`distro_gentoo',`
+/var/lib/munin-node(/.*)?	gen_context(system_u:object_r:munin_var_lib_t,s0)
+/var/lib/munin-node/plugin-state(/.*)?	gen_context(system_u:object_r:munin_plugin_state_t,s0)
+')
 
 /var/log/munin.*	gen_context(system_u:object_r:munin_log_t,s0)
 


### PR DESCRIPTION
Gentoo deploy munin-node plugin state in /var/lib/munin-node

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>