### PR TITLE
Secure the Private Keys corresponding to SSL Certificates used by the HTTP daemon

### DIFF
--- a/policy/modules/roles/webadm.te
+++ b/policy/modules/roles/webadm.te
@@ -41,6 +41,10 @@ seutil_domtrans_setfiles(webadm_t)
 logging_send_audit_msgs(webadm_t)
 logging_send_syslog_msg(webadm_t)
 
+miscfiles_manage_generic_tls_privkey_dirs(webadm_t)
+miscfiles_manage_generic_tls_privkey_files(webadm_t)
+miscfiles_manage_generic_tls_privkey_symlinks(webadm_t)
+
 userdom_dontaudit_search_user_home_dirs(webadm_t)
 
 apache_admin(webadm_t, webadm_r)

--- a/policy/modules/services/certmonger.te
+++ b/policy/modules/services/certmonger.te
@@ -70,6 +70,9 @@ logging_send_syslog_msg(certmonger_t)
 
 miscfiles_read_localization(certmonger_t)
 miscfiles_manage_generic_cert_files(certmonger_t)
+miscfiles_manage_generic_tls_privkey_dirs(certmonger_t)
+miscfiles_manage_generic_tls_privkey_files(certmonger_t)
+miscfiles_manage_generic_tls_privkey_symlinks(certmonger_t)
 
 userdom_search_user_home_content(certmonger_t)
 

--- a/policy/modules/system/miscfiles.fc
+++ b/policy/modules/system/miscfiles.fc
@@ -10,10 +10,13 @@ ifdef(`distro_gentoo',`
 #
 /etc/avahi/etc/localtime --	gen_context(system_u:object_r:locale_t,s0)
 /etc/httpd/alias/[^/]*\.db(\.[^/]*)* -- gen_context(system_u:object_r:cert_t,s0)
+/etc/httpd/conf/ssl(/.*)?	--	gen_context(system_u:object_r:tls_privkey_t,s0)
+/etc/httpd/conf/ssl/.*\.crt	--	gen_context(system_u:object_r:cert_t,s0)
 /etc/localtime		--	gen_context(system_u:object_r:locale_t,s0)
 /etc/pki(/.*)?			gen_context(system_u:object_r:cert_t,s0)
 /etc/pki/.*/private(/.*)?	gen_context(system_u:object_r:tls_privkey_t,s0)
 /etc/ssl(/.*)?			gen_context(system_u:object_r:cert_t,s0)
+/etc/ssl/private(/.*)?		gen_context(system_u:object_r:tls_privkey_t,s0)
 /etc/timezone		--	gen_context(system_u:object_r:locale_t,s0)
 
 ifdef(`distro_debian',`


### PR DESCRIPTION
Secure the Private Keys corresponding to SSL Certificates used by the HTTP daemon in order to fix a serious **Information Disclosure vulnerability** caused by the erroneous labeling of TLS Private Keys and CSR.

The new file contexts are based upon the official Apache HTTP Server recommended locations (see http://www.apache.com/how-to-setup-an-ssl-certificate-on-apache), have been extended to Debian and Gentoo locations, but might need to be further customized for other possible file locations which might still be exposed to the vulnerability.

RedHat distributions are not affected by this issue, thanks to https://github.com/SELinuxProject/refpolicy/commit/cc91fed88d4cedaa4488f045a2da1132d9aeddca but apparentlly such change was not taken up by other distributions file contexts specifications.

Fixes: https://github.com/SELinuxProject/refpolicy/issues/735

Replaces: https://github.com/SELinuxProject/refpolicy/pull/733

Also fixes the certmonger module so that it can manage the above mentioned secret files.