### PR TITLE
Additional file context fix for issue 735 (Information Disclosure vulnerability)

### DIFF
--- a/policy/modules/system/miscfiles.fc
+++ b/policy/modules/system/miscfiles.fc
@@ -60,7 +60,7 @@ ifdef(`distro_redhat',`
 /usr/share/zoneinfo(/.*)?	gen_context(system_u:object_r:locale_t,s0)
 
 /usr/share/ssl/certs(/.*)?	gen_context(system_u:object_r:cert_t,s0)
-/usr/share/ssl/private(/.*)?	gen_context(system_u:object_r:cert_t,s0)
+/usr/share/ssl/private(/.*)?	gen_context(system_u:object_r:tls_privkey_t,s0)
 
 /usr/X11R6/lib/X11/fonts(/.*)?	gen_context(system_u:object_r:fonts_t,s0)
 


### PR DESCRIPTION
Additional file context fix for the following issue: https://github.com/SELinuxProject/refpolicy/issues/735

This patch extends the fix for a serious Information Disclosure vulnerability caused by the erroneous labeling of TLS Private Keys and CSR.

See: https://github.com/SELinuxProject/refpolicy/pull/737/commits/5c9038ec9863463de0eb82badf8f45fb2374780b

---

 policy/modules/system/miscfiles.fc |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)