### PR TITLE
Remove the syslog capability from the unconfined domain

### DIFF
--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -38,7 +38,7 @@ interface(`unconfined_domain_noaudit',`
 
 	# Use most Linux capabilities
 	allow $1 self:{ capability cap_userns } { chown dac_override dac_read_search fowner fsetid kill setgid setuid setpcap linux_immutable net_bind_service net_broadcast net_admin net_raw ipc_lock ipc_owner sys_rawio sys_chroot sys_ptrace sys_pacct sys_admin sys_boot sys_nice sys_resource sys_time sys_tty_config mknod lease audit_write audit_control setfcap };
-	allow $1 self:{ capability2 cap2_userns } { syslog wake_alarm bpf perfmon };
+	allow $1 self:{ capability2 cap2_userns } { wake_alarm bpf perfmon };
 	allow $1 self:fifo_file manage_fifo_file_perms;
 
 	# Manage most namespace capabilities


### PR DESCRIPTION
This bug allows the exploitation of unconfined domains to send fake or forged messages that trick the administrator to perform actions detrimental to the system security.

Originally introduced here:

  https://github.com/SELinuxProject/refpolicy/commit/4067a18530579ba33f7a8cee307ae2be83f6b740
  Date:   Mon Jun 9 14:38:45 2014 +0200

 policy/modules/system/unconfined.if |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)