### PR TITLE
container: add missing filetrans and filecon for containerd/docker

### DIFF
--- a/policy/modules/services/container.fc
+++ b/policy/modules/services/container.fc
@@ -100,6 +100,7 @@ HOME_DIR/\.docker(/.*)?		gen_context(system_u:object_r:container_conf_home_t,s0)
 /var/lib/etcd(/.*)?             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/kube-proxy(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
 
+/var/log/containerd(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/containers(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/crio(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/pods(/.*)?		gen_context(system_u:object_r:container_log_t,s0)

--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -747,7 +747,7 @@ allow container_engine_system_domain container_runtime_t:file { manage_file_perm
 allow container_engine_system_domain container_runtime_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
 allow container_engine_system_domain container_runtime_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
 allow container_engine_system_domain container_runtime_t:sock_file { manage_sock_file_perms relabel_sock_file_perms };
-files_runtime_filetrans(container_engine_system_domain, container_runtime_t, { dir file })
+files_runtime_filetrans(container_engine_system_domain, container_runtime_t, { dir file sock_file })
 
 allow container_engine_system_domain container_engine_cache_t:dir manage_dir_perms;
 allow container_engine_system_domain container_engine_cache_t:file manage_file_perms;


### PR DESCRIPTION
Add a missing file transition for the docker socket in `/run` as well as a missing file context for `/var/log/containerd`.