### PR TITLE
init: only grant getattr in init_getattr_generic_units_files()

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -3359,7 +3359,7 @@ interface(`init_getattr_generic_units_files',`
 		type systemd_unit_t;
 	')
 
-	allow $1 systemd_unit_t:file read_file_perms;
+	allow $1 systemd_unit_t:file getattr;
 ')
 
 ########################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -519,7 +519,7 @@ init_search_runtime(systemd_generator_t)
 init_setattr_runtime_files(systemd_generator_t)
 init_write_runtime_files(systemd_generator_t)
 init_list_unit_dirs(systemd_generator_t)
-init_getattr_generic_units_files(systemd_generator_t)
+init_read_generic_units_files(systemd_generator_t)
 init_read_generic_units_symlinks(systemd_generator_t)
 init_read_script_files(systemd_generator_t)
 


### PR DESCRIPTION
Like the name suggests only grant the permission getattr in init_getattr_generic_units_files().
Adjust the only caller to use init_read_generic_units_files() instead.

Reported-by: Laurent Bigonville