### PR TITLE
Remove an unneeded logging interface from the userdomain module

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1127,8 +1127,6 @@ template(`userdom_restricted_xwindows_user_template',`
 	logging_send_syslog_msg($1_t)
 	logging_dontaudit_send_audit_msgs($1_t)
 
-	# Need to to this just so screensaver will work. Should be moved to screensaver domain
-	logging_send_audit_msgs($1_t)
 	selinux_get_enforce_mode($1_t)
 
 	xserver_restricted_role($1, $1_t, $1_application_exec_domain, $1_r)


### PR DESCRIPTION
According to comments the interface has been moved to the xscreensaver module, but never removed from the userdomain module.
