### PR TITLE
Resolve some denials with colord

### DIFF
--- a/policy/modules/services/colord.te
+++ b/policy/modules/services/colord.te
@@ -137,6 +137,12 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_map_hwdb(colord_t)
+	systemd_read_hwdb(colord_t)
+	systemd_read_logind_sessions_files(colord_t)
+')
+
+optional_policy(`
 	udev_read_runtime_files(colord_t)
 ')
 
@@ -145,6 +151,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	xdg_read_data_files(colord_t)
+')
+
+optional_policy(`
 	xserver_read_xdm_lib_files(colord_t)
+	xserver_read_xdm_state(colord_t)
 	xserver_use_xdm_fds(colord_t)
 ')


### PR DESCRIPTION
Sep 13 19:20:51 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632851.771:656): avc:  denied  { read } for  pid=2039 comm="colord" name="hwdb.bin" dev="dm-1" ino=393952 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:object_r:systemd_hwdb_t:s0 tclass=file permissive=1
Sep 13 19:20:51 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632851.771:656): avc:  denied  { open } for  pid=2039 comm="colord" path="/etc/udev/hwdb.bin" dev="dm-1" ino=393952 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:object_r:systemd_hwdb_t:s0 tclass=file permissive=1
Sep 13 19:20:51 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632851.771:657): avc:  denied  { getattr } for  pid=2039 comm="colord" path="/etc/udev/hwdb.bin" dev="dm-1" ino=393952 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:object_r:systemd_hwdb_t:s0 tclass=file permissive=1
Sep 13 19:20:51 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632851.771:658): avc:  denied  { map } for  pid=2039 comm="colord" path="/etc/udev/hwdb.bin" dev="dm-1" ino=393952 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:object_r:systemd_hwdb_t:s0 tclass=file permissive=1
Sep 13 19:21:39 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632899.106:18931): avc:  denied  { read } for  pid=2039 comm="gdbus" path="/home/toor/.local/share/icc/edid-bb6ad72dc802b000932c73ad20996ae5.icc" dev="dm-9" ino=129692 scontext=system_u:system_r:colord_t:s0 tcontext=toor_u:object_r:xdg_data_t:s0 tclass=file permissive=1
Sep 13 19:21:39 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632899.362:19182): avc:  denied  { getattr } for  pid=2039 comm="colord" path="/home/toor/.local/share/icc/edid-bb6ad72dc802b000932c73ad20996ae5.icc" dev="dm-9" ino=129692 scontext=system_u:system_r:colord_t:s0 tcontext=toor_u:object_r:xdg_data_t:s0 tclass=file permissive=1
Sep 13 19:21:39 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632899.362:19183): avc:  denied  { map } for  pid=2039 comm="colord" path="/home/toor/.local/share/icc/edid-bb6ad72dc802b000932c73ad20996ae5.icc" dev="dm-9" ino=129692 scontext=system_u:system_r:colord_t:s0 tcontext=toor_u:object_r:xdg_data_t:s0 tclass=file permissive=1
Sep 13 19:20:55 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632855.046:678): avc:  denied  { search } for  pid=2039 comm="colord" name="1880" dev="proc" ino=26735 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:system_r:xdm_t:s0 tclass=dir permissive=1
Sep 13 19:20:55 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632855.046:678): avc:  denied  { read } for  pid=2039 comm="colord" name="cgroup" dev="proc" ino=25503 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:system_r:xdm_t:s0 tclass=file permissive=1
Sep 13 19:20:55 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632855.046:678): avc:  denied  { open } for  pid=2039 comm="colord" path="/proc/1880/cgroup" dev="proc" ino=25503 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:system_r:xdm_t:s0 tclass=file permissive=1
Sep 13 19:20:55 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632855.046:679): avc:  denied  { getattr } for  pid=2039 comm="colord" path="/proc/1880/cgroup" dev="proc" ino=25503 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:system_r:xdm_t:s0 tclass=file permissive=1
Sep 13 19:20:55 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632855.046:680): avc:  denied  { ioctl } for  pid=2039 comm="colord" path="/proc/1880/cgroup" dev="proc" ino=25503 ioctlcmd=0x5401 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:system_r:xdm_t:s0 tclass=file permissive=1
Sep 13 19:20:55 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632855.047:681): avc:  denied  { search } for  pid=2039 comm="colord" name="sessions" dev="tmpfs" ino=96 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:object_r:systemd_sessions_runtime_t:s0 tclass=dir permissive=1
Sep 13 19:20:55 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632855.047:681): avc:  denied  { read } for  pid=2039 comm="colord" name="c1" dev="tmpfs" ino=1692 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:object_r:systemd_sessions_runtime_t:s0 tclass=file permissive=1
Sep 13 19:20:55 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632855.047:681): avc:  denied  { open } for  pid=2039 comm="colord" path="/run/systemd/sessions/c1" dev="tmpfs" ino=1692 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:object_r:systemd_sessions_runtime_t:s0 tclass=file permissive=1
Sep 13 19:20:55 localhost.localdomain audisp-syslog[1531]: node=localhost type=AVC msg=audit(1694632855.047:682): avc:  denied  { getattr } for  pid=2039 comm="colord" path="/run/systemd/sessions/c1" dev="tmpfs" ino=1692 scontext=system_u:system_r:colord_t:s0 tcontext=system_u:object_r:systemd_sessions_runtime_t:s0 tclass=file permissive=1