### PR TITLE
rpm: fixes for dnf

### DIFF
--- a/policy/modules/admin/rpm.fc
+++ b/policy/modules/admin/rpm.fc
@@ -55,6 +55,7 @@ ifdef(`distro_redhat',`
 /var/cache/yum(/.*)?	gen_context(system_u:object_r:rpm_var_cache_t,s0)
 
 /var/lib/alternatives(/.*)?	gen_context(system_u:object_r:rpm_var_lib_t,s0)
+/var/lib/dnf(/.*)?	gen_context(system_u:object_r:rpm_var_lib_t,s0)
 /var/lib/rpm(/.*)?	gen_context(system_u:object_r:rpm_var_lib_t,s0)
 /var/lib/YaST2(/.*)?	gen_context(system_u:object_r:rpm_var_lib_t,s0)
 /var/lib/yum(/.*)?	gen_context(system_u:object_r:rpm_var_lib_t,s0)

--- a/policy/modules/admin/rpm.if
+++ b/policy/modules/admin/rpm.if
@@ -340,6 +340,26 @@ interface(`rpm_manage_script_tmp_files',`
 
 #####################################
 ## <summary>
+##	Read rpm temporary files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rpm_read_tmp_files',`
+	gen_require(`
+		type rpm_tmp_t;
+	')
+
+	files_search_tmp($1)
+	read_files_pattern($1, rpm_tmp_t, rpm_tmp_t)
+	read_lnk_files_pattern($1, rpm_tmp_t, rpm_tmp_t)
+')
+
+#####################################
+## <summary>
 ##	Append rpm temporary files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/admin/rpm.te
+++ b/policy/modules/admin/rpm.te
@@ -212,6 +212,11 @@ seutil_read_file_contexts(rpm_t)
 userdom_use_user_terminals(rpm_t)
 userdom_use_unpriv_users_fds(rpm_t)
 
+ifdef(`init_systemd', `
+	systemd_use_logind_fds(rpm_t)
+	systemd_dbus_chat_logind(rpm_t)
+')
+
 optional_policy(`
 	cron_system_entry(rpm_t, rpm_exec_t)
 ')

--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -227,6 +227,7 @@ files_relabel_etc_files(groupadd_t)
 files_read_etc_runtime_files(groupadd_t)
 files_read_usr_symlinks(groupadd_t)
 
+kernel_getattr_proc(groupadd_t)
 kernel_read_kernel_sysctls(groupadd_t)
 
 # Execute /usr/bin/{passwd, chfn, chsh} and /usr/sbin/{useradd, vipw}.
@@ -277,6 +278,8 @@ optional_policy(`
 optional_policy(`
 	rpm_use_fds(groupadd_t)
 	rpm_rw_pipes(groupadd_t)
+	rpm_read_tmp_files(groupadd_t)
+	rpm_append_tmp_files(groupadd_t)
 ')
 
 optional_policy(`
@@ -589,6 +592,8 @@ optional_policy(`
 optional_policy(`
 	rpm_use_fds(useradd_t)
 	rpm_rw_pipes(useradd_t)
+	rpm_read_tmp_files(useradd_t)
+	rpm_append_tmp_files(useradd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
* Set labels for /var/lib/dnf/.
* Allow useradd/groupadd to read/append rpm temporary files.
* Allow rpm_t to send/receive messages from systemd-logind over dbus.
* Allow rpm_t to use inherited systemd-logind file descriptors.

Fixes:
avc:  denied  { send_msg } for msgtype=method_call interface=org.freedesktop.login1.Manager member=Inhibit dest=org.freedesktop.login1 spid=565 tpid=331
scontext=root:sysadm_r:rpm_t tcontext=system_u:system_r:systemd_logind_t tclass=dbus permissive=1

avc:  denied  { send_msg } for msgtype=method_return dest=:1.11 spid=331 tpid=565 scontext=system_u:system_r:systemd_logind_t tcontext=root:sysadm_r:rpm_t tclass=dbus permissive=1

avc:  denied  { use } for  pid=565 comm="python3"
path="/run/systemd/inhibit/1.ref" dev="tmpfs" ino=703 scontext=root:sysadm_r:rpm_t tcontext=system_u:system_r:systemd_logind_t tclass=fd permissive=1

avc:  denied  { read append } for  pid=590 comm="groupadd" path="/tmp/tmpy6epkors" dev="tmpfs" ino=20
scontext=root:sysadm_r:groupadd_t tcontext=root:object_r:rpm_tmp_t tclass=file permissive=1

avc:  denied  { getattr } for  pid=590 comm="groupadd" name="/" dev="proc" ino=1 scontext=root:sysadm_r:groupadd_t tcontext=system_u:object_r:proc_t tclass=filesystem permissive=1

avc:  denied  { ioctl } for  pid=590 comm="groupadd" path="/tmp/tmpy6epkors" dev="tmpfs" ino=20 ioctlcmd=0x5401 scontext=root:sysadm_r:groupadd_t tcontext=root:object_r:rpm_tmp_t tclass=file permissive=1

avc:  denied  { read append } for  pid=626 comm="useradd" path="/tmp/tmpy6epkors" dev="tmpfs" ino=20
scontext=root:sysadm_r:useradd_t tcontext=root:object_r:rpm_tmp_t tclass=file permissive=1

avc:  denied  { ioctl } for  pid=626 comm="useradd" path="/tmp/tmpy6epkors" dev="tmpfs" ino=20 ioctlcmd=0x5401 scontext=root:sysadm_r:useradd_t tcontext=root:object_r:rpm_tmp_t tclass=file permissive=1