### PR TITLE
Fix a security bug in the system logging permissions

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1013,6 +1013,7 @@ template(`userdom_login_user_template', `
 	libs_exec_lib_files($1_t)
 
 	logging_dontaudit_getattr_all_logs($1_t)
+	logging_dontaudit_send_audit_msgs($1_t)
 
 	miscfiles_read_man_pages($1_t)
 	# map is needed for man-dbs apropos program
@@ -1124,7 +1125,6 @@ template(`userdom_restricted_xwindows_user_template',`
 	# gnome keyring wants to read this.
 	dev_dontaudit_read_rand($1_t)
 
-	logging_send_syslog_msg($1_t)
 	logging_dontaudit_send_audit_msgs($1_t)
 
 	selinux_get_enforce_mode($1_t)
@@ -1417,6 +1417,8 @@ template(`userdom_admin_user_template',`
 
 	init_telinit($1_t)
 
+	logging_dontaudit_send_audit_msgs($1_t)
+	# gt: it would be safer to remove syslogging permissions
 	logging_send_syslog_msg($1_t)
 
 	modutils_domtrans($1_t)
@@ -1512,7 +1514,10 @@ interface(`userdom_security_admin_template',`
 
 	init_exec($1)
 
+	# gt: it would be safer to remove syslogging permissions
 	logging_send_syslog_msg($1)
+
+	logging_dontaudit_send_audit_msgs($1)
 	logging_read_audit_log($1)
 	logging_read_generic_logs($1)
 	logging_read_audit_config($1)


### PR DESCRIPTION
Fix a security bug which allows unprivileged users to send messages (including fake/forged ones) to the syslog in order to trick the administrator into performing actions detrimental to the system security.

Originally introduced here:

   https://github.com/SELinuxProject/refpolicy/commit/847937da7ddd093893b68d5386b81d60def4b263
   Date:   Tue Nov 13 19:31:43 2007 +0000

 policy/modules/system/userdomain.if |    7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)