### PR TITLE
systemd-generator: systemd_generator_t load kernel modules used for e…

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -524,6 +524,8 @@ kernel_dontaudit_getattr_proc(systemd_generator_t)
 # Where an unlabeled mountpoint is encounted:
 kernel_dontaudit_search_unlabeled(systemd_generator_t)
 
+modutils_domtrans(systemd_generator_t)
+
 # write for systemd-zram-generator
 storage_raw_rw_fixed_disk(systemd_generator_t)
 storage_raw_read_removable_device(systemd_generator_t)


### PR DESCRIPTION
….g. zram-generator

Fixes:
avc:  denied  { getsched } for  pid=171 comm="zram-generator" scontext=system_u:system_r:systemd_generator_t tcontext=system_u:system_r:systemd_generator_t tclass=process permissive=1 avc:  denied  { execute } for  pid=173 comm="zram-generator" name="kmod" dev="sda2" ino=17417 scontext=system_u:system_r:systemd_generator_t tcontext=system_u:object_r:kmod_exec_t tclass=file permissive=1