### PR TITLE
systemd: allow journalctl to create /var/lib/systemd/catalog

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -783,9 +783,10 @@ seutil_read_file_contexts(systemd_hw_t)
 
 dontaudit systemd_journal_init_t self:capability net_admin;
 
+manage_dirs_pattern(systemd_journal_init_t, systemd_journal_t, systemd_journal_t)
 manage_files_pattern(systemd_journal_init_t, systemd_journal_t, systemd_journal_t)
 
-fs_getattr_cgroup(systemd_journal_init_t)
+fs_getattr_all_fs(systemd_journal_init_t)
 fs_search_cgroup_dirs(systemd_journal_init_t)
 
 kernel_getattr_proc(systemd_journal_init_t)
@@ -794,6 +795,7 @@ kernel_read_system_state(systemd_journal_init_t)
 
 init_read_state(systemd_journal_init_t)
 init_search_var_lib_dirs(systemd_journal_init_t)
+init_var_lib_filetrans(systemd_journal_init_t, systemd_journal_t, dir)
 
 logging_send_syslog_msg(systemd_journal_init_t)
 logging_stream_connect_journald_varlink(systemd_journal_init_t)


### PR DESCRIPTION
If /var/lib/systemd/catalog doesn't exist at first boot, systemd-journal-catalog-update.service would fail:

$ systemctl status systemd-journal-catalog-update.service
  systemd-journal-catalog-update.service - Rebuild Journal Catalog
     Loaded: loaded (/usr/lib/systemd/system/systemd-journal-catalog-update.service; static)
     Active: failed (Result: exit-code) since Sat 2023-09-30 09:46:46 UTC; 50s ago
       Docs: man:systemd-journald.service(8)
             man:journald.conf(5)
    Process: 247 ExecStart=journalctl --update-catalog (code=exited, status=1/FAILURE)
   Main PID: 247 (code=exited, status=1/FAILURE)

Sep 30 09:46:45 qemux86-64 systemd[1]: Starting Rebuild Journal Catalog...
Sep 30 09:46:46 qemux86-64 journalctl[247]: Failed to create parent directories of /var/lib/systemd/catalog/database: Permission denied
Sep 30 09:46:46 qemux86-64 journalctl[247]: Failed to write /var/lib/systemd/catalog/database: Permission denied
Sep 30 09:46:46 qemux86-64 journalctl[247]: Failed to list catalog: Permission denied
Sep 30 09:46:46 qemux86-64 systemd[1]: systemd-journal-catalog-update.service: Main process exited, code=exited, status=1/FAILURE
Sep 30 09:46:46 qemux86-64 systemd[1]: systemd-journal-catalog-update.service: Failed with result 'exit-code'.
Sep 30 09:46:46 qemux86-64 systemd[1]: Failed to start Rebuild Journal Catalog.

Fixes:
AVC avc:  denied  { getattr } for  pid=247 comm="journalctl" name="/" dev="tmpfs" ino=1 scontext=system_u:system_r:systemd_journal_init_t tcontext=system_u:object_r:tmpfs_t tclass=filesystem permissive=0

AVC avc:  denied  { write } for  pid=247 comm="journalctl" name="systemd" dev="vda" ino=13634
scontext=system_u:system_r:systemd_journal_init_t
tcontext=system_u:object_r:init_var_lib_t tclass=dir permissive=0