### PR TITLE
container: fix cilium denial

### DIFF
--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -866,6 +866,7 @@ allow spc_t self:netlink_audit_socket { create_netlink_socket_perms nlmsg_relay 
 allow spc_t self:netlink_generic_socket create_socket_perms;
 allow spc_t self:netlink_netfilter_socket create_socket_perms;
 allow spc_t self:netlink_xfrm_socket create_socket_perms;
+allow spc_t self:perf_event { cpu kernel open read };
 
 allow container_engine_system_domain spc_t:process { setsched signal_perms };
 


### PR DESCRIPTION
Hello,

While testing Cilium CNI in a Kubernetes cluster, I noticed the following denials:
```
Jun 20 08:01:43 localhost audit[3480]: AVC avc:  denied  { open } for  pid=3480 comm="cilium-agent" scontext=system_u:system_r:spc_t:s0 tcontext=system_u:system_r:spc_t:s0 tclass=perf_event permissive=1
Jun 20 08:01:43 localhost audit[3480]: AVC avc:  denied  { kernel } for  pid=3480 comm="cilium-agent" scontext=system_u:system_r:spc_t:s0 tcontext=system_u:system_r:spc_t:s0 tclass=perf_event permissive=1
Jun 20 08:01:43 localhost audit[3480]: AVC avc:  denied  { cpu } for  pid=3480 comm="cilium-agent" scontext=system_u:system_r:spc_t:s0 tcontext=system_u:system_r:spc_t:s0 tclass=perf_event permissive=1
Jun 20 08:01:43 localhost audit[3480]: AVC avc:  denied  { read } for  pid=3480 comm="cilium-agent" scontext=system_u:system_r:spc_t:s0 tcontext=system_u:system_r:spc_t:s0 tclass=perf_event permissive=1
```

It has been seen with release 2.20221101 from Gentoo ebuilds on Flatcar operating system using Cilium 1.12.1 and 1.12.5 