### PR TITLE
Update the gpg module so that the application is able to fetch keys from the network

### DIFF
--- a/policy/modules/apps/gpg.te
+++ b/policy/modules/apps/gpg.te
@@ -83,6 +83,7 @@ allow gpg_t self:process { signal signull setrlimit getcap setcap getsched setsc
 dontaudit gpg_t self:netlink_audit_socket r_netlink_socket_perms;
 allow gpg_t self:fifo_file rw_fifo_file_perms;
 allow gpg_t self:tcp_socket { accept listen };
+allow gpg_t self:unix_stream_socket create_stream_socket_perms;
 
 manage_dirs_pattern(gpg_t, gpg_runtime_t, gpg_runtime_t)
 userdom_user_runtime_filetrans(gpg_t, gpg_runtime_t, dir, "gnupg")
@@ -134,6 +135,7 @@ auth_use_nsswitch(gpg_t)
 logging_send_syslog_msg(gpg_t)
 
 miscfiles_read_localization(gpg_t)
+miscfiles_read_generic_certs(gpg_t)
 
 userdom_use_user_terminals(gpg_t)
 


### PR DESCRIPTION
Without the patch in this pull request the following error is produced:

 $ gpg --recv-keys EA3A87F0A4EBA030E45DF2409E8C1AFBBEFFDB32

 gpg: error running '/usr/bin/dirmngr': exit status 1
 gpg: failed to start dirmngr '/usr/bin/dirmngr': Generic error
 gpg: can't connect to the dirmngr: Generic error
 gpg: keyserver receive failed: dirmngr is not installed

 policy/modules/apps/gpg.te |    2 ++
 1 file changed, 2 insertions(+)