### PR TITLE
Clean the modular policy packages before installing

### DIFF
--- a/Rules.modular
+++ b/Rules.modular
@@ -45,7 +45,11 @@ base: $(base_pkg)
 
 modules: $(mod_pkgs)
 
-install: $(instpkg) $(appfiles)
+clean-pkgs:
+	@echo "Cleaning old policy modules."
+	$(verbose) rm -f $(modpkgdir)/*.pp
+
+install: clean-pkgs $(instpkg) $(appfiles)
 
 ########################################
 #


### PR DESCRIPTION
Before installing the policy modules packages in a modular policy, clean all installed modules as they are obsolete and they might have been disabled.
    
This leaves a clean, fresh modular policy packages directory after "make install".

 Rules.modular |    6 +++++-
 1 file changed, 5 insertions(+), 1 deletion(-)
