### PR TITLE
Stricter yet more customizable xserver policy and three security bug fixes

### DIFF
--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -125,8 +125,12 @@ template(`xserver_restricted_role',`
 	# Client write xserver shm
 	tunable_policy(`allow_write_xshm',`
 		allow $2 xserver_t:shm rw_shm_perms;
+	')
+
+	tunable_policy(`allow_write_xserver_tmpfs',`
 		allow $2 xserver_tmpfs_t:file rw_file_perms;
 	')
+
 	tunable_policy(`xserver_allow_dri',`
 		dev_rw_dri($2)
 	')
@@ -482,6 +486,9 @@ template(`xserver_user_x_domain_template',`
 	# Client write xserver shm
 	tunable_policy(`allow_write_xshm',`
 		allow $2 xserver_t:shm rw_shm_perms;
+	')
+
+	tunable_policy(`allow_write_xserver_tmpfs',`
 		allow $2 xserver_tmpfs_t:file rw_file_perms;
 	')
 ')

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -127,7 +127,7 @@ template(`xserver_restricted_role',`
 		allow $2 xserver_t:shm rw_shm_perms;
 	')
 
-	tunable_policy(`allow_write_xserver_tmpfs',`
+	tunable_policy(`allow_write_xshm || allow_write_xserver_tmpfs',`
 		allow $2 xserver_tmpfs_t:file rw_file_perms;
 	')
 
@@ -295,7 +295,7 @@ interface(`xserver_rw_session',`
 		allow $1 xserver_t:shm rw_shm_perms;
 	')
 
-	tunable_policy(`allow_write_xserver_tmpfs',`
+	tunable_policy(`allow_write_xshm || allow_write_xserver_tmpfs',`
 		allow $1 xserver_tmpfs_t:file rw_file_perms;
 	')
 ')
@@ -494,7 +494,7 @@ template(`xserver_user_x_domain_template',`
 		allow $2 xserver_t:shm rw_shm_perms;
 	')
 
-	tunable_policy(`allow_write_xserver_tmpfs',`
+	tunable_policy(`allow_write_xshm || allow_write_xserver_tmpfs',`
 		allow $2 xserver_tmpfs_t:file rw_file_perms;
 	')
 ')

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -270,8 +270,8 @@ interface(`xserver_ro_session',`
 #######################################
 ## <summary>
 ##	Create sessions on the X server, with read and write
-##	access to the X server shared
-##	memory segments.
+##	access to the X server shared memory segments, but
+##	do not bypass existing tunable policy logic.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -290,8 +290,14 @@ interface(`xserver_rw_session',`
 	')
 
 	xserver_ro_session($1,$2)
-	allow $1 xserver_t:shm rw_shm_perms;
-	allow $1 xserver_tmpfs_t:file rw_file_perms;
+
+	tunable_policy(`allow_write_xshm',`
+		allow $1 xserver_t:shm rw_shm_perms;
+	')
+
+	tunable_policy(`allow_write_xserver_tmpfs',`
+		allow $1 xserver_tmpfs_t:file rw_file_perms;
+	')
 ')
 
 #######################################

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -179,8 +179,14 @@ template(`xserver_role',`
 	xserver_restricted_role($1, $2, $3, $4)
 
 	# Communicate via System V shared memory.
-	allow $2 xserver_t:shm rw_shm_perms;
-	allow $2 xserver_tmpfs_t:file rw_file_perms;
+	tunable_policy(`allow_write_xshm',`
+		# Communicate via System V shared memory.
+		allow $2 xserver_t:shm rw_shm_perms;
+	')
+
+	tunable_policy(`allow_write_xshm || xserver_client_writes_xserver_tmpfs',`
+		allow $2 xserver_tmpfs_t:file rw_file_perms;
+	')
 
 	# XCB Event Queue: used by the Qt library for example
 	allow $2 xserver_tmp_t:file rw_file_perms;

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -127,7 +127,7 @@ template(`xserver_restricted_role',`
 		allow $2 xserver_t:shm rw_shm_perms;
 	')
 
-	tunable_policy(`allow_write_xshm || allow_write_xserver_tmpfs',`
+	tunable_policy(`allow_write_xshm || xserver_client_writes_xserver_tmpfs',`
 		allow $2 xserver_tmpfs_t:file rw_file_perms;
 	')
 
@@ -295,7 +295,7 @@ interface(`xserver_rw_session',`
 		allow $1 xserver_t:shm rw_shm_perms;
 	')
 
-	tunable_policy(`allow_write_xshm || allow_write_xserver_tmpfs',`
+	tunable_policy(`allow_write_xshm || xserver_client_writes_xserver_tmpfs',`
 		allow $1 xserver_tmpfs_t:file rw_file_perms;
 	')
 ')
@@ -494,7 +494,7 @@ template(`xserver_user_x_domain_template',`
 		allow $2 xserver_t:shm rw_shm_perms;
 	')
 
-	tunable_policy(`allow_write_xshm || allow_write_xserver_tmpfs',`
+	tunable_policy(`allow_write_xshm || xserver_client_writes_xserver_tmpfs',`
 		allow $2 xserver_tmpfs_t:file rw_file_perms;
 	')
 ')

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -44,8 +44,6 @@ template(`xserver_restricted_role',`
 
 	allow xserver_t $2:process signal;
 
-	allow xserver_t $2:shm rw_shm_perms;
-
 	allow $2 user_fonts_t:dir list_dir_perms;
 	allow $2 user_fonts_t:file read_file_perms;
 

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -1476,7 +1476,9 @@ interface(`xserver_rw_shm',`
 		type xserver_t;
 	')
 
-	allow $1 xserver_t:shm rw_shm_perms;
+	tunable_policy(`allow_write_xshm',`
+		allow $1 xserver_t:shm rw_shm_perms;
+	')
 ')
 
 ########################################

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -35,6 +35,14 @@ gen_tunable(allow_write_xshm, false)
 
 ## <desc>
 ## <p>
+## Allows clients to write to the X server tmpfs
+## files.
+## </p>
+## </desc>
+gen_tunable(allow_write_xserver_tmpfs, false)
+
+## <desc>
+## <p>
 ## Allow xdm logins as sysadm
 ## </p>
 ## </desc>

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -27,6 +27,13 @@ gen_require(`
 
 ## <desc>
 ## <p>
+## Allow xdm logins as sysadm
+## </p>
+## </desc>
+gen_tunable(xdm_sysadm_login, false)
+
+## <desc>
+## <p>
 ## Allows clients to write to the X server shared
 ## memory segments.
 ## </p>
@@ -39,14 +46,7 @@ gen_tunable(allow_write_xshm, false)
 ## files.
 ## </p>
 ## </desc>
-gen_tunable(allow_write_xserver_tmpfs, false)
-
-## <desc>
-## <p>
-## Allow xdm logins as sysadm
-## </p>
-## </desc>
-gen_tunable(xdm_sysadm_login, false)
+gen_tunable(xserver_client_writes_xserver_tmpfs, false)
 
 ## <desc>
 ## <p>


### PR DESCRIPTION
Separate the tunable permissions to write xserver tmpfs files from the tunable permissions to write X server shared memory.

This allows a stricter, yet more customizable policy.

Fix a security bug in one xserver module interface which allows to bypass existing tunable policy logic.