### PR TITLE
selinuxutil: permit load_policy to use portage ptys

### DIFF
--- a/policy/modules/admin/portage.if
+++ b/policy/modules/admin/portage.if
@@ -313,6 +313,24 @@ interface(`portage_dontaudit_use_fds',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to read and write inherited portage ptys.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`portage_dontaudit_use_inherited_ptys',`
+	gen_require(`
+		type portage_devpts_t;
+	')
+
+	dontaudit $1 portage_devpts_t:chr_file rw_inherited_term_perms;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to search the
 ##	portage temporary directories.
 ## </summary>

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -216,6 +216,7 @@ optional_policy(`
 
 optional_policy(`
 	portage_dontaudit_use_fds(load_policy_t)
+	portage_dontaudit_use_inherited_ptys(load_policy_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Each time portage build and install a new SELinux policy I got the following AVC: allow load_policy_t portage_devpts_t:chr_file { read write };

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>