### PR TITLE
Allow local login to read /run/motd

### DIFF
--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -120,6 +120,25 @@ interface(`auth_use_pam_motd_dynamic',`
 
 ########################################
 ## <summary>
+##	Read the pam module motd with dynamic support during authentication.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_read_pam_motd_dynamic',`
+	gen_require(`
+		type pam_motd_runtime_t;
+	')
+
+	files_search_runtime($1)
+	allow $1 pam_motd_runtime_t:file read_file_perms;
+')
+
+########################################
+## <summary>
 ##	Make the specified domain used for a login program.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -128,6 +128,7 @@ auth_manage_pam_runtime_dirs(local_login_t)
 auth_manage_pam_runtime_files(local_login_t)
 auth_manage_pam_console_data(local_login_t)
 auth_domtrans_pam_console(local_login_t)
+auth_read_pam_motd_dynamic(local_login_t)
 
 init_dontaudit_use_fds(local_login_t)
 


### PR DESCRIPTION
node=localhost type=AVC msg=audit(1689384764.155:53945): avc:  denied  { getattr } for  pid=5125 comm="login" path="/run/motd" dev="tmpfs" ino=1574 scontext=system_u:system_r:local_login_t:s0 tcontext=system_u:object_r:pam_motd_runtime_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1689384764.155:53946): avc:  denied  { read } for  pid=5125 comm="login" name="motd" dev="tmpfs" ino=1574 scontext=system_u:system_r:local_login_t:s0 tcontext=system_u:object_r:pam_motd_runtime_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1689384764.155:53946): avc:  denied  { open } for  pid=5125 comm="login" path="/run/motd" dev="tmpfs" ino=1574 scontext=system_u:system_r:local_login_t:s0 tcontext=system_u:object_r:pam_motd_runtime_t:s0 tclass=file permissive=1