### PR TITLE
separate label for /etc/security/opasswd

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -466,6 +466,7 @@ auth_domtrans_pam_console(xdm_t)
 auth_manage_pam_runtime_dirs(xdm_t)
 auth_manage_pam_runtime_files(xdm_t)
 auth_manage_pam_console_data(xdm_t)
+auth_read_shadow_history(xdm_t)
 auth_write_login_records(xdm_t)
 
 # Run telinit->init to shutdown.

--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -4,8 +4,8 @@
 /etc/gshadow.*		--	gen_context(system_u:object_r:shadow_t,s0)
 /etc/shadow.*		--	gen_context(system_u:object_r:shadow_t,s0)
 /etc/tcb(/.*)?		--	gen_context(system_u:object_r:shadow_t,s0)
-/etc/security/opasswd		--	gen_context(system_u:object_r:shadow_t,s0)
-/etc/security/opasswd\.old	--	gen_context(system_u:object_r:shadow_t,s0)
+/etc/security/opasswd		--	gen_context(system_u:object_r:shadow_history_t,s0)
+/etc/security/opasswd\.old	--	gen_context(system_u:object_r:shadow_history_t,s0)
 
 /usr/bin/login		--	gen_context(system_u:object_r:login_exec_t,s0)
 /usr/bin/pam_console_apply	--	gen_context(system_u:object_r:pam_console_exec_t,s0)

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -577,6 +577,7 @@ interface(`auth_dontaudit_getattr_shadow',`
 #
 interface(`auth_read_shadow',`
 	auth_can_read_shadow_passwords($1)
+	auth_read_shadow_history($1)
 	auth_tunable_read_shadow($1)
 ')
 
@@ -709,6 +710,7 @@ interface(`auth_manage_shadow',`
 		type shadow_t;
 	')
 
+	auth_manage_shadow_history($1)
 	auth_rw_shadow_lock($1)
 	allow $1 shadow_t:file manage_file_perms;
 	typeattribute $1 can_read_shadow_passwords, can_write_shadow_passwords;
@@ -735,6 +737,44 @@ interface(`auth_etc_filetrans_shadow',`
 	')
 
 	files_etc_filetrans($1, shadow_t, file, $2)
+')
+
+########################################
+## <summary>
+##	Read the shadow history file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_read_shadow_history',`
+	gen_require(`
+		type shadow_history_t;
+	')
+
+	files_search_etc($1)
+	allow $1 shadow_history_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Manage the shadow history file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_manage_shadow_history',`
+	gen_require(`
+		type shadow_history_t;
+	')
+
+	files_search_etc($1)
+	allow $1 shadow_history_t:file manage_file_perms;
 ')
 
 #######################################

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -75,6 +75,9 @@ neverallow ~can_relabelto_shadow_passwords shadow_t:file relabelto;
 type shadow_lock_t;
 files_lock_file(shadow_lock_t)
 
+type shadow_history_t;
+files_auth_file(shadow_history_t)
+
 type updpwd_t;
 type updpwd_exec_t;
 domain_type(updpwd_t)
@@ -137,6 +140,7 @@ term_dontaudit_use_unallocated_ttys(chkpwd_t)
 term_dontaudit_use_generic_ptys(chkpwd_t)
 term_dontaudit_use_all_ptys(chkpwd_t)
 
+auth_read_shadow_history(chkpwd_t)
 auth_use_nsswitch(chkpwd_t)
 
 logging_send_audit_msgs(chkpwd_t)
@@ -382,6 +386,9 @@ allow updpwd_t self:fifo_file rw_fifo_file_perms;
 allow updpwd_t self:unix_stream_socket create_stream_socket_perms;
 allow updpwd_t self:unix_dgram_socket create_socket_perms;
 
+files_etc_filetrans(updpwd_t, shadow_history_t, file)
+allow updpwd_t shadow_history_t:file manage_file_perms;
+
 kernel_read_system_state(updpwd_t)
 
 dev_read_urand(updpwd_t)
@@ -391,7 +398,6 @@ files_manage_etc_files(updpwd_t)
 term_dontaudit_use_console(updpwd_t)
 term_dontaudit_use_unallocated_ttys(updpwd_t)
 
-auth_etc_filetrans_shadow(updpwd_t)
 auth_manage_shadow(updpwd_t)
 auth_use_nsswitch(updpwd_t)
 

--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -129,6 +129,7 @@ auth_manage_pam_runtime_files(local_login_t)
 auth_manage_pam_console_data(local_login_t)
 auth_domtrans_pam_console(local_login_t)
 auth_read_pam_motd_dynamic(local_login_t)
+auth_read_shadow_history(local_login_t)
 
 init_dontaudit_use_fds(local_login_t)
 


### PR DESCRIPTION
Seting /etc/security/opasswd to shadow_t has some negative side effects like the fact that pam_unix needs to read that.  Once pam_unix can read shadow_t that changes the behavour of how pam_unix uses unix_update to update the password.  So, this change defines the new type, shadow_history_t, for /etc/secuirty/opasswd.