### PR TITLE
openvpn: Allow netlink genl

### DIFF
--- a/policy/modules/services/openvpn.te
+++ b/policy/modules/services/openvpn.te
@@ -62,6 +62,7 @@ allow openvpn_t self:unix_stream_socket { accept connectto listen };
 allow openvpn_t self:tcp_socket server_stream_socket_perms;
 allow openvpn_t self:tun_socket { create_socket_perms relabelfrom relabelto };
 allow openvpn_t self:netlink_route_socket nlmsg_write;
+allow openvpn_t self:netlink_generic_socket create_socket_perms;
 
 allow openvpn_t openvpn_etc_t:dir list_dir_perms;
 allow openvpn_t openvpn_etc_t:file read_file_perms;


### PR DESCRIPTION
OpenVPN 2.6 can use an OpenVPN specific kernel module to handle the VPN data channel.  The communication via userspace and kernel space happens over a generic netlink interface.

Without this access, the following denials can be found in the logs

    [...] denied  { create } for pid=... comm="openvpn" scontext=system_u:system_r:openvpn_t:s0 tcontext=system_u:system_r:openvpn_t:s0 tclass=netlink_generic_socket
    [...] denied  { setopt } for pid=... comm="openvpn" scontext=system_u:system_r:openvpn_t:s0 tcontext=system_u:system_r:openvpn_t:s0 tclass=netlink_generic_socket
    [...] denied  { bind } for pid=... comm="openvpn" scontext=system_u:system_r:openvpn_t:s0 tcontext=system_u:system_r:openvpn_t:s0 tclass=netlink_generic_socket
    [...] denied  { getattr } for pid=... comm="openvpn" scontext=system_u:system_r:openvpn_t:s0 tcontext=system_u:system_r:openvpn_t:s0 tclass=netlink_generic_socket

Signed-off-by: David Sommerseth <davids@openvpn.net>