### PR TITLE
Allow rsyslog to drop capabilities

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -570,6 +570,11 @@ ifdef(`distro_gentoo',`
 	term_dontaudit_setattr_unallocated_ttys(syslogd_t)
 ')
 
+ifdef(`distro_redhat',`
+	# EL9 configures with --enable-libcap-ng
+	allow syslogd_t self:capability setpcap;
+')
+
 ifdef(`distro_suse',`
 	# suse creates a /dev/log under /var/lib/stunnel for chrooted stunnel
 	files_var_lib_filetrans(syslogd_t, devlog_t, sock_file)


### PR DESCRIPTION
Aug 28 19:01:43 localhost.localdomain audisp-syslog[1565]: node=localhost type=AVC msg=audit(1693249303.693:415): avc:  denied  { setpcap } for  pid=1722 comm="rsyslogd" capability=8 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:system_r:syslogd_t:s0 tclass=capability permissive=0
Aug 28 19:01:43 localhost.localdomain rsyslogd[1722]: libcap-ng used by "/usr/sbin/rsyslogd" failed dropping bounding set in capng_apply