### PR TITLE
mplayer module fixes for vlc

### DIFF
--- a/policy/modules/apps/mplayer.te
+++ b/policy/modules/apps/mplayer.te
@@ -174,6 +174,7 @@ kernel_dontaudit_getattr_unlabeled_files(mplayer_t)
 kernel_dontaudit_read_unlabeled_files(mplayer_t)
 kernel_read_system_state(mplayer_t)
 kernel_read_kernel_sysctls(mplayer_t)
+kernel_read_device_sysctls(mplayer_t)
 
 corecmd_exec_bin(mplayer_t)
 corecmd_exec_shell(mplayer_t)

--- a/policy/modules/apps/mplayer.te
+++ b/policy/modules/apps/mplayer.te
@@ -277,6 +277,11 @@ optional_policy(`
 	alsa_read_config(mplayer_t)
 ')
 
+# needed by vlc
+optional_policy(`
+	dbus_all_session_bus_client(mplayer_t)
+')
+
 optional_policy(`
 	pulseaudio_run(mplayer_t, mplayer_roles)
 ')


### PR DESCRIPTION
Let vlc (mplayer) act as a dbus session client and read device sysctls.