### PR TITLE
Dir transition goes with dir create perms.

### DIFF
--- a/policy/modules/services/zfs.te
+++ b/policy/modules/services/zfs.te
@@ -84,6 +84,7 @@ list_dirs_pattern(zfs_t, zfs_config_t, zfs_config_t)
 read_files_pattern(zfs_t, zfs_config_t, zfs_config_t)
 read_lnk_files_pattern(zfs_t, zfs_config_t, zfs_config_t)
 
+manage_dirs_pattern(zfs_t, zfs_runtime_t, zfs_runtime_t)
 manage_files_pattern(zfs_t, zfs_runtime_t, zfs_runtime_t)
 files_runtime_filetrans(zfs_t, zfs_runtime_t, { dir file })
 


### PR DESCRIPTION
During boot openrc service zfs-import creates /run/blkid/ dir and /run/blkid/blkid.tab file. There is file transition rule for both { dir file }, but policy lacks dir { create } permission.

As for cups.te config I believe manage dir permission should go there as well.

type=PROCTITLE msg=audit(05/03/23 09:33:15.202:10) : proctitle=/sbin/zpool import
type=PATH msg=audit(05/03/23 09:33:15.202:10) : item=1 name=(null) inode=986 dev=00:16 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:zfs_runtime_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(05/03/23 09:33:15.202:10) : item=0 name=(null) inode=1 dev=00:16 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:var_run_t:s0-s15:c0.c1023 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(05/03/23 09:33:15.202:10) : cwd=/
type=SYSCALL msg=audit(05/03/23 09:33:15.202:10) : arch=x86_64 syscall=mkdir success=yes exit=0 a0=0x73670146a43a a1=0755 a2=0xffffffffffffdef0 a3=0x0 items=2 ppid=1434 pid=1435 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=zpool exe=/sbin/zpool subj=system_u:system_r:zfs_t:s0-s15:c0.c1023 key=(null)
type=AVC msg=audit(05/03/23 09:33:15.202:10) : avc:  granted  { create } for  pid=1435 comm=zpool name=blkid scontext=system_u:system_r:zfs_t:s0-s15:c0.c1023 tcontext=system_u:object_r:zfs_runtime_t:s0 tclass=dir