### PR TITLE
Support new Debian/Ubuntu /run/motd.d directory

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -260,7 +260,11 @@ corenet_sendrecv_xserver_server_packets(sshd_t)
 
 ifdef(`distro_debian',`
 	allow sshd_t self:process { getcap setcap };
+	auth_read_pam_motd_files(sshd_t)
 	auth_use_pam_motd_dynamic(sshd_t)
+
+	# for unattended-upgrades notices.  Should we have a domain transition?
+	files_read_var_lib_files(sshd_t)
 ',`
 	dontaudit sshd_t self:process { getcap setcap };
 ')

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -456,6 +456,7 @@ auth_domtrans_pam_console(xdm_t)
 auth_manage_pam_runtime_dirs(xdm_t)
 auth_manage_pam_runtime_files(xdm_t)
 auth_manage_pam_console_data(xdm_t)
+auth_use_pam_motd_dynamic(xdm_t)
 auth_write_login_records(xdm_t)
 
 # Run telinit->init to shutdown.

--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -53,6 +53,7 @@ ifdef(`distro_suse', `
 /run/motd		--	gen_context(system_u:object_r:pam_motd_runtime_t,s0)
 /run/motd\.dynamic	--	gen_context(system_u:object_r:pam_motd_runtime_t,s0)
 /run/motd\.dynamic\.new	--	gen_context(system_u:object_r:pam_motd_runtime_t,s0)
+/run/motd\.d(/.*)?		gen_context(system_u:object_r:pam_motd_runtime_t,s0)
 /run/pam_mount(/.*)?	gen_context(system_u:object_r:pam_runtime_t,s0)
 /run/pam_ssh(/.*)?		gen_context(system_u:object_r:var_auth_t,s0)
 /run/sepermit(/.*)? 	gen_context(system_u:object_r:pam_runtime_t,s0)

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -120,6 +120,44 @@ interface(`auth_use_pam_motd_dynamic',`
 
 ########################################
 ## <summary>
+##	Write files in /run/motd.d directory
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_write_pam_motd_files',`
+	gen_require(`
+		type pam_motd_runtime_t;
+	')
+
+	allow $1 pam_motd_runtime_t:dir rw_dir_perms;
+	allow $1 pam_motd_runtime_t:file manage_file_perms;
+')
+
+########################################
+## <summary>
+##	Read files in /run/motd.d directory
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_read_pam_motd_files',`
+	gen_require(`
+		type pam_motd_runtime_t;
+	')
+
+	allow $1 pam_motd_runtime_t:dir list_dir_perms;
+	allow $1 pam_motd_runtime_t:file read_file_perms;
+')
+
+########################################
+## <summary>
 ##	Make the specified domain used for a login program.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -154,6 +154,7 @@ ifdef(`init_systemd',`
 ')
 
 ifdef(`distro_debian',`
+	auth_read_pam_motd_files(local_login_t)
 	auth_use_pam_motd_dynamic(local_login_t)
 ')
 


### PR DESCRIPTION
Policy for the new system of managing the motd with the /run/motd.d directory.

Signed-off-by: Russell Coker <russell@coker.com.au>
