### PR TITLE
Set label systemd-oomd

### DIFF
--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -31,6 +31,7 @@ ifdef(`distro_gentoo',`
 /usr/lib/dracut/modules\.d/[^/]+/.*\.service	--	gen_context(system_u:object_r:systemd_unit_t,s0)
 /usr/lib/systemd/systemd -- gen_context(system_u:object_r:init_exec_t,s0)
 /usr/lib/systemd/systemd-shutdown	--	gen_context(system_u:object_r:init_exec_t,s0)
+/usr/lib/systemd/systemd-oomd	--	gen_context(system_u:object_r:init_exec_t,s0)
 /usr/lib/systemd/system-preset(/.*)? gen_context(system_u:object_r:systemd_unit_t,s0)
 /usr/lib/systemd/user-preset(/.*)? gen_context(system_u:object_r:systemd_unit_t,s0)
 /usr/lib/systemd/ntp-units\.d -d gen_context(system_u:object_r:systemd_unit_t,s0)


### PR DESCRIPTION
Feb 24 19:02:53 localhost audit[1664]: AVC avc:  denied  { write } for  pid=1664 comm="systemd-oomd" path=2F6D656D66643A646174612D6664202864656C6574656429 dev="tmpfs" ino=2051 scontext=system_u:system_r:initrc_t tcontext=system_u:object_r:tmpfs_t tclass=file permissive=1

Needs to manage cgroups and kill processes, so make it init_exec_t