### PR TITLE
portage: misc fixes when emerging man-db

### DIFF
--- a/policy/modules/admin/portage.te
+++ b/policy/modules/admin/portage.te
@@ -154,7 +154,7 @@ optional_policy(`
 # - setfscreate for merging to live fs
 allow portage_t self:process { setfscreate };
 # - kill for mysql merging, at least
-allow portage_t self:capability { kill setfcap sys_nice };
+allow portage_t self:capability { kill setfcap sys_nice sys_resource };
 dontaudit portage_t self:capability { dac_read_search };
 dontaudit portage_t self:netlink_route_socket create_netlink_socket_perms;
 
@@ -181,6 +181,7 @@ corecmd_shell_spec_domtrans(portage_t, portage_sandbox_t)
 can_exec(portage_t, portage_tmp_t)
 
 kernel_dontaudit_request_load_module(portage_t)
+kernel_getattr_proc(portage_t)
 # merging baselayout will need this:
 kernel_write_proc_files(portage_t)
 
@@ -201,6 +202,7 @@ init_exec(portage_t)
 libs_run_ldconfig(portage_t, portage_roles)
 
 miscfiles_read_localization(portage_t)
+miscfiles_relabel_man_cache(portage_t)
 
 # run setfiles -r
 seutil_run_setfiles(portage_t, portage_roles)


### PR DESCRIPTION
When emerging man-db, the following AVC were found: allow portage_t man_cache_t:dir { relabelfrom relabelto }; allow portage_t proc_t:filesystem getattr;
allow portage_t self:capability sys_resource;