### PR TITLE
Allow all users to send syslog messages

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -139,6 +139,10 @@ template(`userdom_base_user_template',`
 		allow $1_t self:process execstack;
 	')
 
+	tunable_policy(`user_all_users_send_syslog',`
+		logging_send_syslog_msg($1_t)
+	')
+
 	optional_policy(`
 		devicekit_dbus_chat_disk($1_t)
 		devicekit_dbus_chat_power($1_t)

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -21,6 +21,13 @@ gen_tunable(allow_user_postgresql_connect, false)
 
 ## <desc>
 ## <p>
+## Allow all users to send syslog messages
+## </p>
+## </desc>
+gen_tunable(user_all_users_send_syslog, true)
+
+## <desc>
+## <p>
 ## Allow regular users direct mouse access
 ## </p>
 ## </desc>


### PR DESCRIPTION
Aug 29 12:53:06 localhost.localdomain audisp-syslog[1550]: node=localhost type=AVC msg=audit(1693313586.678:437): avc:  denied  { write } for  pid=1757 comm="systemctl" name="socket" dev="tmpfs" ino=58 scontext=user_u:user_r:user_t:s0 tcontext=system_u:object_r:devlog_t:s0 tclass=sock_file permissive=1
Aug 29 12:53:06 localhost.localdomain audisp-syslog[1550]: node=localhost type=AVC msg=audit(1693313586.678:437): avc:  denied  { sendto } for  pid=1757 comm="systemctl" path="/run/systemd/journal/socket" scontext=user_u:user_r:user_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_dgram_socket permissive=1
Aug 29 13:10:01 localhost.localdomain audisp-syslog[1545]: node=localhost type=AVC msg=audit(1693314601.860:435): avc:  denied  { write } for  pid=1756 comm="systemctl" name="socket" dev="tmpfs" ino=58 scontext=user_u:user_r:user_t:s0 tcontext=system_u:object_r:devlog_t:s0 tclass=sock_file permissive=1
Aug 29 13:10:01 localhost.localdomain audisp-syslog[1545]: node=localhost type=AVC msg=audit(1693314601.860:435): avc:  denied  { sendto } for  pid=1756 comm="systemctl" path="/run/systemd/journal/socket" scontext=user_u:user_r:user_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_dgram_socket permissive=1