### PR TITLE
To allow setting for net.netfilter.nf_* in /etc/sysctl.d/*.conf

### DIFF
--- a/policy/modules/system/modutils.te
+++ b/policy/modules/system/modutils.te
@@ -63,6 +63,7 @@ kernel_read_debugfs(kmod_t)
 # Rules for /proc/sys/kernel/tainted
 kernel_read_kernel_sysctls(kmod_t)
 kernel_rw_kernel_sysctl(kmod_t)
+kernel_rw_net_sysctls(kmod_t)
 kernel_read_hotplug_sysctls(kmod_t)
 kernel_setsched(kmod_t)
 # for when /var is not mounted early in the boot:


### PR DESCRIPTION
node=localhost type=AVC msg=audit(1691097149.019:422): avc:  denied  { search } for  pid=2332 comm="sysctl" name="net" dev="proc" ino=11426 scontext=system_u:system_r:kmod_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1691097149.019:422): avc:  denied  { getattr } for  pid=2332 comm="sysctl" path="/proc/sys/net/netfilter/nf_conntrack_max" dev="proc" ino=23194 scontext=system_u:system_r:kmod_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1691097149.020:423): avc:  denied  { write } for  pid=2332 comm="sysctl" name="nf_conntrack_max" dev="proc" ino=23194 scontext=system_u:system_r:kmod_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1691097149.020:423): avc:  denied  { open } for  pid=2332 comm="sysctl" path="/proc/sys/net/netfilter/nf_conntrack_max" dev="proc" ino=23194 scontext=system_u:system_r:kmod_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1