### PR TITLE
container: rework capabilities

### DIFF
--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -60,10 +60,27 @@ gen_tunable(container_use_ecryptfs, false)
 
 ## <desc>
 ##	<p>
+##	Allow containers to use all capabilities in a
+##	non-namespaced context for various privileged operations
+##	directly on the host.
+##	</p>
+## </desc>
+gen_tunable(container_use_host_all_caps, false)
+
+## <desc>
+##	<p>
 ##	Allow containers to use huge pages.
 ##	</p>
 ## </desc>
 gen_tunable(container_use_hugetlbfs, false)
+
+## <desc>
+##	<p>
+##	Allow containers to use the mknod syscall, e.g. for
+##	creating special device files.
+##	</p>
+## </desc>
+gen_tunable(container_use_mknod, false)
 
 ## <desc>
 ##	<p>
@@ -78,6 +95,41 @@ gen_tunable(container_use_nfs, false)
 ##	</p>
 ## </desc>
 gen_tunable(container_use_samba, false)
+
+## <desc>
+##	<p>
+##	Allow containers to use the sysadmin capability, e.g.
+##	for mounting filesystems.
+##	</p>
+## </desc>
+gen_tunable(container_use_sysadmin, false)
+
+## <desc>
+##	<p>
+##	Allow containers to use all capabilities in a
+##	namespaced context for various privileged operations
+##	within the container itself.
+##	</p>
+## </desc>
+gen_tunable(container_use_userns_all_caps, false)
+
+## <desc>
+##	<p>
+##	Allow containers to use the mknod syscall in a
+##	namespaced context, e.g. for creating special device
+##	files within the container itself.
+##	</p>
+## </desc>
+gen_tunable(container_use_userns_mknod, false)
+
+## <desc>
+##	<p>
+##	Allow containers to use the sysadmin capability in a
+##	namespaced context, e.g. for mounting filesystems
+##	within the container itself.
+##	</p>
+## </desc>
+gen_tunable(container_use_userns_sysadmin, false)
 
 ########################################
 #
@@ -228,7 +280,8 @@ corenet_port(container_port_t)
 # Common container domain local policy
 #
 
-allow container_domain self:capability { dac_override kill setgid setuid sys_boot sys_chroot };
+dontaudit container_domain self:capability fsetid;
+dontaudit container_domain self:capability2 block_suspend;
 allow container_domain self:cap_userns { chown dac_override dac_read_search fowner kill setgid setuid };
 allow container_domain self:process { execstack execmem getattr getsched getsession setsched setcap setpgid signal_perms };
 allow container_domain self:dir rw_dir_perms;
@@ -410,7 +463,6 @@ optional_policy(`
 # Common container net domain local policy
 #
 
-allow container_net_domain self:capability { net_admin net_raw };
 allow container_net_domain self:cap_userns { net_admin net_bind_service net_raw };
 allow container_net_domain self:tcp_socket create_stream_socket_perms;
 allow container_net_domain self:udp_socket create_socket_perms;
@@ -446,8 +498,6 @@ corenet_tcp_connect_all_ports(container_net_domain)
 # Container local policy
 #
 
-allow container_t self:capability { chown dac_override dac_read_search fowner fsetid setpcap sys_admin sys_nice sys_ptrace sys_resource };
-dontaudit container_t self:capability2 block_suspend;
 allow container_t self:process setrlimit;
 
 allow container_t container_file_t:filesystem getattr;
@@ -474,6 +524,36 @@ auth_use_nsswitch(container_t)
 logging_send_audit_msgs(container_t)
 
 userdom_use_user_ptys(container_t)
+
+tunable_policy(`container_use_host_all_caps',`
+	# omitted sys_module
+	allow container_t self:capability { chown dac_override dac_read_search fowner fsetid kill setgid setuid setpcap linux_immutable net_bind_service net_broadcast net_admin net_raw ipc_lock ipc_owner sys_rawio sys_chroot sys_ptrace sys_pacct sys_admin sys_boot sys_nice sys_resource sys_time sys_tty_config mknod lease audit_write audit_control setfcap };
+	# omitted mac_admin, mac_override
+	allow container_t self:capability2 { syslog wake_alarm block_suspend audit_read perfmon bpf checkpoint_restore };
+')
+
+tunable_policy(`container_use_mknod',`
+	allow container_t self:capability mknod;
+')
+
+tunable_policy(`container_use_sysadmin',`
+	allow container_t self:capability sys_admin;
+')
+
+tunable_policy(`container_use_userns_all_caps',`
+	# omitted sys_module
+	allow container_t self:cap_userns { chown dac_override dac_read_search fowner fsetid kill setgid setuid setpcap linux_immutable net_bind_service net_broadcast net_admin net_raw ipc_lock ipc_owner sys_rawio sys_chroot sys_ptrace sys_pacct sys_admin sys_boot sys_nice sys_resource sys_time sys_tty_config mknod lease audit_write audit_control setfcap };
+	# omitted mac_admin, mac_override
+	allow container_t self:cap2_userns { syslog wake_alarm block_suspend audit_read perfmon bpf checkpoint_restore };
+')
+
+tunable_policy(`container_use_userns_mknod || container_use_mknod',`
+	allow container_t self:cap_userns mknod;
+')
+
+tunable_policy(`container_use_userns_sysadmin || container_use_sysadmin',`
+	allow container_t self:cap_userns sys_admin;
+')
 
 optional_policy(`
 	rpm_read_db(container_t)


### PR DESCRIPTION
Rework (primarily) non-namespaced capabilities. These accesses are leftovers from earlier policy versions before the container module was introduced that are most likely too coarse for most container applications.

Put all non-namespaced capability accesses for containers behind tunables, borrowing ideas from container-selinux. For the more privileged capabilities (sysadmin, mknod), add a tunable to control both namespaced and non-namespaced access to these operations.

I'm not hard-set on having a tunable for namespaced and a tunable for non-namespaced capabilities each, so if there is any opposition I'd be happy to change it.