### PR TITLE
filesystem:Add type contexts and interface for functionfs

### DIFF
--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -360,6 +360,7 @@ files_mountpoint(usbfs_t)
 fs_pseudo_type(usbfs_t)
 genfscon usbfs / gen_context(system_u:object_r:usbfs_t,s0)
 genfscon usbdevfs / gen_context(system_u:object_r:usbfs_t,s0)
+genfscon functionfs / gen_context(system_u:object_r:usbfs_t,s0)
 
 #
 # usb_device_t is the type for /dev/bus/usb/[0-9]+/[0-9]+


### PR DESCRIPTION
When start up adbd by adb initscript, there's a command like: mount -o uid=2000,gid=2000 -t functionfs adb /dev/usb-ffs/adb

will cause below deny because lack of functionfs related contexts.

avc:  denied  { mount } for  pid=346 comm="mount" name="/" dev="functionfs" ino=17700 scontext=system_u:system_r:mount_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=filesystem permissive=1