### PR TITLE
cloudinit: Add permissions derived from sysadm.

### DIFF
--- a/policy/modules/admin/cloudinit.if
+++ b/policy/modules/admin/cloudinit.if
@@ -2,6 +2,25 @@
 
 ########################################
 ## <summary>
+##	Read and write inherited cloud-init pipes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cloudinit_rw_inherited_pipes',`
+	gen_require(`
+		type cloud_init_t;
+	')
+
+	allow $1 cloud_init_t:fifo_file rw_inherited_fifo_file_perms;
+	allow $1 cloud_init_t:fd use;
+')
+
+########################################
+## <summary>
 ##	Create cloud-init runtime directory.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/admin/cloudinit.if
+++ b/policy/modules/admin/cloudinit.if
@@ -59,6 +59,25 @@ interface(`cloudinit_write_runtime_files',`
 
 ########################################
 ## <summary>
+##	Read and write cloud-init runtime files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cloudinit_rw_runtime_files',`
+	gen_require(`
+		type cloud_init_runtime_t;
+	')
+
+	files_search_runtime($1)
+	rw_files_pattern($1, cloud_init_runtime_t, cloud_init_runtime_t)
+')
+
+########################################
+## <summary>
 ##	Create cloud-init runtime files.
 ## </summary>
 ## <param name="domain">
@@ -124,4 +143,42 @@ interface(`cloudinit_getattr_state_files',`
 	allow $1 cloud_init_state_t:dir list_dir_perms;
 	allow $1 cloud_init_state_t:lnk_file read_lnk_file_perms;
 	allow $1 cloud_init_state_t:file getattr;
+')
+
+########################################
+## <summary>
+##	Read and write cloud-init temporary files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cloudinit_rw_tmp_files',`
+	gen_require(`
+		type cloud_init_tmp_t;
+	')
+
+	files_search_tmp($1)
+	rw_files_pattern($1, cloud_init_tmp_t, cloud_init_tmp_t)
+')
+
+########################################
+## <summary>
+##	Create cloud-init temporary files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cloudinit_create_tmp_files',`
+	gen_require(`
+		type cloud_init_tmp_t;
+	')
+
+	files_search_tmp($1)
+	create_files_pattern($1, cloud_init_tmp_t, cloud_init_tmp_t)
 ')

--- a/policy/modules/admin/cloudinit.te
+++ b/policy/modules/admin/cloudinit.te
@@ -115,5 +115,19 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# If sudo is used in runcmd:
+	allow cloud_init_t self:capability sys_resource;
+	allow cloud_init_t self:process { setrlimit setsched };
+
+	sudo_exec(cloud_init_t)
+
+	userdom_search_user_runtime(cloud_init_t)
+
+	optional_policy(`
+		systemd_write_inherited_logind_sessions_pipes(cloud_init_t)
+	')
+')
+
+optional_policy(`
 	systemd_dbus_chat_hostnamed(cloud_init_t)
 ')

--- a/policy/modules/admin/cloudinit.te
+++ b/policy/modules/admin/cloudinit.te
@@ -100,6 +100,7 @@ sysnet_domtrans_ifconfig(cloud_init_t)
 
 term_write_console(cloud_init_t)
 
+udev_manage_rules_files(cloud_init_t)
 udev_read_runtime_files(cloud_init_t)
 
 usermanage_domtrans_useradd(cloud_init_t)

--- a/policy/modules/admin/cloudinit.te
+++ b/policy/modules/admin/cloudinit.te
@@ -75,10 +75,6 @@ fstools_domtrans(cloud_init_t)
 
 hostname_domtrans(cloud_init_t)
 
-init_get_system_status(cloud_init_t)
-init_read_state(cloud_init_t)
-init_stream_connect(cloud_init_t)
-
 kernel_read_system_state(cloud_init_t)
 kernel_read_kernel_sysctls(cloud_init_t)
 
@@ -129,5 +125,13 @@ optional_policy(`
 ')
 
 optional_policy(`
+	init_get_system_status(cloud_init_t)
+	init_start_all_units(cloud_init_t)
+	init_stop_all_units(cloud_init_t)
+	init_get_all_units_status(cloud_init_t)
+	init_list_all_units(cloud_init_t)
+
+	systemd_exec_systemctl(cloud_init_t)
 	systemd_dbus_chat_hostnamed(cloud_init_t)
+	systemd_dbus_chat_logind(cloud_init_t)
 ')

--- a/policy/modules/admin/cloudinit.te
+++ b/policy/modules/admin/cloudinit.te
@@ -9,6 +9,13 @@ gen_require(`
 # Declarations
 #
 
+## <desc>
+## <p>
+## Enable support for cloud-init to manage all non-security files.
+## </p>
+## </desc>
+gen_tunable(cloudinit_manage_non_security, false)
+
 type cloud_init_t;
 type cloud_init_exec_t;
 init_system_domain(cloud_init_t, cloud_init_exec_t)
@@ -22,6 +29,9 @@ files_mountpoint(cloud_init_runtime_t)
 
 type cloud_init_state_t;
 files_type(cloud_init_state_t)
+
+type cloud_init_tmp_t;
+files_tmp_file(cloud_init_tmp_t)
 
 ########################################
 #
@@ -48,10 +58,14 @@ manage_lnk_files_pattern(cloud_init_t, cloud_init_state_t, cloud_init_state_t)
 manage_dirs_pattern(cloud_init_t, cloud_init_state_t, cloud_init_state_t)
 files_var_lib_filetrans(cloud_init_t, cloud_init_state_t, { dir file lnk_file })
 
+manage_files_pattern(cloud_init_t, cloud_init_tmp_t, cloud_init_tmp_t)
+manage_lnk_files_pattern(cloud_init_t, cloud_init_tmp_t, cloud_init_tmp_t)
+manage_dirs_pattern(cloud_init_t, cloud_init_tmp_t, cloud_init_tmp_t)
+files_tmp_filetrans(cloud_init_t, cloud_init_tmp_t, { dir file lnk_file })
+
 auth_domtrans_chk_passwd(cloud_init_t)
 
-corecmd_exec_bin(cloud_init_t)
-corecmd_exec_shell(cloud_init_t)
+corecmd_exec_all_executables(cloud_init_t)
 
 corenet_dontaudit_tcp_bind_generic_node(cloud_init_t)
 
@@ -60,6 +74,9 @@ dbus_system_bus_client(cloud_init_t)
 dev_getattr_all_blk_files(cloud_init_t)
 # /sys/devices/pci0000:00/0000:00:03.0/net/eth0/address
 dev_read_sysfs(cloud_init_t)
+
+domain_read_all_domains_state(cloud_init_t)
+domain_obj_id_change_exemption(cloud_init_t)
 
 files_manage_config_dirs(cloud_init_t)
 files_relabel_config_dirs(cloud_init_t)
@@ -87,7 +104,14 @@ miscfiles_read_localization(cloud_init_t)
 
 mount_domtrans(cloud_init_t)
 
+selinux_set_enforce_mode(cloud_init_t)
+selinux_set_all_booleans(cloud_init_t)
+selinux_set_parameters(cloud_init_t)
+selinux_read_policy(cloud_init_t)
+
 seutil_read_default_contexts(cloud_init_t)
+seutil_domtrans_semanage(cloud_init_t)
+seutil_domtrans_setfiles(cloud_init_t)
 
 ssh_domtrans_keygen(cloud_init_t)
 ssh_manage_home_files(cloud_init_t)
@@ -107,8 +131,825 @@ usermanage_domtrans_useradd(cloud_init_t)
 usermanage_domtrans_groupadd(cloud_init_t)
 usermanage_domtrans_passwd(cloud_init_t)
 
+tunable_policy(`cloudinit_manage_non_security',`
+	files_manage_non_security_dirs(cloud_init_t)
+	files_manage_non_security_files(cloud_init_t)
+	files_relabel_non_security_dirs(cloud_init_t)
+	files_relabel_non_security_files(cloud_init_t)
+')
+
+optional_policy(`
+	abrt_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	accountsd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	acct_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	afs_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	aide_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	aisexecd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	amanda_domtrans_recover(cloud_init_t)
+')
+
+optional_policy(`
+	amavis_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	amtu_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	apt_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	aptcacher_domtrans_acngtool(cloud_init_t)
+')
+
+optional_policy(`
+	arpwatch_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	automount_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	avahi_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	backup_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	bacula_domtrans_admin(cloud_init_t)
+	bacula_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	bind_admin(cloud_init_t, system_r)
+	bind_domtrans_ndc(cloud_init_t)
+')
+
+optional_policy(`
+	bird_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	bitlbee_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	boinc_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	bootloader_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	bugzilla_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	cachefilesd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	calamaris_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	canna_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	certbot_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	certmaster_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	certmonger_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	certwatch_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	cfengine_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	cgroup_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	chkrootkit_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	chronyd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	clamav_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	clock_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	cobbler_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	collectd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	condor_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	consoletype_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	container_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	corosync_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	couchdb_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	cron_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	ctdb_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	cups_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	cvs_admin(cloud_init_t, system_r)
+	cvs_exec(cloud_init_t)
+')
+
+optional_policy(`
+	cyphesis_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	cyrus_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	dante_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	ddclient_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	devicekit_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	dev_rw_xen(cloud_init_t)
+')
+
+optional_policy(`
+	dhcpd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	dictd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	dirmngr_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	distcc_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	dkim_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	dmidecode_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	dnsmasq_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	dovecot_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	dphysswapfile_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	dpkg_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	drbd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	entropyd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	exim_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	fail2ban_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	fapolicyd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	fcoe_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	fetchmail_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	firewalld_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	firstboot_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	ftp_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	gatekeeper_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	gdomap_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	glance_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	glusterfs_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	gssproxy_admin(cloud_init_t)
+')
+
+optional_policy(`
+	hostname_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	hwloc_admin(cloud_init_t)
+	hwloc_domtrans_dhwd(cloud_init_t)
+')
+
+optional_policy(`
+	hypervkvp_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	i18n_input_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	icecast_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	ifplugd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	inn_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	iodine_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	ipsec_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	iptables_admin(cloud_init_t, system_r)
+	iptables_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	irqbalance_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	iscsi_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	isnsd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	jabber_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	kdump_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	kerberos_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	kerneloops_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	keystone_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	knot_admin(cloud_init_t, system_r)
+	knot_domtrans_client(cloud_init_t)
+')
+
+optional_policy(`
+	kismet_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	ksmtuned_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	l2tp_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	ldap_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	libs_domtrans_ldconfig(cloud_init_t)
+')
+
+optional_policy(`
+	lightsquid_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	likewise_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	lircd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	lldpad_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	logrotate_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	lsmd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	lvm_admin(cloud_init_t, system_r)
+	lvm_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	mandb_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	mcelog_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	memcached_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	minidlna_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	minissdpd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	modutils_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	mongodb_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	monit_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	monop_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	mpd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	mrtg_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	munin_stream_connect(cloud_init_t)
+')
+
+optional_policy(`
+	mysql_admin(cloud_init_t, system_r)
+	mysql_stream_connect(cloud_init_t)
+')
+
+optional_policy(`
+	nagios_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	nessus_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	netlabel_run_mgmt(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	netutils_domtrans(cloud_init_t)
+	netutils_domtrans_ping(cloud_init_t)
+	netutils_domtrans_traceroute(cloud_init_t)
+')
+
+optional_policy(`
+	networkmanager_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	nis_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	nscd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+        nsd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	nslcd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	ntop_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	ntp_admin(cloud_init_t, system_r)
+	corenet_udp_bind_ntp_port(cloud_init_t)
+')
+
+optional_policy(`
+	numad_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	nut_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	oident_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	openct_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	openhpi_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	opensm_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	openvpn_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	openvswitch_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	pacemaker_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	pads_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	pcscd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	pegasus_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	perdition_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	pingd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	pkcs_admin_slotd(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	plymouthd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	portage_domtrans(cloud_init_t)
+	portage_domtrans_fetch(cloud_init_t)
+	portage_domtrans_gcc_config(cloud_init_t)
+')
+
+optional_policy(`
+	portmap_domtrans_helper(cloud_init_t)
+	portmap_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	portreserve_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	postfix_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	postfixpolicyd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	postgrey_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	ppp_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	prelude_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	privoxy_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	psad_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	puppet_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	pxe_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	pyzor_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	qpidd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	quantum_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	quota_run(cloud_init_t, system_r)
+	quota_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	rabbitmq_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	radius_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	radvd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	raid_domtrans_mdadm(cloud_init_t)
+	raid_admin_mdadm(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	redis_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	resmgr_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	rhsmcertd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	rkhunter_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	rngd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	rpc_admin(cloud_init_t, system_r)
+	rpc_domtrans_nfsd(cloud_init_t)
+')
+
+optional_policy(`
+	rpcbind_admin(cloud_init_t, system_r)
+')
+
 optional_policy(`
 	rpm_domtrans(cloud_init_t)
+	rpm_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	rsync_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	rtkit_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	rwho_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	samba_admin(cloud_init_t, system_r)
+	samba_domtrans_smbcontrol(cloud_init_t)
+	samba_domtrans_smbmount(cloud_init_t)
+	samba_domtrans_net(cloud_init_t)
+	samba_domtrans_winbind_helper(cloud_init_t)
+')
+
+optional_policy(`
+	samhain_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	sanlock_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	sasl_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	sblim_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	sensord_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	setrans_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	setroubleshoot_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	shorewall_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	slpd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	smartmon_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	smokeping_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	smstools_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	snmp_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	snort_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	soundserver_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	spamassassin_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	sssd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	stapserver_admin(cloud_init_t, system_r)
 ')
 
 optional_policy(`
@@ -126,13 +967,155 @@ optional_policy(`
 ')
 
 optional_policy(`
+	svnserve_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	sysnet_domtrans_ifconfig(cloud_init_t)
+	sysnet_domtrans_dhcpc(cloud_init_t)
+')
+
+optional_policy(`
+	sysstat_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	init_start_system(cloud_init_t)
+	init_stop_system(cloud_init_t)
+	init_reload(cloud_init_t)
 	init_get_system_status(cloud_init_t)
-	init_start_all_units(cloud_init_t)
-	init_stop_all_units(cloud_init_t)
-	init_get_all_units_status(cloud_init_t)
+	init_manage_all_units(cloud_init_t)
+	init_manage_all_unit_files(cloud_init_t)
 	init_list_all_units(cloud_init_t)
 
 	systemd_exec_systemctl(cloud_init_t)
 	systemd_dbus_chat_hostnamed(cloud_init_t)
 	systemd_dbus_chat_logind(cloud_init_t)
+	systemd_list_journal_dirs(cloud_init_t)
+	systemd_read_journal_files(cloud_init_t)
+')
+
+optional_policy(`
+	tboot_domtrans_txtstat(cloud_init_t)
+')
+
+optional_policy(`
+	tcsd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	tftp_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	tgtd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	tor_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	transproxy_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	tripwire_domtrans_siggen(cloud_init_t)
+	tripwire_domtrans_tripwire(cloud_init_t)
+	tripwire_domtrans_twadmin(cloud_init_t)
+	tripwire_domtrans_twprint(cloud_init_t)
+')
+
+optional_policy(`
+	tzdata_domtrans(cloud_init_t)
+')
+
+optional_policy(`
+	udev_domtrans_udevadm(cloud_init_t)
+')
+
+optional_policy(`
+	ulogd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	unconfined_domtrans(cloud_init_t)
+')
+
+optional_policy(`
+	uptime_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	uucp_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	uuidd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	varnishd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	varnishd_admin_varnishlog(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	vdagent_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	vhostmd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	virt_admin(cloud_init_t, system_r)
+	virt_stream_connect(cloud_init_t)
+')
+
+optional_policy(`
+	vnstatd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	vpn_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	watchdog_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	wdmd_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	webalizer_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	wireguard_admin(cloud_init_t, system_r)
+	wireguard_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	vlock_run(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	zabbix_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	zarafa_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	zebra_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	zfs_admin(cloud_init_t, system_r)
 ')

--- a/policy/modules/admin/cloudinit.te
+++ b/policy/modules/admin/cloudinit.te
@@ -1,5 +1,9 @@
 policy_module(cloudinit)
 
+gen_require(`
+	class passwd passwd;
+')
+
 ########################################
 #
 # Declarations
@@ -28,6 +32,7 @@ allow cloud_init_t self:capability { chown dac_override dac_read_search fowner f
 dontaudit cloud_init_t self:capability { net_admin sys_tty_config };
 allow cloud_init_t self:fifo_file rw_fifo_file_perms;
 allow cloud_init_t self:unix_dgram_socket create_socket_perms;
+allow cloud_init_t self:passwd passwd;
 
 allow cloud_init_t cloud_init_log_t:file { create_file_perms append_file_perms setattr };
 logging_log_filetrans(cloud_init_t, cloud_init_log_t, file)
@@ -37,6 +42,7 @@ manage_lnk_files_pattern(cloud_init_t, cloud_init_runtime_t, cloud_init_runtime_
 manage_dirs_pattern(cloud_init_t, cloud_init_runtime_t, cloud_init_runtime_t)
 files_runtime_filetrans(cloud_init_t, cloud_init_runtime_t, { dir file lnk_file })
 
+can_exec(cloud_init_t, cloud_init_state_t)
 manage_files_pattern(cloud_init_t, cloud_init_state_t, cloud_init_state_t)
 manage_lnk_files_pattern(cloud_init_t, cloud_init_state_t, cloud_init_state_t)
 manage_dirs_pattern(cloud_init_t, cloud_init_state_t, cloud_init_state_t)
@@ -98,9 +104,15 @@ sysnet_domtrans_ifconfig(cloud_init_t)
 
 term_write_console(cloud_init_t)
 
+udev_read_runtime_files(cloud_init_t)
+
 usermanage_domtrans_useradd(cloud_init_t)
 usermanage_domtrans_groupadd(cloud_init_t)
 usermanage_domtrans_passwd(cloud_init_t)
+
+optional_policy(`
+	rpm_domtrans(cloud_init_t)
+')
 
 optional_policy(`
 	systemd_dbus_chat_hostnamed(cloud_init_t)

--- a/policy/modules/admin/rpm.te
+++ b/policy/modules/admin/rpm.te
@@ -368,6 +368,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	cloudinit_rw_inherited_pipes(rpm_script_t)
+')
+
+optional_policy(`
 	dbus_system_bus_client(rpm_script_t)
 
 	optional_policy(`

--- a/policy/modules/admin/rpm.te
+++ b/policy/modules/admin/rpm.te
@@ -90,6 +90,7 @@ allow rpm_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow rpm_t rpm_log_t:file { append_file_perms create_file_perms setattr_file_perms };
 logging_log_filetrans(rpm_t, rpm_log_t, file)
 
+allow rpm_t rpm_tmp_t:dir watch;
 manage_dirs_pattern(rpm_t, rpm_tmp_t, rpm_tmp_t)
 manage_files_pattern(rpm_t, rpm_tmp_t, rpm_tmp_t)
 files_tmp_filetrans(rpm_t, rpm_tmp_t, { file dir })
@@ -101,6 +102,7 @@ manage_fifo_files_pattern(rpm_t, rpm_tmpfs_t, rpm_tmpfs_t)
 manage_sock_files_pattern(rpm_t, rpm_tmpfs_t, rpm_tmpfs_t)
 fs_tmpfs_filetrans(rpm_t, rpm_tmpfs_t, { dir file lnk_file sock_file fifo_file })
 
+allow rpm_t rpm_var_cache_t:dir watch;
 manage_dirs_pattern(rpm_t, rpm_var_cache_t, rpm_var_cache_t)
 manage_files_pattern(rpm_t, rpm_var_cache_t, rpm_var_cache_t)
 files_var_filetrans(rpm_t, rpm_var_cache_t, dir)
@@ -398,6 +400,7 @@ optional_policy(`
 
 optional_policy(`
 	unconfined_domtrans(rpm_script_t)
+	unconfined_write_inherited_pipes(rpm_script_t)
 
 	optional_policy(`
 		java_domtrans_unconfined(rpm_script_t)

--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -229,3 +229,22 @@ interface(`sudo_sigchld',`
 
 	allow $1 sudodomain:process sigchld;
 ')
+
+########################################
+## <summary>
+##	Execute sudo in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sudo_exec',`
+	gen_require(`
+		type sudo_exec_t;
+	')
+
+	can_exec($1, sudo_exec_t)
+	corecmd_search_bin($1)
+')

--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -202,6 +202,10 @@ allow groupadd_t self:unix_stream_socket create_stream_socket_perms;
 allow groupadd_t self:unix_dgram_socket sendto;
 allow groupadd_t self:unix_stream_socket connectto;
 
+# for getting the number of groups
+kernel_read_kernel_sysctls(groupadd_t)
+kernel_dontaudit_getattr_proc(groupadd_t)
+
 fs_getattr_xattr_fs(groupadd_t)
 fs_search_auto_mountpoints(groupadd_t)
 

--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -465,7 +465,7 @@ optional_policy(`
 # Useradd local policy
 #
 
-allow useradd_t self:capability { chown dac_override fowner fsetid kill setuid sys_resource };
+allow useradd_t self:capability { chown dac_read_search dac_override fowner fsetid kill setuid sys_resource };
 dontaudit useradd_t self:capability { net_admin sys_tty_config };
 dontaudit useradd_t self:cap_userns sys_ptrace;
 allow useradd_t self:process { transition signal_perms getsched setsched getsession getpgid setpgid getcap setcap share getattr setfscreate noatsecure siginh rlimitinh dyntransition setkeycreate setsockcreate getrlimit };

--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -288,7 +288,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	unconfined_use_fds(groupadd_t)
+	unconfined_write_inherited_pipes(groupadd_t)
 ')
 
 ########################################
@@ -470,7 +470,7 @@ optional_policy(`
 #
 
 allow useradd_t self:capability { chown dac_read_search dac_override fowner fsetid kill setuid sys_resource };
-dontaudit useradd_t self:capability { net_admin sys_tty_config };
+dontaudit useradd_t self:capability { net_admin sys_ptrace sys_tty_config };
 dontaudit useradd_t self:cap_userns sys_ptrace;
 allow useradd_t self:process { transition signal_perms getsched setsched getsession getpgid setpgid getcap setcap share getattr setfscreate noatsecure siginh rlimitinh dyntransition setkeycreate setsockcreate getrlimit };
 allow useradd_t self:fd use;
@@ -595,5 +595,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	unconfined_use_fds(useradd_t)
+	unconfined_write_inherited_pipes(useradd_t)
 ')

--- a/policy/modules/system/fstools.te
+++ b/policy/modules/system/fstools.te
@@ -190,6 +190,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	cloudinit_rw_tmp_files(fsadm_t)
+	cloudinit_create_tmp_files(fsadm_t)
+')
+
+optional_policy(`
 	# for smartctl cron jobs
 	cron_system_entry(fsadm_t, fsadm_exec_t)
 ')

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -3663,6 +3663,25 @@ interface(`init_reload_all_units',`
 
 ########################################
 ## <summary>
+##	List systemd unit dirs and the files in them
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_list_all_units',`
+	gen_require(`
+		attribute systemdunit;
+	')
+
+	list_dirs_pattern($1, systemdunit, systemdunit)
+	read_lnk_files_pattern($1, systemdunit, systemdunit)
+')
+
+########################################
+## <summary>
 ##	Manage systemd unit dirs and the files in them
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -220,6 +220,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	unconfined_write_inherited_pipes(load_policy_t)
         # leaked file descriptors
         unconfined_dontaudit_read_pipes(load_policy_t)
 ')
@@ -531,6 +532,10 @@ term_use_all_terms(semanage_t)
 
 # Running genhomedircon requires this for finding all users
 auth_use_nsswitch(semanage_t)
+
+# Python module compilations
+libs_dontaudit_manage_lib_dirs(semanage_t)
+libs_dontaudit_manage_lib_files(semanage_t)
 
 logging_send_syslog_msg(semanage_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -512,7 +512,7 @@ init_rename_runtime_files(systemd_generator_t)
 init_search_runtime(systemd_generator_t)
 init_setattr_runtime_files(systemd_generator_t)
 init_write_runtime_files(systemd_generator_t)
-init_list_unit_dirs(systemd_generator_t)
+init_list_all_units(systemd_generator_t)
 init_getattr_generic_units_files(systemd_generator_t)
 init_read_generic_units_symlinks(systemd_generator_t)
 init_read_script_files(systemd_generator_t)
@@ -543,7 +543,7 @@ ifdef(`distro_gentoo',`
 
 optional_policy(`
 	cloudinit_create_runtime_dirs(systemd_generator_t)
-	cloudinit_write_runtime_files(systemd_generator_t)
+	cloudinit_rw_runtime_files(systemd_generator_t)
 	cloudinit_create_runtime_files(systemd_generator_t)
 	cloudinit_filetrans_runtime(systemd_generator_t, dir, "cloud-init")
 

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -389,6 +389,25 @@ interface(`unconfined_read_pipes',`
 
 ########################################
 ## <summary>
+##	Write unconfined domain unnamed pipes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_write_inherited_pipes',`
+	gen_require(`
+		type unconfined_t;
+	')
+
+	allow $1 unconfined_t:fd use;
+	allow $1 unconfined_t:fifo_file { getattr ioctl append write };
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to read unconfined domain unnamed pipes.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Allow a similar amount of admin capability to cloud-init as sysadm.  Also add
a tunable to allow non-security file management for fallback.