### PR TITLE
init and shutdown fixes

### DIFF
--- a/policy/modules/admin/shutdown.fc
+++ b/policy/modules/admin/shutdown.fc
@@ -1,9 +1,11 @@
 /etc/nologin	--	gen_context(system_u:object_r:shutdown_etc_t,s0)
 
-/usr/bin/shutdown	--	gen_context(system_u:object_r:shutdown_exec_t,s0)
+/sbin/halt	--	gen_context(system_u:object_r:shutdown_exec_t,s0)
+/sbin/shutdown	--	gen_context(system_u:object_r:shutdown_exec_t,s0)
 
 /usr/lib/upstart/shutdown	--	gen_context(system_u:object_r:shutdown_exec_t,s0)
 
+/usr/sbin/halt		--	gen_context(system_u:object_r:shutdown_exec_t,s0)
 /usr/sbin/shutdown	--	gen_context(system_u:object_r:shutdown_exec_t,s0)
 
 /run/shutdown\.pid	--	gen_context(system_u:object_r:shutdown_runtime_t,s0)

--- a/policy/modules/admin/shutdown.te
+++ b/policy/modules/admin/shutdown.te
@@ -34,7 +34,7 @@ files_runtime_file(shutdown_runtime_t)
 # Local policy
 #
 
-allow shutdown_t self:capability { dac_override kill setuid sys_nice sys_tty_config };
+allow shutdown_t self:capability { dac_override kill setuid sys_boot sys_nice sys_tty_config };
 allow shutdown_t self:process { setsched signal signull };
 allow shutdown_t self:fifo_file manage_fifo_file_perms;
 allow shutdown_t self:unix_stream_socket create_stream_socket_perms;
@@ -47,6 +47,7 @@ files_runtime_filetrans(shutdown_t, shutdown_runtime_t, file)
 
 kernel_read_system_state(shutdown_t)
 
+domain_signal_all_domains(shutdown_t)
 domain_use_interactive_fds(shutdown_t)
 
 files_delete_boot_flag(shutdown_t)
@@ -61,6 +62,7 @@ term_use_all_terms(shutdown_t)
 auth_use_nsswitch(shutdown_t)
 auth_write_login_records(shutdown_t)
 
+init_manage_random_seed(shutdown_t)
 init_rw_utmp(shutdown_t)
 init_stream_connect(shutdown_t)
 init_telinit(shutdown_t)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -6249,13 +6249,12 @@ interface(`files_read_var_lib_symlinks',`
 ## </param>
 #
 interface(`files_manage_urandom_seed',`
-	gen_require(`
-		type var_t, var_lib_t;
-	')
-
-	allow $1 var_t:dir search_dir_perms;
-	manage_files_pattern($1, var_lib_t, var_lib_t)
+	refpolicywarn(`$0($*) has been deprecated, please use init_manage_random_seed() instead.')
+	init_manage_random_seed($1)
 ')
+
+# cjp: the next interface really needs to be fixed
+# in some way.  It really needs its own type.
 
 ########################################
 ## <summary>
@@ -6794,6 +6793,24 @@ interface(`files_create_runtime_dirs',`
 	')
 
 	allow $1 var_run_t:dir create_dir_perms;
+')
+
+########################################
+## <summary>
+##	Read and write a /var/run directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_rw_runtime_dirs',`
+	gen_require(`
+		type var_run_t;
+	')
+
+	rw_dirs_pattern($1, var_run_t, var_run_t)
 ')
 
 ########################################

--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -68,13 +68,14 @@ ifdef(`distro_redhat',`
 #
 # /var
 #
+/var/lib/random-seed	--	gen_context(system_u:object_r:init_random_seed_t,s0)
 /var/lib/systemd(/.*)?		gen_context(system_u:object_r:init_var_lib_t,s0)
 
 /run/initctl	-p	gen_context(system_u:object_r:initctl_t,s0)
 /run/kerneloops\.pid	--	gen_context(system_u:object_r:initrc_runtime_t,s0)
 /run/utmp		--	gen_context(system_u:object_r:initrc_runtime_t,s0)
 /run/runlevel\.dir		gen_context(system_u:object_r:initrc_runtime_t,s0)
-/run/random-seed	--	gen_context(system_u:object_r:initrc_runtime_t,s0)
+/run/random-seed	--	gen_context(system_u:object_r:init_random_seed_t,s0)
 /run/setmixer_flag	--	gen_context(system_u:object_r:initrc_runtime_t,s0)
 /run/systemd(/.*)?		gen_context(system_u:object_r:init_runtime_t,s0)
 /run/wd_keepalive\.pid	--	gen_context(system_u:object_r:initrc_runtime_t,s0)

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1453,6 +1453,30 @@ interface(`init_relabel_var_lib_dirs',`
 
 ########################################
 ## <summary>
+##	Create, read, write, and delete the
+##	pseudorandom number generator seed
+##	file in /var/lib or /var/run
+##	directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_manage_random_seed',`
+	gen_require(`
+		type init_random_seed_t;
+	')
+
+	files_rw_var_lib_dirs($1)
+	files_rw_runtime_dirs($1)
+
+	allow $1 init_random_seed_t:file manage_file_perms;
+')
+
+########################################
+## <summary>
 ##	Manage files in /var/lib/systemd/.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -53,6 +53,9 @@ attribute systemprocess;
 # Mark file type as a daemon pid file
 attribute daemonpidfile;
 
+type init_random_seed_t;
+files_type(init_random_seed_t)
+
 #
 # init_t is the domain of the init process.
 #
@@ -429,7 +432,6 @@ ifdef(`init_systemd',`
 	files_manage_generic_tmp_dirs(init_t)
 	files_relabel_generic_tmp_dirs(init_t)
 	files_mounton_tmp(init_t)
-	files_manage_urandom_seed(init_t)
 	files_read_boot_files(init_t)
 	files_remount_boot(init_t)
 	files_remount_etc(init_t)
@@ -479,6 +481,7 @@ ifdef(`init_systemd',`
 	# needed by systemd-creds
 	fs_setattr_ramfs_dirs(init_t)
 
+	init_manage_random_seed(init_t)
 	init_manage_all_unit_files(init_t)
 	init_read_script_state(init_t)
 
@@ -754,6 +757,7 @@ manage_files_pattern(initrc_t, initrc_var_log_t, initrc_var_log_t)
 logging_log_filetrans(initrc_t, initrc_var_log_t, dir)
 
 init_write_initctl(initrc_t)
+init_manage_random_seed(initrc_t)
 
 kernel_read_system_state(initrc_t)
 kernel_read_software_raid_state(initrc_t)
@@ -848,7 +852,6 @@ files_manage_etc_runtime_files(initrc_t)
 files_etc_filetrans_etc_runtime(initrc_t, file)
 files_exec_etc_files(initrc_t)
 files_read_usr_files(initrc_t)
-files_manage_urandom_seed(initrc_t)
 files_manage_generic_spool(initrc_t)
 # Mount and unmount file systems.
 # cjp: not sure why these are here; should use mount policy


### PR DESCRIPTION
Fix the label and interface needed to manage the random seed file (additional entropy source) used during system boot/reboot.

Modify the init and shutdown policy accordingly and also fix some bugs in the latter module.