### PR TITLE
systemd: allow systemd-networkd to create file in /run/systemd directory

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1141,7 +1141,7 @@ auth_use_nsswitch(systemd_networkd_t)
 init_dgram_send(systemd_networkd_t)
 init_read_state(systemd_networkd_t)
 init_read_runtime_files(systemd_networkd_t)
-init_runtime_filetrans(systemd_networkd_t, systemd_networkd_runtime_t, dir)
+init_runtime_filetrans(systemd_networkd_t, systemd_networkd_runtime_t, { dir file })
 
 logging_send_syslog_msg(systemd_networkd_t)
 


### PR DESCRIPTION
systemd-networkd creates files in /run/systemd directory which should be labeled appropriately.

Fixes:
avc:  denied  { create } for  pid=136 comm="systemd-network" name=".#networkd2c6a2ac2dbf34a8"
scontext=system_u:system_r:systemd_networkd_t
tcontext=system_u:object_r:init_runtime_t tclass=file permissive=1

avc:  denied  { write } for  pid=136 comm="systemd-network" path="/run/systemd/.#networkd2c6a2ac2dbf34a8" dev="tmpfs" ino=81 scontext=system_u:system_r:systemd_networkd_t
tcontext=system_u:object_r:init_runtime_t tclass=file permissive=1

avc:  denied  { setattr } for  pid=136 comm="systemd-network" name=".#networkd2c6a2ac2dbf34a8" dev="tmpfs" ino=81 scontext=system_u:system_r:systemd_networkd_t
tcontext=system_u:object_r:init_runtime_t tclass=file permissive=1

avc:  denied  { rename } for  pid=136 comm="systemd-network" name=".#networkd2c6a2ac2dbf34a8" dev="tmpfs" ino=81 scontext=system_u:system_r:systemd_networkd_t
tcontext=system_u:object_r:init_runtime_t tclass=file permissive=1