### PR TITLE
chromium: allow chromium-naclhelper to create user namespaces

### DIFF
--- a/policy/modules/apps/chromium.te
+++ b/policy/modules/apps/chromium.te
@@ -379,6 +379,7 @@ allow chromium_sandbox_t chromium_naclhelper_t:process share;
 # Chromium nacl helper local policy
 #
 
+allow chromium_naclhelper_t self:user_namespace create;
 allow chromium_naclhelper_t chromium_t:unix_stream_socket { getattr read write };
 allow chromium_naclhelper_t chromium_sandbox_t:unix_stream_socket { getattr read write };
 


### PR DESCRIPTION
Closes: https://github.com/SELinuxProject/refpolicy/issues/605