### PR TITLE
path marking for vlc(mplayer_t)

### DIFF
--- a/policy/modules/apps/mplayer.fc
+++ b/policy/modules/apps/mplayer.fc
@@ -1,3 +1,7 @@
+HOME_DIR/\.cache/vlc(/.*)?			gen_context(system_u:object_r:mplayer_xdg_cache_t,s0)
+HOME_DIR/\.config/vlc(/.*)?			gen_context(system_u:object_r:mplayer_xdg_config_t,s0)
+HOME_DIR/\.local/share/vlc(/.*)?		gen_context(system_u:object_r:mplayer_xdg_data_t,s0)
+
 HOME_DIR/\.mplayer(/.*)?	gen_context(system_u:object_r:mplayer_home_t,s0)
 
 /etc/mplayer(/.*)?	gen_context(system_u:object_r:mplayer_etc_t,s0)

--- a/policy/modules/apps/mplayer.te
+++ b/policy/modules/apps/mplayer.te
@@ -43,6 +43,15 @@ optional_policy(`
 	pulseaudio_tmpfs_content(mplayer_tmpfs_t)
 ')
 
+type mplayer_xdg_cache_t;
+files_type(mplayer_xdg_cache_t)
+
+type mplayer_xdg_config_t;
+files_type(mplayer_xdg_config_t)
+
+type mplayer_xdg_data_t;
+files_type(mplayer_xdg_data_t)
+
 ########################################
 #
 # Mencoder local policy
@@ -148,6 +157,18 @@ manage_fifo_files_pattern(mplayer_t, mplayer_tmpfs_t, mplayer_tmpfs_t)
 manage_sock_files_pattern(mplayer_t, mplayer_tmpfs_t, mplayer_tmpfs_t)
 fs_tmpfs_filetrans(mplayer_t, mplayer_tmpfs_t,{ dir file lnk_file sock_file fifo_file })
 
+manage_dirs_pattern(mplayer_t, mplayer_xdg_cache_t, mplayer_xdg_cache_t)
+manage_files_pattern(mplayer_t, mplayer_xdg_cache_t, mplayer_xdg_cache_t)
+xdg_cache_filetrans(mplayer_t, mplayer_xdg_cache_t, dir, "vlc")
+
+manage_dirs_pattern(mplayer_t, mplayer_xdg_config_t, mplayer_xdg_config_t)
+manage_files_pattern(mplayer_t, mplayer_xdg_config_t, mplayer_xdg_config_t)
+xdg_config_filetrans(mplayer_t, mplayer_xdg_config_t, dir, "vlc")
+
+manage_dirs_pattern(mplayer_t, mplayer_xdg_data_t, mplayer_xdg_data_t)
+manage_files_pattern(mplayer_t, mplayer_xdg_data_t, mplayer_xdg_data_t)
+xdg_data_filetrans(mplayer_t, mplayer_xdg_data_t, dir, "vlc")
+
 kernel_dontaudit_list_unlabeled(mplayer_t)
 kernel_dontaudit_getattr_unlabeled_files(mplayer_t)
 kernel_dontaudit_read_unlabeled_files(mplayer_t)
@@ -183,6 +204,7 @@ files_read_non_security_files(mplayer_t)
 files_list_home(mplayer_t)
 files_read_etc_runtime_files(mplayer_t)
 files_read_usr_files(mplayer_t)
+files_map_usr_files(mplayer_t)
 
 fs_getattr_all_fs(mplayer_t)
 fs_search_auto_mountpoints(mplayer_t)


### PR DESCRIPTION
path marking for vlc(https://www.videolan.org/vlc/)
*To write these paths, the domain still needs to be granted access to xdg_{data,config,cache}_t