### PR TITLE
For systemd-journal-catalog-update.service to operate

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1161,6 +1161,7 @@ ifdef(`init_systemd',`
 	# journalctl:
 	logging_watch_runtime_dirs(initrc_t)
 	logging_manage_runtime_sockets(initrc_t)
+	systemd_manage_journal_files(initrc_t)
 
 	# lvm2-activation-generator checks file labels
 	seutil_read_file_contexts(initrc_t)


### PR DESCRIPTION
× systemd-journal-catalog-update.service - Rebuild Journal Catalog
     Loaded: loaded (/usr/lib/systemd/system/systemd-journal-catalog-update.service; static)
     Active: failed (Result: exit-code) since Wed 2023-09-13 12:51:28 GMT; 10min ago
       Docs: man:systemd-journald.service(8)
             man:journald.conf(5)
    Process: 1626 ExecStart=journalctl --update-catalog (code=exited, status=1/FAILURE)
   Main PID: 1626 (code=exited, status=1/FAILURE)
        CPU: 102ms

Sep 13 12:51:28 localhost systemd[1]: Starting Rebuild Journal Catalog...
Sep 13 12:51:28 localhost journalctl[1626]: Failed to open database for writing: /var/lib/systemd/catalog/database: Permission denied
Sep 13 12:51:28 localhost journalctl[1626]: Failed to write /var/lib/systemd/catalog/database: Permission denied
Sep 13 12:51:28 localhost journalctl[1626]: Failed to list catalog: Permission denied
Sep 13 12:51:28 localhost systemd[1]: systemd-journal-catalog-update.service: Main process exited, code=exited, status=1/FAILURE
Sep 13 12:51:28 localhost systemd[1]: systemd-journal-catalog-update.service: Failed with result 'exit-code'.
Sep 13 12:51:28 localhost systemd[1]: Failed to start Rebuild Journal Catalog.

node=localhost type=AVC msg=audit(1692308998.328:136): avc:  denied  { write } for  pid=1631 comm="journalctl" name="catalog" dev="dm-10" ino=131106 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:systemd_journal_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1692308998.328:136): avc:  denied  { add_name } for  pid=1631 comm="journalctl" name=".#database6ZdcMU" scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:systemd_journal_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1692308998.328:136): avc:  denied  { create } for  pid=1631 comm="journalctl" name=".#database6ZdcMU" scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:systemd_journal_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1692308998.328:136): avc:  denied  { write } for  pid=1631 comm="journalctl" path="/var/lib/systemd/catalog/.#database6ZdcMU" dev="dm-10" ino=131204 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:systemd_journal_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1692308998.330:137): avc:  denied  { setattr } for  pid=1631 comm="journalctl" name=".#database6ZdcMU" dev="dm-10" ino=131204 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:systemd_journal_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1692308998.330:138): avc:  denied  { remove_name } for pid=1631 comm="journalctl" name=".#database6ZdcMU" dev="dm-10" ino=131204 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:systemd_journal_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1692308998.330:138): avc:  denied  { rename } for  pid=1631 comm="journalctl" name=".#database6ZdcMU" dev="dm-10" ino=131204 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:systemd_journal_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1692308998.330:138): avc:  denied  { unlink } for  pid=1631 comm="journalctl" name="database" dev="dm-10" ino=131133 scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:object_r:systemd_journal_t:s0 tclass=file permissive=1