### PR TITLE
Add label and interfaces for kernel PSI files

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -1537,6 +1537,51 @@ interface(`kernel_read_network_state_symlinks',`
 
 ########################################
 ## <summary>
+##	Allow caller to receive pressure stall information (PSI).
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`kernel_read_psi',`
+	gen_require(`
+		type proc_t, proc_psi_t;
+	')
+
+	read_files_pattern($1, { proc_t proc_psi_t }, proc_psi_t)
+	read_lnk_files_pattern($1, { proc_t proc_psi_t }, proc_psi_t)
+	list_dirs_pattern($1, { proc_t proc_psi_t }, proc_psi_t)
+')
+
+########################################
+## <summary>
+##	Allow caller to set up pressure stall information (PSI).
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`kernel_rw_psi',`
+	gen_require(`
+		type proc_t, proc_psi_t;
+	')
+
+	rw_files_pattern($1, { proc_t proc_psi_t }, proc_psi_t)
+	read_lnk_files_pattern($1, { proc_t proc_psi_t }, proc_psi_t)
+	list_dirs_pattern($1, { proc_t proc_psi_t }, proc_psi_t)
+
+	# kernel requires writers to have CAP_SYS_RESOURCE
+	allow $1 self:capability sys_resource;
+')
+
+########################################
+## <summary>
 ##	Allow searching of xen state directory.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -109,6 +109,9 @@ genfscon proc /mdstat gen_context(system_u:object_r:proc_mdstat_t,s0)
 type proc_net_t, proc_type;
 genfscon proc /net gen_context(system_u:object_r:proc_net_t,s0)
 
+type proc_psi_t, proc_type;
+genfscon proc /pressure gen_context(system_u:object_r:proc_psi_t,s0)
+
 type proc_xen_t, proc_type;
 files_mountpoint(proc_xen_t)
 genfscon proc /xen gen_context(system_u:object_r:proc_xen_t,s0)


### PR DESCRIPTION
The pressure stall information (PSI) special files in /proc/pressure currently don't have a separate file context, and so default to proc_t. Since users need read/write permissions to those files to use PSI, and handing out blanket permissions to proc_t is strongly discouraged, introduce a new proc_psi_t label, as well as interfaces for it.