### PR TITLE
Smartmon policy update

### DIFF
--- a/policy/modules/services/smartmon.te
+++ b/policy/modules/services/smartmon.te
@@ -72,7 +72,6 @@ domain_use_interactive_fds(fsdaemon_t)
 files_exec_etc_files(fsdaemon_t)
 files_read_etc_files(fsdaemon_t)
 files_read_etc_runtime_files(fsdaemon_t)
-files_read_usr_files(fsdaemon_t)
 files_search_var_lib(fsdaemon_t)
 
 fs_getattr_all_fs(fsdaemon_t)


### PR DESCRIPTION
Revert obsolete permissions that are no longer needed, after the database file got its own label:

 Date:   Wed Feb 16 07:24:34 2011 +0100
 patch to allow smartmon to read usr files
 37ba0d04377033e44d3808d6c795c18edba191bb

 policy/modules/services/smartmon.te |    1 -
 1 file changed, 1 deletion(-)