### PR TITLE
Solve issue with no keyboard/mouse on X login screen

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -716,6 +716,7 @@ corenet_tcp_connect_all_ports(xserver_t)
 corenet_sendrecv_xserver_server_packets(xserver_t)
 corenet_sendrecv_all_client_packets(xserver_t)
 
+dev_getattr_sysfs(xserver_t)
 dev_rw_sysfs(xserver_t)
 dev_rw_mouse(xserver_t)
 dev_rw_mtrr(xserver_t)


### PR DESCRIPTION
I was having a problem where when booting to an X login screen (sddm or lightdm) on RHEL9, there was no keyboard/mouse access.  Thus I was stuck.  This one change seems to resolve.  

Sep 08 03:15:59 localhost audisp-syslog[1620]: node=localhost type=AVC msg=audit(1694142959.038:650): avc:  denied  { getattr } for  pid=1695 comm="Xorg" name="/" dev="sysfs" ino=1 scontext=system_u:system_r:xserver_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=filesystem permissive=0