### PR TITLE
policy/modules/services/smartmon.te: make fstools optional

### DIFF
--- a/policy/modules/services/smartmon.te
+++ b/policy/modules/services/smartmon.te
@@ -143,8 +143,6 @@ corenet_tcp_connect_http_port(smartmon_update_drivedb_t)
 
 files_read_etc_files(smartmon_update_drivedb_t)
 
-fstools_exec(smartmon_update_drivedb_t)
-
 kernel_dontaudit_read_system_state(smartmon_update_drivedb_t)
 
 miscfiles_read_generic_certs(smartmon_update_drivedb_t)
@@ -160,6 +158,10 @@ ifdef(`distro_gentoo',`
 optional_policy(`
 	cron_rw_inherited_system_job_tmp_files(smartmon_update_drivedb_t)
 	cron_system_entry(smartmon_update_drivedb_t, smartmon_update_drivedb_exec_t)
+')
+
+optional_policy(`
+	fstools_exec(smartmon_update_drivedb_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Make fstools optional to avoid the following build failure raised since version 2.20231002 and https://github.com/SELinuxProject/refpolicy/commit/cb068f09d224f90a97fa63a574fb423bbe1ceeda:

```
 Compiling targeted policy.33
 env LD_LIBRARY_PATH="/home/thomas/autobuild/instance-2/output-1/host/lib:/home/thomas/autobuild/instance-2/output-1/host/usr/lib" /home/thomas/autobuild/instance-2/output-1/host/usr/bin/checkpolicy -c 33 -U deny -S -O -E policy.conf -o policy.33
 policy/modules/services/smartmon.te:146:ERROR 'type fsadm_exec_t is not within scope' at token ';' on line 237472:
 	allow smartmon_update_drivedb_t fsadm_exec_t:file { { getattr open map read execute ioctl } ioctl lock execute_no_trans };
 #line 146
 checkpolicy:  error(s) encountered while parsing configuration
 make[1]: *** [Rules.monolithic:80: policy.33] Error 1
```

Fixes:
 - http://autobuild.buildroot.org/results/a01123de9a8c1927060e7e4748666bebfc82ea44