### PR TITLE
selinuxutil: permit run_init to read kernel sysctl

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -450,6 +450,8 @@ init_spec_domtrans_script(run_init_t)
 # for utmp
 init_rw_utmp(run_init_t)
 
+kernel_read_kernel_sysctls(run_init_t)
+
 logging_send_syslog_msg(run_init_t)
 
 miscfiles_read_localization(run_init_t)


### PR DESCRIPTION
When restarting services with run_init, I got some AVC due to run_init reading /proc/sys/kernel/cap_last_cap

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>