### PR TITLE
container: set default context for local-path-provisioner

### DIFF
--- a/policy/modules/services/container.fc
+++ b/policy/modules/services/container.fc
@@ -32,6 +32,8 @@ HOME_DIR/\.docker(/.*)?		gen_context(system_u:object_r:container_conf_home_t,s0)
 
 /opt/cni(/.*)?		gen_context(system_u:object_r:container_plugin_t,s0)
 
+/opt/local-path-provisioner(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
+
 /etc/containers(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
 /etc/cni(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
 /etc/docker(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
@@ -99,6 +101,8 @@ HOME_DIR/\.docker(/.*)?		gen_context(system_u:object_r:container_conf_home_t,s0)
 /var/lib/calico(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/etcd(/.*)?             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/kube-proxy(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
+
+/var/local-path-provisioner(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
 
 /var/log/containerd(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/containers(/.*)?		gen_context(system_u:object_r:container_log_t,s0)


### PR DESCRIPTION
The kubernetes local-path-provisioner uses either
/opt/local-path-provisioner or
/var/local-path-provisioner for its physical volumes