### PR TITLE
systemd-locale write to init_t runtime socket

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -776,6 +776,8 @@ kernel_read_kernel_sysctls(systemd_locale_t)
 
 files_read_etc_files(systemd_locale_t)
 
+init_write_runtime_socket(systemd_locale_t)
+
 selinux_use_status_page(systemd_locale_t)
 
 seutil_read_file_contexts(systemd_locale_t)


### PR DESCRIPTION
Sep 13 19:20:47 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632847.823:567): avc:  denied  { write } for  pid=1807 comm="systemd-localed" name="notify" dev="tmpfs" ino=47 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:init_runtime_t:s0 tclass=sock_file permissive=1
Sep 13 19:21:21 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632881.720:696): avc:  denied  { write } for  pid=1807 comm="systemd-localed" name="notify" dev="tmpfs" ino=47 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:init_runtime_t:s0 tclass=sock_file permissive=1
Sep 13 19:22:05 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632925.429:22455): avc:  denied  { write } for  pid=2643 comm="systemd-localed" name="notify" dev="tmpfs" ino=47 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:init_runtime_t:s0 tclass=sock_file permissive=1