### PR TITLE
bind: fix for named service

### DIFF
--- a/policy/modules/services/bind.te
+++ b/policy/modules/services/bind.te
@@ -80,6 +80,8 @@ allow named_t self:process { setsched getsched getcap setcap setrlimit signal_pe
 allow named_t self:fifo_file rw_fifo_file_perms;
 allow named_t self:unix_stream_socket { accept listen };
 allow named_t self:tcp_socket { accept listen };
+allow named_t self:anon_inode { create map read write };
+allow named_t self:io_uring sqpoll;
 
 manage_files_pattern(named_t, dnssec_t, dnssec_t)
 filetrans_pattern(named_t, named_conf_t, dnssec_t, dir, "cache")


### PR DESCRIPTION
Fixes:
avc:  denied  { sqpoll } for  pid=373 comm="named" scontext=system_u:system_r:named_t:s0-s15:c0.c1023 tcontext=system_u:system_r:named_t:s0-s15:c0.c1023 tclass=io_uring permissive=0

avc:  denied  { create } for  pid=373 comm="named" anonclass=[io_uring] scontext=system_u:system_r:named_t:s0-s15:c0.c1023 tcontext=system_u:object_r:named_t:s0 tclass=anon_inode permissive=0