### PR TITLE
Secure the Private Keys corresponding to SSL Certificates used by the HTTP daemon

### DIFF
--- a/policy/modules/roles/webadm.te
+++ b/policy/modules/roles/webadm.te
@@ -8,6 +8,16 @@ policy_module(webadm)
 ## <desc>
 ##	<p>
 ##	Determine whether webadm can
+##	manage http daemon secret
+##	configuration files such as
+##	private keys for SSL certs.
+##	</p>
+## </desc>
+gen_tunable(webadm_manage_secret_files, true)
+
+## <desc>
+##	<p>
+##	Determine whether webadm can
 ##	manage generic user files.
 ##	</p>
 ## </desc>
@@ -44,6 +54,10 @@ logging_send_syslog_msg(webadm_t)
 userdom_dontaudit_search_user_home_dirs(webadm_t)
 
 apache_admin(webadm_t, webadm_r)
+
+tunable_policy(`webadm_manage_secret_files',`
+	apache_manage_secret(webadm_t)
+')
 
 tunable_policy(`webadm_manage_user_files',`
 	userdom_manage_user_home_content_files(webadm_t)

--- a/policy/modules/services/apache.fc
+++ b/policy/modules/services/apache.fc
@@ -14,6 +14,8 @@ HOME_DIR/((www)|(web)|(public_html))(/.*)?/logs(/.*)?		gen_context(system_u:obje
 /etc/htdig(/.*)?						gen_context(system_u:object_r:httpd_sys_content_t,s0)
 /etc/httpd(/.*)?						gen_context(system_u:object_r:httpd_config_t,s0)
 /etc/httpd/conf/keytab					--	gen_context(system_u:object_r:httpd_keytab_t,s0)
+/etc/httpd/conf/ssl(/.*)?				--	gen_context(system_u:object_r:httpd_secret_t,s0)
+/etc/httpd/conf/ssl/.*\.crt				--	gen_context(system_u:object_r:httpd_config_t,s0)
 /etc/httpd/logs							gen_context(system_u:object_r:httpd_log_t,s0)
 /etc/httpd/modules						gen_context(system_u:object_r:httpd_modules_t,s0)
 /etc/lighttpd(/.*)?						gen_context(system_u:object_r:httpd_config_t,s0)

--- a/policy/modules/services/apache.if
+++ b/policy/modules/services/apache.if
@@ -754,6 +754,32 @@ interface(`apache_manage_config',`
 
 ########################################
 ## <summary>
+##	Create, read, write, and delete
+##	httpd secret configuration files
+##	such as Private Keys for SSL
+##	Certificates.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`apache_manage_secret',`
+	gen_require(`
+		type httpd_config_t;
+		type httpd_secret_t;
+	')
+
+	files_search_etc($1)
+        
+	manage_dirs_pattern($1, httpd_config_t, httpd_config_t)
+	manage_files_pattern($1, httpd_config_t, httpd_secret_t)
+	read_lnk_files_pattern($1, httpd_config_t, httpd_secret_t)
+')
+
+########################################
+## <summary>
 ##	Execute the Apache helper program
 ##	with a domain transition.
 ## </summary>

--- a/policy/modules/services/apache.te
+++ b/policy/modules/services/apache.te
@@ -306,6 +306,10 @@ init_daemon_domain(httpd_rotatelogs_t, httpd_rotatelogs_exec_t)
 type httpd_runtime_t alias httpd_var_run_t;
 files_runtime_file(httpd_runtime_t)
 
+# SSL Certificates and Private Keys
+type httpd_secret_t;
+files_config_file(httpd_secret_t)
+
 type httpd_squirrelmail_t;
 files_type(httpd_squirrelmail_t)
 
@@ -412,6 +416,10 @@ read_files_pattern(httpd_t, httpd_modules_t, httpd_modules_t)
 read_lnk_files_pattern(httpd_t, httpd_modules_t, httpd_modules_t)
 
 allow httpd_t httpd_rotatelogs_t:process signal_perms;
+
+# Private Keys for SSL Certificates should
+# only be read by the http daemon
+allow httpd_t httpd_secret_t:file read_file_perms;
 
 manage_dirs_pattern(httpd_t, httpd_squirrelmail_t, httpd_squirrelmail_t)
 mmap_manage_files_pattern(httpd_t, httpd_squirrelmail_t, httpd_squirrelmail_t)

--- a/policy/modules/services/certbot.te
+++ b/policy/modules/services/certbot.te
@@ -124,6 +124,9 @@ optional_policy(`
 	# for certbot to create nginx config
 	apache_manage_config(certbot_t)
 
+	# certbot manages SSL Private Keys and CSR
+	apache_manage_secret(certbot_t)
+
 	apache_rw_runtime_files(certbot_t)
 	apache_signal(certbot_t)
 ')

--- a/policy/modules/services/certmonger.te
+++ b/policy/modules/services/certmonger.te
@@ -78,6 +78,8 @@ optional_policy(`
 	apache_search_config(certmonger_t)
 	apache_signal(certmonger_t)
 	apache_signull(certmonger_t)
+	# certmonger manages SSL Certificates
+	apache_manage_config(certmonger_t)
 	# certmonger manages SSL Private Keys and CSR
 	apache_manage_secret(certmonger_t)
 ')

--- a/policy/modules/services/certmonger.te
+++ b/policy/modules/services/certmonger.te
@@ -78,6 +78,8 @@ optional_policy(`
 	apache_search_config(certmonger_t)
 	apache_signal(certmonger_t)
 	apache_signull(certmonger_t)
+	# certmonger manages SSL Private Keys and CSR
+	apache_manage_secret(certmonger_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Secure the Private Keys corresponding to SSL Certificates used by the HTTP daemon against an Information Disclosure vulnerability.

The new file contexts are based upon the official Apache HTTP Server recommended locations (see http://www.apache.com/how-to-setup-an-ssl-certificate-on-apache) and might need to be adapted for other distributions.

Modify the webadm role with new tunable policy to support file management of SSL Private Keys.

Fix the certmonger policy module so that it can manage SSL Certificates and corresponding SSL Private Keys and CSR.

This pull request is now being replaced by a revised solution: https://github.com/SELinuxProject/refpolicy/pull/737