### PR TITLE
Label pwhistory_helper

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -334,6 +334,7 @@ term_use_all_ttys(passwd_t)
 term_use_all_ptys(passwd_t)
 
 auth_run_chk_passwd(passwd_t, passwd_roles)
+auth_run_upd_passwd(passwd_t, passwd_roles)
 auth_manage_shadow(passwd_t)
 auth_relabel_shadow(passwd_t)
 auth_etc_filetrans_shadow(passwd_t)

--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -4,6 +4,8 @@
 /etc/gshadow.*		--	gen_context(system_u:object_r:shadow_t,s0)
 /etc/shadow.*		--	gen_context(system_u:object_r:shadow_t,s0)
 /etc/tcb(/.*)?		--	gen_context(system_u:object_r:shadow_t,s0)
+/etc/security/opasswd		--	gen_context(system_u:object_r:shadow_t,s0)
+/etc/security/opasswd\.old	--	gen_context(system_u:object_r:shadow_t,s0)
 
 /usr/bin/login		--	gen_context(system_u:object_r:login_exec_t,s0)
 /usr/bin/pam_console_apply	--	gen_context(system_u:object_r:pam_console_exec_t,s0)
@@ -24,6 +26,7 @@
 
 /usr/sbin/pam_console_apply	--	gen_context(system_u:object_r:pam_console_exec_t,s0)
 /usr/sbin/pam_timestamp_check	--	gen_context(system_u:object_r:pam_exec_t,s0)
+/usr/sbin/pwhistory_helper	--	gen_context(system_u:object_r:updpwd_exec_t,s0)
 /usr/sbin/tcb_convert		--	gen_context(system_u:object_r:updpwd_exec_t,s0)
 /usr/sbin/tcb_unconvert		--	gen_context(system_u:object_r:updpwd_exec_t,s0)
 /usr/sbin/unix_chkpwd		--	gen_context(system_u:object_r:chkpwd_exec_t,s0)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -391,6 +391,7 @@ files_manage_etc_files(updpwd_t)
 term_dontaudit_use_console(updpwd_t)
 term_dontaudit_use_unallocated_ttys(updpwd_t)
 
+auth_etc_filetrans_shadow(updpwd_t)
 auth_manage_shadow(updpwd_t)
 auth_use_nsswitch(updpwd_t)
 


### PR DESCRIPTION
pwhistory_helper is executed by pam_pwhistory (as configued in /etc/pam.d/sysem-auth).  It updates /etc/security/opasswd which contains old passwords.  Label /etc/security/opasswd as shadow_t to control access.

node=localhost type=AVC msg=audit(1689391847.287:8989): avc:  denied  { execute } for  pid=2667 comm="passwd" name="pwhistory_helper" dev="dm-1" ino=402516 scontext=toor_u:staff_r:passwd_t:s0 tcontext=system_u:object_r:updpwd_exec_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1689391847.287:8989): avc:  denied  { read open } for  pid=2667 comm="passwd" path="/usr/sbin/pwhistory_helper" dev="dm-1" ino=402516 scontext=toor_u:staff_r:passwd_t:s0 tcontext=system_u:object_r:updpwd_exec_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1689391847.287:8989): avc:  denied  { execute_no_trans } for  pid=2667 comm="passwd" path="/usr/sbin/pwhistory_helper" dev="dm-1" ino=402516 scontext=toor_u:staff_r:passwd_t:s0 tcontext=system_u:object_r:updpwd_exec_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1689391847.287:8989): avc:  denied  { map } for  pid=2667 comm="pwhistory_helpe" path="/usr/sbin/pwhistory_helper" dev="dm-1" ino=402516 scontext=toor_u:staff_r:passwd_t:s0 tcontext=system_u:object_r:updpwd_exec_t:s0 tclass=file permissive=1