### PR TITLE
git: add fcontext for default binary

### DIFF
--- a/policy/modules/services/git.fc
+++ b/policy/modules/services/git.fc
@@ -9,6 +9,7 @@ HOME_DIR/\.git-credentials	--	gen_context(system_u:object_r:git_xdg_config_t,s0)
 
 /usr/lib/git-core/git-daemon	--	gen_context(system_u:object_r:gitd_exec_t,s0)
 
+/usr/libexec/git-core/git	--	gen_context(system_u:object_r:git_exec_t,s0)
 /usr/libexec/git-core/git-[^/]+ --	gen_context(system_u:object_r:git_exec_t,s0)
 /usr/libexec/git-core/git-daemon --	gen_context(system_u:object_r:gitd_exec_t,s0)
 


### PR DESCRIPTION
Avoid relabel loops if the helper binaries are hardlinked:

    $ restorecon -vRF -T0 /usr/libexec/
    Relabeled /usr/libexec/git-core/git from system_u:object_r:git_exec_t to system_u:object_r:bin_t
    Relabeled /usr/libexec/git-core/git-rev-parse from system_u:object_r:bin_t to system_u:object_r:git_exec_t
    Relabeled /usr/libexec/git-core/git-fsmonitor--daemon from system_u:object_r:bin_t to system_u:object_r:git_exec_t