### PR TITLE
resolve lvm_t issues at shutdown with LUKS encrypted devices

### DIFF
--- a/policy/modules/system/lvm.te
+++ b/policy/modules/system/lvm.te
@@ -219,9 +219,14 @@ sysnet_write_config(lvm_t)
 userdom_use_inherited_user_terminals(lvm_t)
 
 ifdef(`init_systemd',`
+	fs_getattr_cgroup(lvm_t)
+	fs_list_pstore_dirs(lvm_t)
+	fs_manage_hugetlbfs_dirs(lvm_t)
+	fs_search_cgroup_dirs(lvm_t)
+
 	init_rw_stream_sockets(lvm_t)
 
-	fs_manage_hugetlbfs_dirs(lvm_t)
+	miscfiles_read_generic_certs(lvm_t)
 ')
 
 ifdef(`distro_redhat',`


### PR DESCRIPTION
Errors:
Sep 06 15:27:15 localhost systemd-cryptsetup[1611]: Device luks-7e802906-791a-432d-8069-dd290fba6dcf is still in use. Sep 06 15:27:15 localhost systemd-cryptsetup[1611]: Failed to deactivate: Device or resource busy
Sep 06 15:27:15 localhost systemd[1]: systemd-cryptsetup@luks\x2d7e802906\x2d791a\x2d432d\x2d8069\x2ddd290fba6dcf.service: Control process exited, code=exited, status=1/FAILURE
Sep 06 15:27:15 localhost systemd[1]: systemd-cryptsetup@luks\x2d7e802906\x2d791a\x2d432d\x2d8069\x2ddd290fba6dcf.service: Failed with result 'exit-code'.

Denials:
Sep 06 15:25:19 localhost.localdomain audisp-syslog[1522]: node=localhost type=AVC msg=audit(1694013919.081:10597): avc:  denied  { getattr } for  pid=1996 comm="systemd-cryptse" name="/" dev="cgroup2" ino=1 scontext=system_u:system_r:lvm_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=filesystem permissive=1
Sep 06 15:25:19 localhost.localdomain audisp-syslog[1522]: node=localhost type=SYSCALL msg=audit(1694013919.081:10597): arch=c000003e syscall=137 success=yes exit=0 a0=7efdc7a96e0e a1=7ffdbbacde50 a2=7efdc69b75e0 a3=1000 items=1 ppid=1 pid=1996 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="systemd-cryptse" exe="/usr/lib/systemd/systemd-cryptsetup" subj=system_u:system_r:lvm_t:s0 key=(null) ARCH=x86_64 SYSCALL=statfs AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"
Sep 06 15:25:19 localhost.localdomain audisp-syslog[1522]: node=localhost type=AVC msg=audit(1694013919.082:10598): avc:  denied  { search } for  pid=1996 comm="systemd-cryptse" name="/" dev="cgroup2" ino=1 scontext=system_u:system_r:lvm_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=dir permissive=1

Sep 06 15:25:19 localhost.localdomain audisp-syslog[1522]: node=localhost type=AVC msg=audit(1694013919.085:10599): avc:  denied  { search } for  pid=1996 comm="systemd-cryptse" name="pki" dev="dm-1" ino=393276 scontext=system_u:system_r:lvm_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=dir permissive=1
Sep 06 15:25:19 localhost.localdomain audisp-syslog[1522]: node=localhost type=AVC msg=audit(1694013919.085:10599): avc:  denied  { read } for  pid=1996 comm="systemd-cryptse" name="openssl.cnf" dev="dm-1" ino=393383 scontext=system_u:system_r:lvm_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=file permissive=1
Sep 06 15:25:19 localhost.localdomain audisp-syslog[1522]: node=localhost type=AVC msg=audit(1694013919.085:10599): avc:  denied  { open } for  pid=1996 comm="systemd-cryptse" path="/etc/pki/tls/openssl.cnf" dev="dm-1" ino=393383 scontext=system_u:system_r:lvm_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=file permissive=1
Sep 06 15:25:19 localhost.localdomain audisp-syslog[1522]: node=localhost type=SYSCALL msg=audit(1694013919.085:10599): arch=c000003e syscall=257 success=yes exit=7 a0=ffffff9c a1=55943c6cdb90 a2=0 a3=0 items=1 ppid=1 pid=1996 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="systemd-cryptse" exe="/usr/lib/systemd/systemd-cryptsetup" subj=system_u:system_r:lvm_t:s0 key=(null) ARCH=x86_64 SYSCALL=openat AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"
Sep 06 15:25:19 localhost.localdomain audisp-syslog[1522]: node=localhost type=AVC msg=audit(1694013919.086:10600): avc:  denied  { getattr } for  pid=1996 comm="systemd-cryptse" path="/etc/pki/tls/openssl.cnf" dev="dm-1" ino=393383 scontext=system_u:system_r:lvm_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=file permissive=1
Sep 06 15:25:19 localhost.localdomain audisp-syslog[1522]: node=localhost type=AVC msg=audit(1694013919.087:10601): avc:  denied  { read } for  pid=1996 comm="systemd-cryptse" name="fips_local.cnf" dev="dm-1" ino=393381 scontext=system_u:system_r:lvm_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=lnk_file permissive=1

Sep 06 15:27:15 localhost audisp-syslog[1497]: node=localhost type=AVC msg=audit(1694014035.204:367): avc:  denied  { search } for  pid=1611 comm="systemd-cryptse" name="/" dev="pstore" ino=2357 scontext=system_u:system_r:lvm_t:s0 tcontext=system_u:object_r:pstore_t:s0 tclass=dir permissive=0