### PR TITLE
Allow iceauth write to xsession log

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -228,6 +228,8 @@ fs_search_auto_mountpoints(iceauth_t)
 userdom_use_user_terminals(iceauth_t)
 userdom_read_user_tmp_files(iceauth_t)
 
+xserver_write_inherited_xsession_log(iceauth_t)
+
 tunable_policy(`use_nfs_home_dirs',`
 	fs_manage_nfs_files(iceauth_t)
 ')


### PR DESCRIPTION
node=localhost type=AVC msg=audit(1689822970.302:4180): avc:  denied  { write } for  pid=2610 comm="iceauth" path="/home/toor/.xsession-errors" dev="dm-9" ino=129541 scontext=toor_u:staff_r:iceauth_t:s0 tcontext=system_u:object_r:xsession_log_t:s0 tclass=file permissive=1