### PR TITLE
systemd-rfkill.socket reads and writes /dev/rfkill (with ListenSocket=) option.

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -368,6 +368,7 @@ ifdef(`init_systemd',`
 	dev_write_urand(init_t)
 	dev_rw_lvm_control(init_t)
 	dev_rw_autofs(init_t)
+	dev_rw_wireless(init_t)
 	dev_manage_generic_symlinks(init_t)
 	dev_manage_generic_dirs(init_t)
 	dev_manage_null_service(initrc_t)


### PR DESCRIPTION
Need to allow this to open the file so the service starts properly.

node=localhost type=AVC msg=audit(1689883855.890:419): avc:  denied  { open } for  pid=1 comm="systemd" path="/dev/rfkill" dev="devtmpfs" ino=152 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:wireless_device_t:s0 tclass=chr_file permissive=1
node=localhost type=AVC msg=audit(1689883962.317:408): avc:  denied  { read write } for  pid=1 comm="systemd" name="rfkill" dev="devtmpfs" ino=152 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:wireless_device_t:s0 tclass=chr_file permissive=0