### PR TITLE
If domain can read system_dbusd_var_lib_t files, also allow symlinks

### DIFF
--- a/policy/modules/services/dbus.if
+++ b/policy/modules/services/dbus.if
@@ -142,6 +142,7 @@ interface(`dbus_system_bus_client',`
 
 	files_search_var_lib($1)
 	read_files_pattern($1, system_dbusd_var_lib_t, system_dbusd_var_lib_t)
+	read_lnk_files_pattern($1, system_dbusd_var_lib_t, system_dbusd_var_lib_t)
 
 	files_search_runtime($1)
 	stream_connect_pattern($1, system_dbusd_runtime_t, system_dbusd_runtime_t, system_dbusd_t)


### PR DESCRIPTION
node=localhost type=AVC msg=audit(1689811752.145:511): avc:  denied  { read } for  pid=2622 comm="lightdm-gtk-gre" name="machine-id" dev="dm-10" ino=262170 scontext=system_u:system_r:xdm_t:s0 tcontext=system_u:object_r:system_dbusd_var_lib_t:s0 tclass=lnk_file permissive=0
node=localhost type=AVC msg=audit(1689811752.404:514): avc:  denied  { read } for  pid=2629 comm="at-spi-bus-laun" name="machine-id" dev="dm-10" ino=262170 scontext=system_u:system_r:xdm_t:s0 tcontext=system_u:object_r:system_dbusd_var_lib_t:s0 tclass=lnk_file permissive=0