### PR TITLE
Fix some ssh agent denials

### DIFF
--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -412,6 +412,7 @@ template(`ssh_role_template',`
 
 	files_read_etc_files($1_ssh_agent_t)
 	files_read_etc_runtime_files($1_ssh_agent_t)
+	files_read_usr_files($1_ssh_agent_t)
 	files_search_home($1_ssh_agent_t)
 
 	libs_read_lib_files($1_ssh_agent_t)
@@ -470,6 +471,7 @@ template(`ssh_role_template',`
 		xserver_use_xdm_fds($1_ssh_agent_t)
 		xserver_rw_xdm_pipes($1_ssh_agent_t)
 		xserver_sigchld_xdm($1_ssh_agent_t)
+		xserver_write_inherited_xsession_log($1_ssh_agent_t)
 	')
 ')
 


### PR DESCRIPTION
Aug 29 21:38:07 localhost.localdomain audisp-syslog[1582]: node=localhost type=AVC msg=audit(1693345086.894:3623): avc:  denied  { write } for  pid=1840 comm="ssh-agent" path="/home/sugar/.xsession-errors" dev="dm-9" ino=65541 scontext=staff_u:staff_r:staff_ssh_agent_t:s0 tcontext=system_u:object_r:xsession_log_t:s0 tclass=file permissive=1

Aug 29 21:38:07 localhost.localdomain audisp-syslog[1582]: node=localhost type=AVC msg=audit(1693345086.937:3634): avc:  denied  { getattr } for  pid=1840 comm="ssh-agent" path="/usr/share/crypto-policies/FIPS/opensslcnf.txt" dev="dm-1" ino=262231 scontext=staff_u:staff_r:staff_ssh_agent_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1
Aug 29 21:38:07 localhost.localdomain audisp-syslog[1582]: node=localhost type=AVC msg=audit(1693345086.937:3635): avc:  denied  { read } for  pid=1840 comm="ssh-agent" name="opensslcnf.txt" dev="dm-1" ino=262231 scontext=staff_u:staff_r:staff_ssh_agent_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1
Aug 29 21:38:07 localhost.localdomain audisp-syslog[1582]: node=localhost type=AVC msg=audit(1693345086.937:3635): avc:  denied  { open } for  pid=1840 comm="ssh-agent" path="/usr/share/crypto-policies/FIPS/opensslcnf.txt" dev="dm-1" ino=262231 scontext=staff_u:staff_r:staff_ssh_agent_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1