### PR TITLE
Updates for utempter

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -22,6 +22,9 @@
 
 /usr/lib/([^/]+/)?utempter/utempter --	gen_context(system_u:object_r:utempter_exec_t,s0)
 
+ifdef(`distro_redhat', `
+/usr/libexec/utempter/utempter	--	gen_context(system_u:object_r:utempter_exec_t,s0)
+')
 /usr/libexec/chkpwd/tcb_chkpwd	--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
 
 /usr/sbin/pam_console_apply	--	gen_context(system_u:object_r:pam_console_exec_t,s0)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -450,6 +450,7 @@ optional_policy(`
 optional_policy(`
 	xserver_use_xdm_fds(utempter_t)
 	xserver_rw_xdm_pipes(utempter_t)
+	xserver_write_inherited_xsession_log(utempter_t)
 ')
 
 #######################################


### PR DESCRIPTION
Fix label (for RedHat) which places utempter in /usr/libexec/utempter/utempter
Allow utempter to write to xsession log

Sep 07 01:30:50 localhost.localdomain audisp-syslog[1649]: node=localhost type=AVC msg=audit(1694050250.483:3994): avc:  denied  { write } for  pid=1927 comm="utempter" path="/home/toor/.xsession-errors" dev="dm-9" ino=129543 scontext=toor_u:staff_r:utempter_t:s0 tcontext=toor_u:object_r:xsession_log_t:s0 tclass=file permissive=1
Sep 07 01:30:50 localhost.localdomain audisp-syslog[1649]: node=localhost type=AVC msg=audit(1694050250.485:3997): avc:  denied  { getattr } for  pid=1927 comm="utempter" path="/home/toor/.xsession-errors" dev="dm-9" ino=129543 scontext=toor_u:staff_r:utempter_t:s0 tcontext=toor_u:object_r:xsession_log_t:s0 tclass=file permissive=1