### PR TITLE
portage: permit to build on tmpfs

### DIFF
--- a/policy/modules/admin/portage.if
+++ b/policy/modules/admin/portage.if
@@ -116,11 +116,15 @@ interface(`portage_compile_domain',`
 	# SELinux-enabled programs running in the sandbox
 	allow $1 portage_tmp_t:file relabel_file_perms;
 
+	can_exec($1, portage_tmpfs_t)
+	manage_dirs_pattern($1, portage_tmpfs_t, portage_tmpfs_t)
 	manage_files_pattern($1, portage_tmpfs_t, portage_tmpfs_t)
 	manage_lnk_files_pattern($1, portage_tmpfs_t, portage_tmpfs_t)
 	manage_fifo_files_pattern($1, portage_tmpfs_t, portage_tmpfs_t)
 	manage_sock_files_pattern($1, portage_tmpfs_t, portage_tmpfs_t)
 	fs_tmpfs_filetrans($1, portage_tmpfs_t, { dir file lnk_file sock_file fifo_file })
+	relabel_files_pattern($1, portage_tmpfs_t, portage_tmpfs_t)
+	relabel_dirs_pattern($1, portage_tmpfs_t, portage_tmpfs_t)
 
 	kernel_read_system_state($1)
 	kernel_read_network_state($1)


### PR DESCRIPTION
My portage PORTAGE_TMPDIR directory is on a tmpfs, but emerging openssl fail with: Can not execute files in /var/tmp/portage
This is due to missing rules permiting portage to execute files in tmpfs.
After this error, some relabel/manage rules was still missing, so this commit add them also.