### PR TITLE
Increase general syslog daemon policy security by making network permissions tunable

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -5,6 +5,14 @@ policy_module(logging)
 # Declarations
 #
 
+## <desc>
+## <p>
+## Allows syslogd internet domain sockets
+## functionality (dangerous).
+## </p>
+## </desc>
+gen_tunable(logging_syslog_can_network, false)
+
 attribute logfile;
 
 type auditctl_t;
@@ -386,8 +394,7 @@ optional_policy(`
 # chown fsetid for syslog-ng
 # sys_admin for the integrated klog of syslog-ng and metalog
 # sys_nice for rsyslog
-# cjp: why net_admin!
-allow syslogd_t self:capability { chown dac_override fsetid net_admin setgid setuid sys_admin sys_nice sys_resource sys_tty_config };
+allow syslogd_t self:capability { chown dac_override fsetid setgid setuid sys_admin sys_nice sys_resource sys_tty_config };
 dontaudit syslogd_t self:capability { sys_ptrace };
 dontaudit syslogd_t self:cap_userns { kill sys_ptrace };
 # setpgid for metalog
@@ -456,29 +463,6 @@ kernel_change_ring_buffer_level(syslogd_t)
 kernel_read_ring_buffer(syslogd_t)
 # /initrd is not umounted before minilog starts
 kernel_dontaudit_search_unlabeled(syslogd_t)
-
-corenet_all_recvfrom_netlabel(syslogd_t)
-corenet_udp_sendrecv_generic_if(syslogd_t)
-corenet_udp_sendrecv_generic_node(syslogd_t)
-corenet_udp_bind_generic_node(syslogd_t)
-corenet_udp_bind_syslogd_port(syslogd_t)
-# syslog-ng can listen and connect on tcp port 514 (rsh)
-corenet_tcp_sendrecv_generic_if(syslogd_t)
-corenet_tcp_sendrecv_generic_node(syslogd_t)
-corenet_tcp_bind_generic_node(syslogd_t)
-corenet_tcp_bind_rsh_port(syslogd_t)
-corenet_tcp_connect_rsh_port(syslogd_t)
-# Allow users to define additional syslog ports to connect to
-corenet_tcp_bind_syslogd_port(syslogd_t)
-corenet_tcp_connect_syslogd_port(syslogd_t)
-corenet_tcp_connect_postgresql_port(syslogd_t)
-corenet_tcp_connect_mysqld_port(syslogd_t)
-
-# syslog-ng can send or receive logs
-corenet_sendrecv_syslogd_client_packets(syslogd_t)
-corenet_sendrecv_syslogd_server_packets(syslogd_t)
-corenet_sendrecv_postgresql_client_packets(syslogd_t)
-corenet_sendrecv_mysqld_client_packets(syslogd_t)
 
 dev_filetrans(syslogd_t, devlog_t, sock_file)
 dev_read_sysfs(syslogd_t)
@@ -595,6 +579,33 @@ ifdef(`distro_ubuntu',`
 	optional_policy(`
 		unconfined_domain(syslogd_t)
 	')
+')
+
+tunable_policy(`logging_syslog_can_network',`
+	allow syslogd_t self:capability { net_admin };
+
+	corenet_all_recvfrom_netlabel(syslogd_t)
+	corenet_udp_sendrecv_generic_if(syslogd_t)
+	corenet_udp_sendrecv_generic_node(syslogd_t)
+	corenet_udp_bind_generic_node(syslogd_t)
+	corenet_udp_bind_syslogd_port(syslogd_t)
+	# syslog-ng can listen and connect on tcp port 514 (rsh)
+	corenet_tcp_sendrecv_generic_if(syslogd_t)
+	corenet_tcp_sendrecv_generic_node(syslogd_t)
+	corenet_tcp_bind_generic_node(syslogd_t)
+	corenet_tcp_bind_rsh_port(syslogd_t)
+	corenet_tcp_connect_rsh_port(syslogd_t)
+	# Allow users to define additional syslog ports to connect to
+	corenet_tcp_bind_syslogd_port(syslogd_t)
+	corenet_tcp_connect_syslogd_port(syslogd_t)
+	corenet_tcp_connect_postgresql_port(syslogd_t)
+	corenet_tcp_connect_mysqld_port(syslogd_t)
+
+	# syslog-ng can send or receive logs
+	corenet_sendrecv_syslogd_client_packets(syslogd_t)
+	corenet_sendrecv_syslogd_server_packets(syslogd_t)
+	corenet_sendrecv_postgresql_client_packets(syslogd_t)
+	corenet_sendrecv_mysqld_client_packets(syslogd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
This patchset introduces a new "logging_syslog_can_network" boolean and corresponding tunable policy to isolate the syslog daemon from the network for increased security in most of its use cases.

See also: https://github.com/SELinuxProject/refpolicy/pull/644#issuecomment-1707302056