### PR TITLE
Restrict LDAP server init script permissions on generic certificate files

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -914,7 +914,7 @@ logging_read_audit_config(initrc_t)
 
 miscfiles_read_localization(initrc_t)
 # slapd needs to read cert files from its initscript
-miscfiles_manage_generic_cert_files(initrc_t)
+miscfiles_read_generic_certs(initrc_t)
 
 seutil_read_config(initrc_t)
 


### PR DESCRIPTION
The LDAP server only needs to read generic certificate files, not manage them.

Modify the init policy to match the comment and the LDAP server actual behavior.

---
 policy/modules/system/init.te |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)