### PR TITLE
Add iio-sensor-proxy.

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -166,6 +166,7 @@ ifdef(`distro_suse', `
 
 /dev/dvb/.*		-c	gen_context(system_u:object_r:v4l_device_t,s0)
 
+/dev/iio:device[0-9]	-c	gen_context(system_u:object_r:iio_device_t,s0)
 /dev/infiniband/.*      -c      gen_context(system_u:object_r:infiniband_device_t,s0)
 
 /dev/input/.*		-c	gen_context(system_u:object_r:event_device_t,s0)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -2414,6 +2414,24 @@ interface(`dev_rw_hyperv_vss',`
 ##	</summary>
 ## </param>
 #
+interface(`dev_read_iio',`
+	gen_require(`
+		type device_t, iio_device_t;
+	')
+
+	read_chr_files_pattern($1, device_t, iio_device_t)
+')
+
+########################################
+## <summary>
+##	Allow read/write access to InfiniBand devices.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
 interface(`dev_rw_infiniband',`
 	gen_require(`
 		type device_t, infiniband_device_t;

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -136,6 +136,12 @@ type hyperv_vss_device_t;
 dev_node(hyperv_vss_device_t)
 
 #
+# Type for /dev/iio:device* (Industrial IO)
+#
+type iio_device_t;
+dev_node(iio_device_t)
+
+#
 # Type for /dev/infiniband/*
 #
 type infiniband_device_t;

--- a/policy/modules/services/iiosensorproxy.fc
+++ b/policy/modules/services/iiosensorproxy.fc
@@ -1,0 +1,1 @@
+/usr/libexec/iio-sensor-proxy	--	gen_context(system_u:object_r:iiosensorproxy_exec_t,s0)

--- a/policy/modules/services/iiosensorproxy.if
+++ b/policy/modules/services/iiosensorproxy.if
@@ -1,0 +1,21 @@
+## <summary>IIO sensors to D-Bus proxy</summary>
+##
+## <desc>
+## Industrial I/O subsystem is intended to provide support for devices
+## that in some sense are analog to digital or digital to analog convertors
+## .
+## Devices that fall into this category are:
+##  * ADCs
+##  * Accelerometers
+##  * Gyros
+##  * IMUs
+##  * Capacitance to Digital Converters (CDCs)
+##  * Pressure Sensors
+##  * Color, Light and Proximity Sensors
+##  * Temperature Sensors
+##  * Magnetometers
+##  * DACs
+##  * DDS (Direct Digital Synthesis)
+##  * PLLs (Phase Locked Loops)
+##  * Variable/Programmable Gain Amplifiers (VGA, PGA)
+## </desc>

--- a/policy/modules/services/iiosensorproxy.te
+++ b/policy/modules/services/iiosensorproxy.te
@@ -1,0 +1,70 @@
+policy_module(iiosensorproxy)
+
+########################################
+#
+# iio-sensor-proxy (Debian package iio-sensor-proxy)
+# IIO sensors to D-Bus proxy
+# Industrial I/O subsystem is intended to provide support for devices
+# that in some sense are analog to digital or digital to analog convertors
+# .
+# Devices that fall into this category are:
+#  * ADCs
+#  * Accelerometers
+#  * Gyros
+#  * IMUs
+#  * Capacitance to Digital Converters (CDCs)
+#  * Pressure Sensors
+#  * Color, Light and Proximity Sensors
+#  * Temperature Sensors
+#  * Magnetometers
+#  * DACs
+#  * DDS (Direct Digital Synthesis)
+#  * PLLs (Phase Locked Loops)
+#  * Variable/Programmable Gain Amplifiers (VGA, PGA)
+
+########################################
+#
+# Declarations
+#
+
+type iiosensorproxy_t;
+type iiosensorproxy_exec_t;
+init_daemon_domain(iiosensorproxy_t, iiosensorproxy_exec_t)
+
+
+########################################
+#
+# Local policy
+#
+
+allow iiosensorproxy_t self:netlink_kobject_uevent_socket { bind create getattr setopt read };
+allow iiosensorproxy_t self:process { getsched setsched };
+allow iiosensorproxy_t self:unix_dgram_socket { create write };
+
+kernel_read_system_state(iiosensorproxy_t)
+
+dev_read_iio(iiosensorproxy_t)
+
+# for /sys/bus/iio/devices
+dev_read_sysfs(iiosensorproxy_t)
+
+# for writing to current_trigger
+dev_write_sysfs(iiosensorproxy_t)
+
+dbus_system_bus_client(iiosensorproxy_t)
+dbus_connect_system_bus(iiosensorproxy_t)
+
+logging_send_syslog_msg(iiosensorproxy_t)
+
+miscfiles_read_localization(iiosensorproxy_t)
+
+udev_read_runtime_files(iiosensorproxy_t)
+unconfined_dbus_send(iiosensorproxy_t)
+
+optional_policy(`
+	policykit_dbus_chat(iiosensorproxy_t)
+')
+
+optional_policy(`
+	xserver_dbus_chat_xdm(iiosensorproxy_t)
+')

--- a/policy/modules/services/iiosensorproxy.te
+++ b/policy/modules/services/iiosensorproxy.te
@@ -45,10 +45,11 @@ kernel_read_system_state(iiosensorproxy_t)
 
 dev_read_iio(iiosensorproxy_t)
 
-# for /sys/bus/iio/devices
+# for /sys/bus/iio/devices/* (which links to /sys/devices/pci*)
 dev_read_sysfs(iiosensorproxy_t)
 
-# for writing to current_trigger
+# for writing to current_trigger and to enable devices
+# /sys/devices/pci0000:00/0000:00:13.0/{33AECD58-B679-4E54-9BD9-A04D34F0C226}/001F:8087:0AC2.0005/HID-SENSOR-200083.21.auto/iio:device8/buffer/enable
 dev_write_sysfs(iiosensorproxy_t)
 
 dbus_system_bus_client(iiosensorproxy_t)

--- a/policy/modules/services/iiosensorproxy.te
+++ b/policy/modules/services/iiosensorproxy.te
@@ -59,10 +59,13 @@ logging_send_syslog_msg(iiosensorproxy_t)
 miscfiles_read_localization(iiosensorproxy_t)
 
 udev_read_runtime_files(iiosensorproxy_t)
-unconfined_dbus_send(iiosensorproxy_t)
 
 optional_policy(`
 	policykit_dbus_chat(iiosensorproxy_t)
+')
+
+optional_policy(`
+	unconfined_dbus_send(iiosensorproxy_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
 iio-sensor-proxy (Debian package iio-sensor-proxy)
 IIO sensors to D-Bus proxy
 Industrial I/O subsystem is intended to provide support for devices
 that in some sense are analog to digital or digital to analog convertors
 .
 Devices that fall into this category are:
  * ADCs
  * Accelerometers
  * Gyros
  * IMUs
  * Capacitance to Digital Converters (CDCs)
  * Pressure Sensors
  * Color, Light and Proximity Sensors
  * Temperature Sensors
  * Magnetometers
  * DACs
  * DDS (Direct Digital Synthesis)
  * PLLs (Phase Locked Loops)
  * Variable/Programmable Gain Amplifiers (VGA, PGA)
  
  Signed-off-by: Russell Coker <russell@coker.com.au>
