### PR TITLE
usermanage: permit groupadd to read kernel sysctl

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -227,6 +227,8 @@ files_relabel_etc_files(groupadd_t)
 files_read_etc_runtime_files(groupadd_t)
 files_read_usr_symlinks(groupadd_t)
 
+kernel_read_kernel_sysctls(groupadd_t)
+
 # Execute /usr/bin/{passwd, chfn, chsh} and /usr/sbin/{useradd, vipw}.
 corecmd_exec_bin(groupadd_t)
 


### PR DESCRIPTION
When using groupadd, I got some AVC due to groupadd reading /proc/sys/kernel/cap_last_cap

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>