### PR TITLE
systemd: allow systemd-networkd and sytemd-resolved to write to syste…

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -195,7 +195,7 @@ init_daemon_domain(systemd_modules_load_t, systemd_modules_load_exec_t)
 
 type systemd_networkd_t;
 type systemd_networkd_exec_t;
-init_system_domain(systemd_networkd_t, systemd_networkd_exec_t)
+init_daemon_domain(systemd_networkd_t, systemd_networkd_exec_t)
 
 type systemd_networkd_runtime_t alias systemd_networkd_var_run_t;
 files_runtime_file(systemd_networkd_runtime_t)
@@ -231,7 +231,7 @@ files_type(systemd_pstore_var_lib_t)
 
 type systemd_resolved_t;
 type systemd_resolved_exec_t;
-init_system_domain(systemd_resolved_t, systemd_resolved_exec_t)
+init_daemon_domain(systemd_resolved_t, systemd_resolved_exec_t)
 
 type systemd_resolved_runtime_t alias systemd_resolved_var_run_t;
 files_runtime_file(systemd_resolved_runtime_t)


### PR DESCRIPTION
…md-notify socket

Fixes:
avc:  denied  { write } for  pid=277 comm="systemd-resolve" name="notify" dev="tmpfs" ino=31
scontext=system_u:system_r:systemd_resolved_t
tcontext=system_u:object_r:systemd_runtime_notify_t tclass=sock_file permissive=1

avc:  denied  { write } for  pid=324 comm="systemd-network" name="notify" dev="tmpfs" ino=31
scontext=system_u:system_r:systemd_networkd_t
tcontext=system_u:object_r:systemd_runtime_notify_t tclass=sock_file permissive=1