### PR TITLE
Add interfaces for systemd-hostnamed units

### DIFF
--- a/policy/modules/services/accountsd.fc
+++ b/policy/modules/services/accountsd.fc
@@ -2,4 +2,7 @@
 
 /usr/lib/accountsservice/accounts-daemon	--	gen_context(system_u:object_r:accountsd_exec_t,s0)
 
+/usr/lib/systemd/system/accounts-daemon.*	--	gen_context(system_u:object_r:accountsd_unit_t,s0)
+
 /var/lib/AccountsService(/.*)?	gen_context(system_u:object_r:accountsd_var_lib_t,s0)
+

--- a/policy/modules/services/accountsd.if
+++ b/policy/modules/services/accountsd.if
@@ -119,6 +119,45 @@ interface(`accountsd_manage_lib_files',`
 	manage_files_pattern($1, accountsd_var_lib_t, accountsd_var_lib_t)
 ')
 
+
+########################################
+## <summary>
+##	Allow specified domain to start and stop accountsd units
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`accountsd_startstop',`
+	gen_require(`
+		type accountsd_unit_t;
+		class service { start stop };
+	')
+
+	allow $1 accountsd_unit_t:service { start stop };
+')
+
+########################################
+## <summary>
+##	Get the system status information from accountsd
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`accountsd_status',`
+	gen_require(`
+		type accountsd_unit_t;
+		class service status;
+	')
+
+	allow $1 accountsd_unit_t:service status;
+')
+
 ########################################
 ## <summary>
 ##	All of the rules required to

--- a/policy/modules/services/accountsd.te
+++ b/policy/modules/services/accountsd.te
@@ -13,6 +13,9 @@ type accountsd_t;
 type accountsd_exec_t;
 dbus_system_domain(accountsd_t, accountsd_exec_t)
 
+type accountsd_unit_t;
+init_unit_file(accountsd_unit_t)
+
 type accountsd_var_lib_t;
 files_type(accountsd_var_lib_t)
 

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -245,6 +245,9 @@ optional_policy(`
 	# for starting systemd-hostnamed.service
 	systemd_startstop_hostnamed(system_dbusd_t)
 
+	# for starting systemd-logind.service
+	systemd_startstop_logind(system_dbusd_t)
+
 	# allow populating of /var/lib/dbus by systemd-tmpfilesd
 	systemd_tmpfilesd_managed(system_dbusd_var_lib_t)
 ')

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -242,6 +242,9 @@ optional_policy(`
 	# for passing around terminal file handles for machinectl shell
 	systemd_use_inherited_machined_ptys(system_dbusd_t)
 
+	# for starting systemd-hostnamed.service
+	systemd_startstop_hostnamed(system_dbusd_t)
+
 	# allow populating of /var/lib/dbus by systemd-tmpfilesd
 	systemd_tmpfilesd_managed(system_dbusd_var_lib_t)
 ')

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -253,6 +253,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	accountsd_startstop(system_dbusd_t)
+')
+
+optional_policy(`
 	bluetooth_stream_connect(system_dbusd_t)
 ')
 

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -65,6 +65,7 @@ HOME_DIR/\.local/share/systemd(/.*)?		gen_context(system_u:object_r:systemd_data
 /usr/lib/systemd/system/[^/]*suspend.*	--	gen_context(system_u:object_r:power_unit_t,s0)
 /usr/lib/systemd/system/systemd-backlight.*	--	gen_context(system_u:object_r:systemd_backlight_unit_t,s0)
 /usr/lib/systemd/system/systemd-binfmt.*	--	gen_context(system_u:object_r:systemd_binfmt_unit_t,s0)
+/usr/lib/systemd/system/systemd-hostnamed.*	--	gen_context(system_u:object_r:systemd_hostnamed_unit_t,s0)
 /usr/lib/systemd/system/systemd-networkd.*		gen_context(system_u:object_r:systemd_networkd_unit_t,s0)
 /usr/lib/systemd/system/systemd-network-generator.*		gen_context(system_u:object_r:systemd_networkd_unit_t,s0)
 /usr/lib/systemd/system/systemd-rfkill.*	--	gen_context(system_u:object_r:systemd_rfkill_unit_t,s0)

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -66,6 +66,7 @@ HOME_DIR/\.local/share/systemd(/.*)?		gen_context(system_u:object_r:systemd_data
 /usr/lib/systemd/system/systemd-backlight.*	--	gen_context(system_u:object_r:systemd_backlight_unit_t,s0)
 /usr/lib/systemd/system/systemd-binfmt.*	--	gen_context(system_u:object_r:systemd_binfmt_unit_t,s0)
 /usr/lib/systemd/system/systemd-hostnamed.*	--	gen_context(system_u:object_r:systemd_hostnamed_unit_t,s0)
+/usr/lib/systemd/system/systemd-logind.*	--	gen_context(system_u:object_r:systemd_logind_unit_t,s0)
 /usr/lib/systemd/system/systemd-networkd.*		gen_context(system_u:object_r:systemd_networkd_unit_t,s0)
 /usr/lib/systemd/system/systemd-network-generator.*		gen_context(system_u:object_r:systemd_networkd_unit_t,s0)
 /usr/lib/systemd/system/systemd-rfkill.*	--	gen_context(system_u:object_r:systemd_rfkill_unit_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1538,6 +1538,44 @@ interface(`systemd_dbus_chat_machined',`
 
 ########################################
 ## <summary>
+##	Allow specified domain to start and stop systemd-hostnamed units
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_startstop_hostnamed',`
+	gen_require(`
+		type systemd_hostnamed_unit_t;
+		class service { start stop };
+	')
+
+	allow $1 systemd_hostnamed_unit_t:service { start stop };
+')
+
+########################################
+## <summary>
+##	Allow specified domain to get status of systemd-hostnamed
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_status_hostnamed',`
+	gen_require(`
+		type systemd_hostnamed_unit_t;
+		class service status;
+	')
+
+	allow $1 systemd_hostnamed_unit_t:service status;
+')
+
+########################################
+## <summary>
 ##   Send and receive messages from
 ##   systemd hostnamed over dbus.
 ## </summary>

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1311,6 +1311,26 @@ interface(`systemd_dbus_chat_logind',`
 	allow systemd_logind_t $1:dbus send_msg;
 ')
 
+
+########################################
+## <summary>
+##	Allow specified domain to start and stop systemd-logind units
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_startstop_logind',`
+	gen_require(`
+		type systemd_logind_unit_t;
+		class service { start stop };
+	')
+
+	allow $1 systemd_logind_unit_t:service { start stop };
+')
+
 ########################################
 ## <summary>
 ##	Get the system status information from systemd_login
@@ -1323,11 +1343,11 @@ interface(`systemd_dbus_chat_logind',`
 #
 interface(`systemd_status_logind',`
 	gen_require(`
-		type systemd_logind_t;
+		type systemd_logind_unit_t;
 		class service status;
 	')
 
-	allow $1 systemd_logind_t:service status;
+	allow $1 systemd_logind_unit_t:service status;
 ')
 
 ########################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -142,6 +142,9 @@ type systemd_hostnamed_t;
 type systemd_hostnamed_exec_t;
 init_daemon_domain(systemd_hostnamed_t, systemd_hostnamed_exec_t)
 
+type systemd_hostnamed_unit_t;
+init_unit_file(systemd_hostnamed_unit_t)
+
 type systemd_hw_t;
 type systemd_hw_exec_t;
 init_system_domain(systemd_hw_t, systemd_hw_exec_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -165,6 +165,9 @@ type systemd_logind_exec_t;
 init_daemon_domain(systemd_logind_t, systemd_logind_exec_t)
 init_named_socket_activation(systemd_logind_t, systemd_logind_runtime_t)
 
+type systemd_logind_unit_t;
+init_unit_file(systemd_logind_unit_t)
+
 type systemd_logind_inhibit_runtime_t alias systemd_logind_inhibit_var_run_t;
 files_runtime_file(systemd_logind_inhibit_runtime_t)
 init_mountpoint(systemd_logind_inhibit_runtime_t)


### PR DESCRIPTION
node=localhost type=USER_AVC msg=audit(1689811749.504:399): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { start } for auid=n/a uid=0 gid=81 path="/usr/lib/systemd/system/systemd-hostnamed.service" cmdline="/usr/bin/dbus-broker-launch --scope system --audit" function="bus_unit_method_start_generic" scontext=system_u:system_r:system_dbusd_t:s0 tcontext=system_u:object_r:systemd_unit_t:s0 tclass=service permissive=0 exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=?  terminal=?' UID="root" AUID="unset" AUID="root" UID="root" GID="dbus" SAUID="root"