### PR TITLE
mandb: permit to read inherited cron files

### DIFF
--- a/policy/modules/apps/mandb.te
+++ b/policy/modules/apps/mandb.te
@@ -59,5 +59,6 @@ ifdef(`init_systemd',`
 ')
 
 optional_policy(`
+	cron_rw_inherited_system_job_tmp_files(mandb_t)
 	cron_system_entry(mandb_t, mandb_exec_t)
 ')


### PR DESCRIPTION
Each night /etc/cron.daily/man-db generates some AVC: allow mandb_t system_cronjob_tmp_t:file { read write };

Add the necessary rules for it.

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>