### PR TITLE
dovecot: add missing permissions

### DIFF
--- a/policy/modules/services/dovecot.te
+++ b/policy/modules/services/dovecot.te
@@ -124,8 +124,9 @@ create_files_pattern(dovecot_t, dovecot_var_log_t, dovecot_var_log_t)
 setattr_files_pattern(dovecot_t, dovecot_var_log_t, dovecot_var_log_t)
 logging_log_filetrans(dovecot_t, dovecot_var_log_t, { file dir })
 
+allow dovecot_t dovecot_spool_t:dir watch;
 manage_dirs_pattern(dovecot_t, dovecot_spool_t, dovecot_spool_t)
-manage_files_pattern(dovecot_t, dovecot_spool_t, dovecot_spool_t)
+mmap_manage_files_pattern(dovecot_t, dovecot_spool_t, dovecot_spool_t)
 manage_lnk_files_pattern(dovecot_t, dovecot_spool_t, dovecot_spool_t)
 
 manage_dirs_pattern(dovecot_t, dovecot_runtime_t, dovecot_runtime_t)
@@ -337,6 +338,8 @@ optional_policy(`
 # Deliver local policy
 #
 
+allow dovecot_deliver_t self:process signal;
+
 allow dovecot_deliver_t dovecot_cert_t:dir search_dir_perms;
 
 append_files_pattern(dovecot_deliver_t, dovecot_var_log_t, dovecot_var_log_t)
@@ -354,6 +357,8 @@ stream_connect_pattern(dovecot_deliver_t, dovecot_runtime_t, dovecot_runtime_t, 
 can_exec(dovecot_deliver_t, dovecot_deliver_exec_t)
 
 allow dovecot_deliver_t dovecot_t:process signull;
+
+allow dovecot_deliver_t dovecot_spool_t:file map;
 
 fs_getattr_all_fs(dovecot_deliver_t)
 


### PR DESCRIPTION
I use dovecot for IMAP hosting and several rules are missing.