### PR TITLE
portage: add missing go/hg context in new distfiles location

### DIFF
--- a/policy/modules/admin/portage.fc
+++ b/policy/modules/admin/portage.fc
@@ -31,6 +31,8 @@
 /var/cache/distfiles/cvs-src(/.*)?	gen_context(system_u:object_r:portage_srcrepo_t,s0)
 /var/cache/distfiles/egit-src(/.*)?	gen_context(system_u:object_r:portage_srcrepo_t,s0)
 /var/cache/distfiles/git[0-9]-src(/.*)?	gen_context(system_u:object_r:portage_srcrepo_t,s0)
+/var/cache/distfiles/go-src(/.*)?	gen_context(system_u:object_r:portage_srcrepo_t,s0)
+/var/cache/distfiles/hg-src(/.*)?	gen_context(system_u:object_r:portage_srcrepo_t,s0)
 /var/cache/distfiles/svn-src(/.*)?	gen_context(system_u:object_r:portage_srcrepo_t,s0)
 /var/cache/edb(/.*)?	gen_context(system_u:object_r:portage_cache_t,s0)
 /var/cache/eix(/.*)?	gen_context(system_u:object_r:portage_cache_t,s0)


### PR DESCRIPTION
go/hg source files context are added in old portage distfiles location, but are missing in new one.

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>