### PR TITLE
Keep context of blkid file/dir when created by zpool.

### DIFF
--- a/policy/modules/services/zfs.te
+++ b/policy/modules/services/zfs.te
@@ -129,6 +129,11 @@ userdom_use_user_terminals(zfs_t)
 zfs_rw_zpool_cache(zfs_t)
 
 optional_policy(`
+	fstools_manage_runtime_files(zfs_t)
+	fstools_runtime_filetrans(zfs_t, dir, "blkid")
+')
+
+optional_policy(`
 	kernel_rw_rpc_sysctls(zfs_t)
 
 	rpc_manage_nfs_state_data(zfs_t)

--- a/policy/modules/system/fstools.if
+++ b/policy/modules/system/fstools.if
@@ -321,3 +321,31 @@ interface(`fstools_manage_swap_files',`
 	allow $1 swapfile_t:file manage_file_perms;
 ')
 
+########################################
+## <summary>
+##	Create objects in the runtime directory with an automatic type transition to the fsadm runtime type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="object">
+##      <summary>
+##      The object class of the object being created.
+##      </summary>
+## </param>
+## <param name="name" optional="true">
+##      <summary>
+##      The name of the object being created.
+##      </summary>
+## </param>
+#
+interface(`fstools_runtime_filetrans',`
+	gen_require(`
+		type fsadm_run_t;
+	')
+
+	files_runtime_filetrans($1, fsadm_run_t, $2, $3)
+')
+


### PR DESCRIPTION
Lot of fsadm tools is using /run/blkid/.
I've reached condition when zpool was one to create this dir/file.
This can be relabeled due to https://github.com/SELinuxProject/refpolicy/blob/8f563f58ea6b09ff18bc67b571f65f2e615cdff0/policy/modules/system/fstools.fc#L119

If this gets created by zpool it will break other tools:

type=PROCTITLE msg=audit(05/10/23 15:53:02.940:792) : proctitle=blkid
type=PATH msg=audit(05/10/23 15:53:02.940:792) : item=0 name=/run/blkid/blkid.tab inode=987 dev=00:16 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:zfs_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(05/10/23 15:53:02.940:792) : cwd=/root
type=SYSCALL msg=audit(05/10/23 15:53:02.940:792) : arch=x86_64 syscall=newfstatat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x62816678a700 a2=0x7ffc906a3340 a3=0x0 items=1 ppid=4283 pid=4349 auid=plsph uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts2 ses=2 comm=blkid exe=/sbin/blkid subj=staff_u:sysadm_r:fsadm_t:s0-s15:c0.c1023 key=(null)
type=AVC msg=audit(05/10/23 15:53:02.940:792) : avc:  denied  { getattr } for  pid=4349 comm=blkid path=/run/blkid/blkid.tab dev="tmpfs" ino=987 scontext=staff_u:sysadm_r:fsadm_t:s0-s15:c0.c1023 tcontext=system_u:object_r:zfs_runtime_t:s0 tclass=file permissive=0



If it's not the first to create blkid dir/file zpool don't have access to it:

[   43.807237] audit: type=1400 audit(1683704864.188:10): avc:  denied  { read } for  pid=1430 comm="zpool" name="blkid.tab" dev="tmpfs" ino=932 scontext=system_u:system_r:zfs_t:s0-s15:c0.c1023 tcontext=system_u:object_r:fsadm_run_t:s0 tclass=file permissive=0
[   43.807240] audit: type=1300 audit(1683704864.188:10): arch=c000003e syscall=257 success=no exit=-13 a0=ffffff9c a1=636fa1273320 a2=80000 a3=0 items=0 ppid=1429 pid=1430 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="zpool" exe="/sbin/zpool" subj=system_u:system_r:zfs_t:s0-s15:c0.c1023 key=(null)
[   43.807241] audit: type=1327 audit(1683704864.188:10): proctitle=2F7362696E2F7A706F6F6C00696D706F7274
[   43.807242] audit: type=1400 audit(1683704864.188:11): avc:  denied  { read } for  pid=1430 comm="zpool" name="blkid.tab" dev="tmpfs" ino=932 scontext=system_u:system_r:zfs_t:s0-s15:c0.c1023 tcontext=system_u:object_r:fsadm_run_t:s0 tclass=file permissive=0
[   43.807243] audit: type=1300 audit(1683704864.188:11): arch=c000003e syscall=257 success=no exit=-13 a0=ffffff9c a1=636fa1273320 a2=80000 a3=0 items=0 ppid=1429 pid=1430 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="zpool" exe="/sbin/zpool" subj=system_u:system_r:zfs_t:s0-s15:c0.c1023 key=(null)
[   43.807244] audit: type=1327 audit(1683704864.188:11): proctitle=2F7362696E2F7A706F6F6C00696D706F7274
[   44.064992] audit: type=1400 audit(1683704864.446:12): avc:  denied  { getattr } for  pid=1430 comm="zpool" path="/run/blkid/blkid.tab" dev="tmpfs" ino=932 scontext=system_u:system_r:zfs_t:s0-s15:c0.c1023 tcontext=system_u:object_r:fsadm_run_t:s0 tclass=file permissive=0
[   44.064996] audit: type=1300 audit(1683704864.446:12): arch=c000003e syscall=262 success=no exit=-13 a0=ffffff9c a1=636fa1273320 a2=7ffebb0285f0 a3=0 items=0 ppid=1429 pid=1430 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="zpool" exe="/sbin/zpool" subj=system_u:system_r:zfs_t:s0-s15:c0.c1023 key=(null)
[   44.064997] audit: type=1327 audit(1683704864.446:12): proctitle=2F7362696E2F7A706F6F6C00696D706F7274
[   44.064998] audit: type=1400 audit(1683704864.446:13): avc:  denied  { getattr } for  pid=1430 comm="zpool" path="/run/blkid/blkid.tab" dev="tmpfs" ino=932 scontext=system_u:system_r:zfs_t:s0-s15:c0.c1023 tcontext=system_u:object_r:fsadm_run_t:s0 tclass=file permissive=0


Hence these permissions and transition rules.