### PR TITLE
Separate label for /run/systemd/notify

### DIFF
--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -213,7 +213,7 @@ ifdef(`init_systemd', `
 	init_stop_all_units(system_dbusd_t)
 
 	# Recent versions of dbus are started as Type=notify
-	init_write_runtime_socket(system_dbusd_t)
+	systemd_write_notify_socket(system_dbusd_t)
 
 	tunable_policy(`dbus_broker_system_bus',`
 		init_get_system_status(system_dbusd_t)

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1004,6 +1004,25 @@ interface(`init_unix_stream_socket_connectto',`
 
 ########################################
 ## <summary>
+##	Send to init with a unix socket.
+##  Without any additional permissions.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_unix_stream_socket_sendto',`
+	gen_require(`
+		type init_t;
+	')
+
+	allow $1 init_t:unix_stream_socket sendto;
+')
+
+########################################
+## <summary>
 ##	Inherit and use file descriptors from init.
 ## </summary>
 ## <desc>

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1170,6 +1170,7 @@ ifdef(`init_systemd',`
 
 	systemd_start_power_units(initrc_t)
 	systemd_watch_networkd_runtime_dirs(initrc_t)
+	systemd_write_notify_socket(initrc_t)
 
 	# Ensures the memory.pressure cgroup file is labelled differently, so
 	# that processes can manage it without having access to the rest of the
@@ -1543,7 +1544,7 @@ ifdef(`init_systemd',`
 	fs_search_cgroup_dirs(daemon)
 
 	# need write to /var/run/systemd/notify
-	init_write_runtime_socket(daemon)
+	systemd_write_notify_socket(daemon)
 ')
 
 tunable_policy(`init_daemons_use_tty',`

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -100,7 +100,7 @@ HOME_DIR/\.local/share/systemd(/.*)?		gen_context(system_u:object_r:systemd_data
 /run/systemd/ask-password-block(/.*)?	gen_context(system_u:object_r:systemd_passwd_runtime_t,s0)
 /run/systemd/home(/.*)?         gen_context(system_u:object_r:systemd_homed_runtime_t,s0)
 /run/systemd/network(/.*)?  gen_context(system_u:object_r:systemd_networkd_runtime_t,s0)
-/run/systemd/notify			gen_context(system_u:object_r:systemd_runtime_notify_t,s0)
+/run/systemd/notify		-s	gen_context(system_u:object_r:systemd_runtime_notify_t,s0)
 /run/systemd/resolve(/.*)?  gen_context(system_u:object_r:systemd_resolved_runtime_t,s0)
 /run/systemd/seats(/.*)?	gen_context(system_u:object_r:systemd_sessions_runtime_t,s0)
 /run/systemd/sessions(/.*)?	gen_context(system_u:object_r:systemd_sessions_runtime_t,s0)

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -100,6 +100,7 @@ HOME_DIR/\.local/share/systemd(/.*)?		gen_context(system_u:object_r:systemd_data
 /run/systemd/ask-password-block(/.*)?	gen_context(system_u:object_r:systemd_passwd_runtime_t,s0)
 /run/systemd/home(/.*)?         gen_context(system_u:object_r:systemd_homed_runtime_t,s0)
 /run/systemd/network(/.*)?  gen_context(system_u:object_r:systemd_networkd_runtime_t,s0)
+/run/systemd/notify			gen_context(system_u:object_r:systemd_runtime_notify_t,s0)
 /run/systemd/resolve(/.*)?  gen_context(system_u:object_r:systemd_resolved_runtime_t,s0)
 /run/systemd/seats(/.*)?	gen_context(system_u:object_r:systemd_sessions_runtime_t,s0)
 /run/systemd/sessions(/.*)?	gen_context(system_u:object_r:systemd_sessions_runtime_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -126,6 +126,7 @@ template(`systemd_role_template',`
 	systemd_search_user_runtime_unit_dirs($1_systemd_t)
 	systemd_search_user_transient_unit_dirs($1_systemd_t)
 	systemd_read_user_units_files($1_systemd_t)
+	systemd_write_notify_socket($1_systemd_t)
 
 	dbus_system_bus_client($1_systemd_t)
 	dbus_spec_session_bus_client($1, $1_systemd_t)
@@ -274,6 +275,27 @@ interface(`systemd_user_unix_stream_activated_socket',`
 
 	typeattribute $1 systemd_user_unix_stream_activated_socket_type;
 	systemd_user_activated_sock_file($2)
+')
+
+#######################################
+## <summary>
+##  Allow the specified domain to write to
+##  systemd-notify socket
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_write_notify_socket',`
+	gen_require(`
+		type systemd_runtime_notify_t;
+	')
+
+	init_list_runtime($1)
+	init_unix_stream_socket_sendto($1)
+	allow $1 systemd_runtime_notify_t:sock_file write;
 ')
 
 ######################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -313,6 +313,9 @@ xdg_data_content(systemd_data_home_t)
 type systemd_user_runtime_notify_t;
 userdom_user_runtime_content(systemd_user_runtime_notify_t)
 
+type systemd_runtime_notify_t;
+files_runtime_file(systemd_runtime_notify_t)
+
 type systemd_user_runtime_t;
 userdom_user_runtime_content(systemd_user_runtime_t)
 


### PR DESCRIPTION
label systemd_runtime_notify_t
Allow daemon domains to write by default