### PR TITLE
fsadm: add domain for update-smart-drivedb

### DIFF
--- a/policy/modules/services/smartmon.fc
+++ b/policy/modules/services/smartmon.fc
@@ -3,6 +3,7 @@
 /usr/bin/smartd	--	gen_context(system_u:object_r:fsdaemon_exec_t,s0)
 
 /usr/sbin/smartd	--	gen_context(system_u:object_r:fsdaemon_exec_t,s0)
+/usr/sbin/update-smart-drivedb	--	gen_context(system_u:object_r:smartmon_update_drivedb_exec_t,s0)
 
 /run/smartd\.pid	--	gen_context(system_u:object_r:fsdaemon_runtime_t,s0)
 

--- a/policy/modules/services/smartmon.te
+++ b/policy/modules/services/smartmon.te
@@ -120,3 +120,6 @@ optional_policy(`
 	seutil_sigchld_newrole(fsdaemon_t)
 ')
 
+optional_policy(`
+	fstools_read_fsadm_db_files(fsdaemon_t)
+')

--- a/policy/modules/services/smartmon.te
+++ b/policy/modules/services/smartmon.te
@@ -33,6 +33,10 @@ ifdef(`enable_mls',`
 	init_ranged_daemon_domain(fsdaemon_t, fsdaemon_exec_t, mls_systemhigh)
 ')
 
+type smartmon_update_drivedb_t;
+type smartmon_update_drivedb_exec_t;
+init_system_domain(smartmon_update_drivedb_t, smartmon_update_drivedb_exec_t)
+
 ########################################
 #
 # Local policy
@@ -113,6 +117,10 @@ tunable_policy(`smartmon_3ware',`
 ')
 
 optional_policy(`
+	fstools_read_fsadm_db_files(fsdaemon_t)
+')
+
+optional_policy(`
 	mta_send_mail(fsdaemon_t)
 ')
 
@@ -120,6 +128,46 @@ optional_policy(`
 	seutil_sigchld_newrole(fsdaemon_t)
 ')
 
+########################################
+#
+# smartmon_update_drivedb policy
+#
+
+allow smartmon_update_drivedb_t self:fifo_file rw_fifo_file_perms;
+allow smartmon_update_drivedb_t self:unix_stream_socket connectto;
+
+corecmd_exec_bin(smartmon_update_drivedb_t)
+corecmd_exec_shell(smartmon_update_drivedb_t)
+
+corenet_sendrecv_http_client_packets(smartmon_update_drivedb_t)
+corenet_tcp_connect_http_port(smartmon_update_drivedb_t)
+
+files_read_etc_files(smartmon_update_drivedb_t)
+
+fstools_exec(smartmon_update_drivedb_t)
+
+kernel_dontaudit_read_system_state(smartmon_update_drivedb_t)
+
+miscfiles_read_generic_certs(smartmon_update_drivedb_t)
+miscfiles_read_localization(smartmon_update_drivedb_t)
+
+sysnet_dns_name_resolve(smartmon_update_drivedb_t)
+
+ifdef(`distro_gentoo',`
+	fstools_manage_fsadm_db_files(smartmon_update_drivedb_t)
+	fstools_watch_fsadm_db_dirs(smartmon_update_drivedb_t)
+')
+
 optional_policy(`
-	fstools_read_fsadm_db_files(fsdaemon_t)
+	cron_rw_inherited_system_job_tmp_files(smartmon_update_drivedb_t)
+	cron_system_entry(smartmon_update_drivedb_t, smartmon_update_drivedb_exec_t)
+')
+
+optional_policy(`
+	gpg_exec_agent(smartmon_update_drivedb_t)
+	gpg_exec(smartmon_update_drivedb_t)
+')
+
+optional_policy(`
+	xdg_read_config_files(smartmon_update_drivedb_t)
 ')

--- a/policy/modules/system/fstools.if
+++ b/policy/modules/system/fstools.if
@@ -120,6 +120,62 @@ interface(`fstools_read_pipes',`
 
 ########################################
 ## <summary>
+##	Read fsadm_db_t files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fstools_read_fsadm_db_files',`
+	gen_require(`
+		type fsadm_db_t;
+	')
+
+	read_files_pattern($1, fsadm_db_t, fsadm_db_t)
+')
+
+########################################
+## <summary>
+##	Manage all fsadm_db_t files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fstools_manage_fsadm_db_files',`
+	gen_require(`
+		type fsadm_db_t;
+	')
+
+	manage_dirs_pattern($1, fsadm_db_t, fsadm_db_t)
+	manage_files_pattern($1, fsadm_db_t, fsadm_db_t)
+	manage_sock_files_pattern($1, fsadm_db_t, fsadm_db_t)
+')
+
+########################################
+## <summary>
+##	Watch fsadm_db_t directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fstools_watch_fsadm_db_dirs',`
+	gen_require(`
+		type fsadm_db_t;
+	')
+
+	allow $1 fsadm_db_t:dir watch;
+')
+
+########################################
+## <summary>
 ##	Relabel a file to the type used by the
 ##	filesystem tools programs.
 ## </summary>
@@ -265,20 +321,3 @@ interface(`fstools_manage_swap_files',`
 	allow $1 swapfile_t:file manage_file_perms;
 ')
 
-########################################
-## <summary>
-##	Read fsadm_db_t files.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`fstools_read_fsadm_db_files',`
-	gen_require(`
-		type fsadm_db_t;
-	')
-
-	read_files_pattern($1, fsadm_db_t, fsadm_db_t)
-')

--- a/policy/modules/system/fstools.if
+++ b/policy/modules/system/fstools.if
@@ -264,3 +264,21 @@ interface(`fstools_manage_swap_files',`
 
 	allow $1 swapfile_t:file manage_file_perms;
 ')
+
+########################################
+## <summary>
+##	Read fsadm_db_t files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fstools_read_fsadm_db_files',`
+	gen_require(`
+		type fsadm_db_t;
+	')
+
+	read_files_pattern($1, fsadm_db_t, fsadm_db_t)
+')


### PR DESCRIPTION
update-smart-drivedb is a fsadm_t like but with access to network, so Since it do network access, and dont access any hardware, let's add its own domain.

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>