### PR TITLE
add sysnet_dontaudit_rw_dhcpc_unix_dgram_sockets interface

### DIFF
--- a/policy/modules/system/iscsi.te
+++ b/policy/modules/system/iscsi.te
@@ -90,6 +90,8 @@ dev_rw_userio_dev(iscsid_t)
 domain_use_interactive_fds(iscsid_t)
 domain_dontaudit_read_all_domains_state(iscsid_t)
 
+files_read_etc_runtime_files(iscsid_t)
+
 auth_use_nsswitch(iscsid_t)
 
 init_stream_connect_script(iscsid_t)

--- a/policy/modules/system/lvm.fc
+++ b/policy/modules/system/lvm.fc
@@ -15,6 +15,8 @@
 /etc/lvmtab(/.*)?			gen_context(system_u:object_r:lvm_metadata_t,s0)
 /etc/lvmtab\.d(/.*)?			gen_context(system_u:object_r:lvm_metadata_t,s0)
 
+/etc/multipath(/.*)?                    gen_context(system_u:object_r:lvm_metadata_t,s0)
+
 #
 # /usr
 #

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -94,7 +94,7 @@ interface(`sysnet_dontaudit_use_dhcpc_fds',`
 ##	</summary>
 ## </param>
 #
-interface(`sysnet_dontaudit_rw_dhcpc_unix_dgram_socket',`
+interface(`sysnet_dontaudit_rw_dhcpc_unix_dgram_sockets',`
 	gen_require(`
 		type dhcpc_t;
 	')

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -86,6 +86,25 @@ interface(`sysnet_dontaudit_use_dhcpc_fds',`
 ########################################
 ## <summary>
 ##	Do not audit attempts to read/write to the
+##	dhcp unix datagram socket descriptors.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`sysnet_dontaudit_rw_dhcpc_unix_dgram_socket',`
+	gen_require(`
+		type dhcpc_t;
+	')
+
+	dontaudit $1 dhcpc_t:unix_dgram_socket { read write };
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to read/write to the
 ##	dhcp unix stream socket descriptors.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Added the following code to `modules/system/sysnetwork.if` : 

```
########################################
## <summary>
##	Do not audit attempts to read/write to the
##	dhcp unix datagram socket descriptors.
## </summary>
## <param name="domain">
##	<summary>
##	Domain to not audit.
##	</summary>
## </param>
#
interface(`sysnet_dontaudit_rw_dhcpc_unix_dgram_sockets',`
	gen_require(`
		type dhcpc_t;
	')

	dontaudit $1 dhcpc_t:unix_dgram_socket { read write };
')
```