### PR TITLE
unconfined: Keys are linkable by systemd.

### DIFF
--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -59,6 +59,7 @@ ifdef(`init_systemd',`
 	# for systemd-analyze
 	init_service_status(unconfined_t)
 	# for systemd --user:
+	init_linkable_keyring(unconfined_t)
 	init_pgm_spec_user_daemon_domain(unconfined_t)
 	allow unconfined_t self:system { status start stop reload };
 


### PR DESCRIPTION
Since the `systemd --user` for `unconfined_t` runs in `unconfined_t` too, instead of a derived domain such as with regular users, e.g., `user_systemd_t`, this is required.