### PR TITLE
Allow search xdm_var_run_t directories along with reading files.

### DIFF
--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -1010,7 +1010,7 @@ interface(`xserver_read_xdm_runtime_files',`
 	')
 
 	files_search_runtime($1)
-	allow $1 xdm_var_run_t:file read_file_perms;
+	read_files_pattern($1, xdm_var_run_t, xdm_var_run_t)
 ')
 
 ########################################


### PR DESCRIPTION
Sep 07 23:30:46 localhost audisp-syslog[1669]: node=localhost type=AVC msg=audit(1694129445.663:3622): avc:  denied  { search } for pid=1844 comm="xhost" name="lightdm" dev="tmpfs" ino=1504 scontext=toor_u:staff_r:staff_t:s0 tcontext=system_u:object_r:xdm_var_run_t:s0 tclass=dir permissive=0