### PR TITLE
Update the kernel module to remove misplaced or obsolete permissions

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -539,12 +539,6 @@ if(secure_mode_insmod) {
 
 	files_dontaudit_load_kernel_modules(can_load_kernmodule)
 
-	# load_module() calls stop_machine() which
-	# calls sched_setscheduler()
-	# gt: there seems to be no trace of the above, at
-	# least in kernel versions greater than 2.6.37...
-	dontaudit can_load_kernmodule self:capability sys_nice;
-	dontaudit can_load_kernmodule kernel_t:process setsched;
 	dontaudit can_load_kernmodule kernel_t:key search;
 } else {
 	allow can_load_kernmodule self:capability sys_module;
@@ -552,13 +546,7 @@ if(secure_mode_insmod) {
 
 	files_load_kernel_modules(can_load_kernmodule)
 
-	# load_module() calls stop_machine() which
-	# calls sched_setscheduler()
-	# gt: there seems to be no trace of the above, at
-	# least in kernel versions greater than 2.6.37...
-	allow can_load_kernmodule self:capability sys_nice;
 	kernel_search_key(can_load_kernmodule)
-	kernel_setsched(can_load_kernmodule)
 }
 
 ########################################


### PR DESCRIPTION
Remove misplaced or really obsolete permissions during kernel module loading.

 policy/modules/kernel/kernel.te |   12 ------------
 1 file changed, 12 deletions(-)