### PR TITLE
Remote X11 TCP/IP functionality is generally insecure: switch it off by default. Strengthen XDM authentication file access.

### DIFF
--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -123,6 +123,7 @@ ifndef(`distro_debian',`
 /var/lib/lightdm-data(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
 /var/lib/lxdm(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
 /var/lib/[xkw]dm(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
+/var/lib/xdm/authdir(/.*)?	gen_context(system_u:object_r:xdm_auth_t,s0)
 /var/lib/xkb(/.*)?		gen_context(system_u:object_r:xkb_var_lib_t,s0)
 /var/lib/sddm(/.*)?		gen_context(system_u:object_r:xkb_var_lib_t,s0)
 

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -744,6 +744,39 @@ interface(`xserver_relabel_console_pipes',`
 
 ########################################
 ## <summary>
+##	Create xdm authorization files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="file_type">
+##	<summary>
+##	The type of the object to be created
+##	</summary>
+## </param>
+## <param name="object_class">
+##	<summary>
+##	The object class.
+##	</summary>
+## </param>
+## <param name="name" optional="true">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
+#
+interface(`xserver_xdm_auth_filetrans',`
+	gen_require(`
+		type xdm_auth_t;
+	')
+
+	filetrans_pattern($1, xdm_auth_t, $2, $3, $4)
+')
+
+########################################
+## <summary>
 ##	Use file descriptors for xdm.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -179,6 +179,9 @@ files_lock_file(xdm_lock_t)
 type xdm_rw_etc_t;
 files_type(xdm_rw_etc_t)
 
+type xdm_auth_t;
+files_type(xdm_auth_t)
+
 type xdm_var_lib_t;
 files_type(xdm_var_lib_t)
 
@@ -356,6 +359,11 @@ manage_lnk_files_pattern(xdm_t, xdm_tmpfs_t, xdm_tmpfs_t)
 manage_fifo_files_pattern(xdm_t, xdm_tmpfs_t, xdm_tmpfs_t)
 manage_sock_files_pattern(xdm_t, xdm_tmpfs_t, xdm_tmpfs_t)
 fs_tmpfs_filetrans(xdm_t, xdm_tmpfs_t, { dir file lnk_file sock_file fifo_file })
+
+# this file should be accessed only by xdm_t (rw) and xserver_t (ro)
+manage_dirs_pattern(xdm_t, xdm_auth_t, xdm_auth_t)
+manage_files_pattern(xdm_t, xdm_auth_t, xdm_auth_t)
+xserver_xdm_auth_filetrans(xdm_t, xdm_auth_t, file)
 
 manage_dirs_pattern(xdm_t, xdm_var_lib_t, xdm_var_lib_t)
 manage_files_pattern(xdm_t, xdm_var_lib_t, xdm_var_lib_t)
@@ -663,6 +671,9 @@ allow xserver_t self:msg { send receive };
 allow xserver_t self:unix_dgram_socket { create_socket_perms sendto };
 allow xserver_t self:unix_stream_socket { create_stream_socket_perms connectto };
 allow xserver_t self:netlink_kobject_uevent_socket create_socket_perms;
+
+# this file should be accessed only by xserver_t (ro) and xdm_t (rw)
+allow xserver_t xdm_auth_t:file read_file_perms;
 
 manage_dirs_pattern(xserver_t, xserver_tmp_t, xserver_tmp_t)
 manage_files_pattern(xserver_t, xserver_tmp_t, xserver_tmp_t)

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -27,6 +27,22 @@ gen_require(`
 
 ## <desc>
 ## <p>
+## Allows the X server to use TCP/IP
+## networking functionality (insecure).
+## </p>
+## </desc>
+gen_tunable(xserver_can_network, false)
+
+## <desc>
+## <p>
+## Allows the X display manager to use
+## TCP/IP networking functionality (insecure).
+## </p>
+## </desc>
+gen_tunable(xserver_xdm_can_network, false)
+
+## <desc>
+## <p>
 ## Allows clients to write to the X server shared
 ## memory segments.
 ## </p>
@@ -309,8 +325,6 @@ allow xdm_t self:shm create_shm_perms;
 allow xdm_t self:sem create_sem_perms;
 allow xdm_t self:unix_stream_socket { connectto create_stream_socket_perms };
 allow xdm_t self:unix_dgram_socket create_socket_perms;
-allow xdm_t self:tcp_socket create_stream_socket_perms;
-allow xdm_t self:udp_socket create_socket_perms;
 allow xdm_t self:socket create_socket_perms;
 allow xdm_t self:appletalk_socket create_socket_perms;
 allow xdm_t self:key { search link write };
@@ -385,18 +399,6 @@ kernel_view_key(xdm_t)
 
 corecmd_exec_shell(xdm_t)
 corecmd_exec_bin(xdm_t)
-
-corenet_all_recvfrom_netlabel(xdm_t)
-corenet_tcp_sendrecv_generic_if(xdm_t)
-corenet_udp_sendrecv_generic_if(xdm_t)
-corenet_tcp_sendrecv_generic_node(xdm_t)
-corenet_udp_sendrecv_generic_node(xdm_t)
-corenet_tcp_bind_generic_node(xdm_t)
-corenet_udp_bind_generic_node(xdm_t)
-corenet_tcp_connect_all_ports(xdm_t)
-corenet_sendrecv_all_client_packets(xdm_t)
-# xdm tries to bind to biff_port_t
-corenet_dontaudit_tcp_bind_all_ports(xdm_t)
 
 dev_read_rand(xdm_t)
 dev_read_sysfs(xdm_t)
@@ -514,6 +516,23 @@ tunable_policy(`xdm_sysadm_login',`
 
 tunable_policy(`xserver_gnome_xdm',`
 	allow xdm_t self:process execmem;
+')
+
+tunable_policy(`xserver_xdm_can_network',`
+	allow xdm_t self:tcp_socket create_stream_socket_perms;
+	allow xdm_t self:udp_socket create_socket_perms;
+
+	corenet_all_recvfrom_netlabel(xdm_t)
+	corenet_tcp_sendrecv_generic_if(xdm_t)
+	corenet_udp_sendrecv_generic_if(xdm_t)
+	corenet_tcp_sendrecv_generic_node(xdm_t)
+	corenet_udp_sendrecv_generic_node(xdm_t)
+	corenet_tcp_bind_generic_node(xdm_t)
+	corenet_udp_bind_generic_node(xdm_t)
+	corenet_tcp_connect_all_ports(xdm_t)
+	corenet_sendrecv_all_client_packets(xdm_t)
+	# xdm tries to bind to biff_port_t
+	corenet_dontaudit_tcp_bind_all_ports(xdm_t)
 ')
 
 optional_policy(`
@@ -643,8 +662,6 @@ allow xserver_t self:msgq create_msgq_perms;
 allow xserver_t self:msg { send receive };
 allow xserver_t self:unix_dgram_socket { create_socket_perms sendto };
 allow xserver_t self:unix_stream_socket { create_stream_socket_perms connectto };
-allow xserver_t self:tcp_socket create_stream_socket_perms;
-allow xserver_t self:udp_socket create_socket_perms;
 allow xserver_t self:netlink_kobject_uevent_socket create_socket_perms;
 
 manage_dirs_pattern(xserver_t, xserver_tmp_t, xserver_tmp_t)
@@ -693,17 +710,6 @@ kernel_write_proc_files(xserver_t)
 # Run helper programs in xserver_t.
 corecmd_exec_bin(xserver_t)
 corecmd_exec_shell(xserver_t)
-
-corenet_all_recvfrom_netlabel(xserver_t)
-corenet_tcp_sendrecv_generic_if(xserver_t)
-corenet_udp_sendrecv_generic_if(xserver_t)
-corenet_tcp_sendrecv_generic_node(xserver_t)
-corenet_udp_sendrecv_generic_node(xserver_t)
-corenet_tcp_bind_generic_node(xserver_t)
-corenet_tcp_bind_xserver_port(xserver_t)
-corenet_tcp_connect_all_ports(xserver_t)
-corenet_sendrecv_xserver_server_packets(xserver_t)
-corenet_sendrecv_all_client_packets(xserver_t)
 
 dev_rw_sysfs(xserver_t)
 dev_rw_mouse(xserver_t)
@@ -776,6 +782,25 @@ xserver_use_user_fonts(xserver_t)
 ifdef(`enable_mls',`
 	range_transition xserver_t xserver_tmp_t:sock_file s0 - mls_systemhigh;
 	range_transition xserver_t xserver_t:x_drawable s0 - mls_systemhigh;
+')
+
+tunable_policy(`xserver_can_network',`
+	allow xserver_t self:tcp_socket create_stream_socket_perms;
+	allow xserver_t self:udp_socket create_socket_perms;
+
+	corenet_all_recvfrom_netlabel(xserver_t)
+	corenet_tcp_sendrecv_generic_if(xserver_t)
+	corenet_udp_sendrecv_generic_if(xserver_t)
+	corenet_tcp_sendrecv_generic_node(xserver_t)
+	corenet_udp_sendrecv_generic_node(xserver_t)
+	corenet_tcp_bind_generic_node(xserver_t)
+	corenet_tcp_bind_xserver_port(xserver_t)
+	corenet_tcp_connect_all_ports(xserver_t)
+	corenet_sendrecv_xserver_server_packets(xserver_t)
+	corenet_sendrecv_all_client_packets(xserver_t)
+
+	# VNC v4 module in X server
+	corenet_tcp_bind_vnc_port(xserver_t)
 ')
 
 tunable_policy(`!xserver_object_manager',`
@@ -851,9 +876,6 @@ allow xdm_t xdm_tmpfs_t:file execmod;
 
 # Run Xorg.wrap
 can_exec(xserver_t, xserver_exec_t)
-
-# VNC v4 module in X server
-corenet_tcp_bind_vnc_port(xserver_t)
 
 init_use_fds(xserver_t)
 


### PR DESCRIPTION
Disable X11 server TCP/IP networking functionality by default, as it is generally insecure.