### PR TITLE
Allow initrc_t read zfs config files.

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -109,6 +109,8 @@ ifdef(`distro_redhat',`
 /etc/xen/qemu-ifup		--	gen_context(system_u:object_r:bin_t,s0)
 /etc/xen/scripts(/.*)?			gen_context(system_u:object_r:bin_t,s0)
 
+/etc/zfs/zfs-functions		--      gen_context(system_u:object_r:bin_t,s0)
+
 ifdef(`distro_debian',`
 /etc/mysql/debian-start		--	gen_context(system_u:object_r:bin_t,s0)
 ')


### PR DESCRIPTION
OpenRC reads zfs config during boot.
----
type=PROCTITLE msg=audit(04/27/23 13:56:20.937:11) : proctitle=/bin/sh /lib/rc/sh/gendepends.sh
type=SYSCALL msg=audit(04/27/23 13:56:20.937:11) : arch=x86_64 syscall=openat success=yes exit=4 a0=AT_FDCWD a1=0x558b0743b330 a2=O_RDONLY a3=0x0 items=0 ppid=356 pid=605 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=roo
t sgid=root fsgid=root tty=tty1 ses=unset comm=gendepends.sh exe=/bin/bash subj=system_u:system_r:initrc_t:s0-s15:c0.c1023 key=(null)
type=AVC msg=audit(04/27/23 13:56:20.937:11) : avc:  granted  { read open } for  pid=605 comm=gendepends.sh path=/etc/zfs/zfs-functions dev="dm-3" ino=658657 scontext=system_u:system_r:initrc_t:s0-s15:c0.c1023 tcontext=system_u:object_r:zf
s_config_t:s0 tclass=file
type=AVC msg=audit(04/27/23 13:56:20.937:11) : avc:  granted  { read } for  pid=605 comm=gendepends.sh name=zfs-functions dev="dm-3" ino=658657 scontext=system_u:system_r:initrc_t:s0-s15:c0.c1023 tcontext=system_u:object_r:zfs_config_t:s0
tclass=file
----
