### PR TITLE
Allow display manager to read hwdata

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -467,6 +467,7 @@ libs_exec_lib_files(xdm_t)
 
 logging_read_generic_logs(xdm_t)
 
+miscfiles_read_hwdata(xdm_t)
 miscfiles_read_localization(xdm_t)
 miscfiles_read_fonts(xdm_t)
 


### PR DESCRIPTION
Sep 01 01:53:02 localhost.localdomain audisp-syslog[1524]: node=localhost type=AVC msg=audit(1693533182.968:431): avc:  denied  { search } for  pid=1744 comm="sddm-greeter" name="hwdata" dev="dm-1" ino=1726 scontext=system_u:system_r:xdm_t:s0 tcontext=system_u:object_r:hwdata_t:s0 tclass=dir permissive=1
Sep 01 01:53:02 localhost.localdomain audisp-syslog[1524]: node=localhost type=AVC msg=audit(1693533182.968:432): avc:  denied  { read } for  pid=1744 comm="sddm-greeter" name="pnp.ids" dev="dm-1" ino=1730 scontext=system_u:system_r:xdm_t:s0 tcontext=system_u:object_r:hwdata_t:s0 tclass=file permissive=1
Sep 01 01:53:02 localhost.localdomain audisp-syslog[1524]: node=localhost type=AVC msg=audit(1693533182.968:432): avc:  denied  { open } for  pid=1744 comm="sddm-greeter" path="/usr/share/hwdata/pnp.ids" dev="dm-1" ino=1730 scontext=system_u:system_r:xdm_t:s0 tcontext=system_u:object_r:hwdata_t:s0 tclass=file permissive=1
Sep 01 01:53:02 localhost.localdomain audisp-syslog[1524]: node=localhost type=AVC msg=audit(1693533182.974:433): avc:  denied  { getattr } for  pid=1744 comm="sddm-greeter" path="/usr/share/hwdata/pnp.ids" dev="dm-1" ino=1730 scontext=system_u:system_r:xdm_t:s0 tcontext=system_u:object_r:hwdata_t:s0 tclass=file permissive=1