### PR TITLE
/var/lib/sddm should be xdm_var_lib_t

### DIFF
--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -124,7 +124,7 @@ ifndef(`distro_debian',`
 /var/lib/lxdm(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
 /var/lib/[xkw]dm(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
 /var/lib/xkb(/.*)?		gen_context(system_u:object_r:xkb_var_lib_t,s0)
-/var/lib/sddm(/.*)?		gen_context(system_u:object_r:xkb_var_lib_t,s0)
+/var/lib/sddm(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
 
 /var/log/[kwx]dm\.log.*	--	gen_context(system_u:object_r:xserver_log_t,s0)
 /var/log/lightdm(/.*)?		gen_context(system_u:object_r:xserver_log_t,s0)


### PR DESCRIPTION
based on denials, the fact that sddm runs as xdm_t and how other directories are labeled, xdm_var_lib_t seems more correct here.

Sep 13 14:57:10 localhost.localdomain audisp-syslog[1570]: node=localhost type=AVC msg=audit(1694617030.144:419): avc:  denied  { search } for  pid=1702 comm="sddm" name="sddm" dev="dm-10" ino=393297 scontext=system_u:system_r:xdm_t:s0 tcontext=system_u:object_r:xkb_var_lib_t:s0 tclass=dir permissive=0
Sep 13 14:59:31 localhost.localdomain audisp-syslog[1571]: node=localhost type=AVC msg=audit(1694617171.431:477): avc:  denied  { add_name } for  pid=1768 comm="QQmlThread" name=".cache" scontext=system_u:system_r:xdm_t:s0 tcontext=system_u:object_r:xkb_var_lib_t:s0 tclass=dir permissive=1
Sep 13 14:59:31 localhost.localdomain audisp-syslog[1571]: node=localhost type=AVC msg=audit(1694617171.431:477): avc:  denied  { create } for  pid=1768 comm="QQmlThread" name=".cache" scontext=system_u:system_r:xdm_t:s0 tcontext=system_u:object_r:xkb_var_lib_t:s0 tclass=dir permissive=1
Sep 13 14:59:31 localhost.localdomain audisp-syslog[1571]: node=localhost type=AVC msg=audit(1694617171.470:478): avc:  denied  { getattr } for  pid=1768 comm="QQmlThread" path="/var/lib/sddm/.cache/sddm-greeter/qmlcache" dev="dm-10" ino=393280 scontext=system_u:system_r:xdm_t:s0 tcontext=system_u:object_r:xkb_var_lib_t:s0 tclass=dir permissive=1