### PR TITLE
Allow system_dbusd_t to start/stop all units

### DIFF
--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -164,7 +164,6 @@ auth_read_pam_console_data(system_dbusd_t)
 init_use_fds(system_dbusd_t)
 init_use_script_ptys(system_dbusd_t)
 init_all_labeled_script_domtrans(system_dbusd_t)
-init_start_system(system_dbusd_t) # needed by dbus-broker
 
 # for powerdevil /usr/lib/x86_64-linux-gnu/libexec/kauth/*
 libs_exec_lib_files(system_dbusd_t)
@@ -196,6 +195,12 @@ ifdef(`init_systemd', `
 	# for /run/systemd/dynamic-uid/
 	init_list_runtime(system_dbusd_t)
 	init_read_runtime_symlinks(system_dbusd_t)
+
+	init_start_system(system_dbusd_t) # needed by dbus-broker
+
+	# for system dbus daemon to start/stop units
+	init_start_all_units(system_dbusd_t)
+	init_stop_all_units(system_dbusd_t)
 
 	# Recent versions of dbus are started as Type=notify
 	init_write_runtime_socket(system_dbusd_t)


### PR DESCRIPTION
Examples of denials I'm seeing requiring this type of access: 

node=localhost type=USER_AVC msg=audit(1689811749.504:399): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { start } for auid=n/a uid=0 gid=81 path="/usr/lib/systemd/system/systemd-hostnamed.service" cmdline="/usr/bin/dbus-broker-launch --scope system --audit" function="bus_unit_method_start_generic" scontext=system_u:system_r:system_dbusd_t:s0 tcontext=system_u:object_r:systemd_unit_t:s0 tclass=service permissive=0 exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=?  terminal=?'␝UID="root" AUID="unset" AUID="root" UID="root" GID="dbus" SAUID="root" 
node=localhost type=USER_AVC msg=audit(1692287535.229:262): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { start } for auid=n/a uid=0 gid=81 path="/usr/lib/systemd/system/systemd-logind.service" cmdline="/usr/bin/dbus-broker-launch --scope system --audit" function="bus_unit_method_start_generic" scontext=system_u:system_r:system_dbusd_t:s0 tcontext=system_u:object_r:systemd_unit_t:s0 tclass=service permissive=1 exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'␝UID="root" AUID="unset" AUID="root" UID="root" GID="dbus" SAUID="root" 
node=localhost type=USER_AVC msg=audit(1692305808.055:375): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { start } for auid=n/a uid=0 gid=81 path="/usr/lib/systemd/system/accounts-daemon.service" cmdline="/usr/bin/dbus-broker-launch --scope system --audit" function="bus_unit_method_start_generic" scontext=system_u:system_r:system_dbusd_t:s0 tcontext=system_u:object_r:systemd_unit_t:s0 tclass=service permissive=0 exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=?  terminal=?' UID="root" AUID="unset" AUID="root" UID="root" GID="dbus" SAUID="root"