### PR TITLE
Modify the gpg module so that gpg and the gpg_agent

### DIFF
--- a/policy/modules/apps/gpg.te
+++ b/policy/modules/apps/gpg.te
@@ -86,6 +86,7 @@ allow gpg_t self:tcp_socket { accept listen };
 
 manage_dirs_pattern(gpg_t, gpg_runtime_t, gpg_runtime_t)
 userdom_user_runtime_filetrans(gpg_t, gpg_runtime_t, dir, "gnupg")
+manage_sock_files_pattern(gpg_t, gpg_runtime_t, gpg_runtime_t)
 
 manage_dirs_pattern(gpg_t, gpg_agent_tmp_t, gpg_agent_tmp_t)
 manage_files_pattern(gpg_t, gpg_agent_tmp_t, gpg_agent_tmp_t)
@@ -230,6 +231,7 @@ allow gpg_agent_t gpg_secret_t:dir watch;
 
 manage_dirs_pattern(gpg_agent_t, gpg_runtime_t, gpg_runtime_t)
 userdom_user_runtime_filetrans(gpg_agent_t, gpg_runtime_t, dir, "gnupg")
+manage_sock_files_pattern(gpg_agent_t, gpg_runtime_t, gpg_runtime_t)
 allow gpg_agent_t gpg_runtime_t:dir watch;
 
 manage_dirs_pattern(gpg_agent_t, gpg_agent_tmp_t, gpg_agent_tmp_t)


### PR DESCRIPTION
Modify the gpg module so that gpg and the gpg_agent can manage gpg_runtime_t socket files.

See the gpg file contexts definition for further reference on the gpg_runtime_t label and the need for this patch.

---
 policy/modules/apps/gpg.te |    2 ++
 1 file changed, 2 insertions(+)