### PR TITLE
Fix two long-standing build failures

### DIFF
--- a/policy/modules/services/dbus.if
+++ b/policy/modules/services/dbus.if
@@ -60,7 +60,7 @@ interface(`dbus_exec',`
 template(`dbus_role_template',`
 	gen_require(`
 		class dbus { send_msg acquire_svc };
-		attribute session_bus_type;
+		type $1_dbusd_t;
 		type system_dbusd_t, dbusd_exec_t;
 		type session_dbusd_tmp_t, session_dbusd_home_t;
 		type session_dbusd_runtime_t;
@@ -71,7 +71,6 @@ template(`dbus_role_template',`
 	# Declarations
 	#
 
-	type $1_dbusd_t, session_bus_type;
 	domain_type($1_dbusd_t)
 	domain_entry_file($1_dbusd_t, dbusd_exec_t)
 	ubac_constrained($1_dbusd_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -27,8 +27,8 @@
 #
 template(`systemd_role_template',`
 	gen_require(`
-		attribute systemd_user_session_type, systemd_log_parse_env_type;
 		attribute systemd_user_activated_sock_file_type, systemd_user_unix_stream_activated_socket_type;
+		type $1_systemd_t;
 		type systemd_analyze_exec_t;
 		type systemd_conf_home_t, systemd_data_home_t;
 		type systemd_user_runtime_t, systemd_user_runtime_notify_t;
@@ -40,7 +40,6 @@ template(`systemd_role_template',`
 	#
 	# Declarations
 	#
-	type $1_systemd_t, systemd_user_session_type, systemd_log_parse_env_type;
 	init_pgm_spec_user_daemon_domain($1_systemd_t)
 	domain_user_exemption_target($1_systemd_t)
 	userdom_application_exec_domain($1_systemd_t, $1)


### PR DESCRIPTION
This patchset fixes two long-standing build failures due to semantic errors in the systemd and dbus modules (interfaces/templates).