### PR TITLE
systemd: allow systemd-resolved to search directories on tmpfs and ramfs

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1503,6 +1503,8 @@ files_list_runtime(systemd_resolved_t)
 
 fs_getattr_all_fs(systemd_resolved_t)
 fs_search_cgroup_dirs(systemd_resolved_t)
+fs_search_tmpfs(systemd_resolved_t)
+fs_search_ramfs(systemd_resolved_t)
 
 init_dgram_send(systemd_resolved_t)
 


### PR DESCRIPTION
Fixes:
avc:  denied  { search } for  pid=233 comm="systemd-resolve" name="/" dev="tmpfs" ino=1 scontext=system_u:system_r:systemd_resolved_t tcontext=system_u:object_r:tmpfs_t tclass=dir permissive=1

avc:  denied  { search } for  pid=233 comm="systemd-resolve" name="/" dev="ramfs" ino=813 scontext=system_u:system_r:systemd_resolved_t tcontext=system_u:object_r:ramfs_t tclass=dir permissive=1