### PR TITLE
Firewalld need to relabel direct.xml.old file

### DIFF
--- a/policy/modules/services/firewalld.te
+++ b/policy/modules/services/firewalld.te
@@ -43,7 +43,7 @@ allow firewalld_t self:netlink_netfilter_socket create_socket_perms;
 allow firewalld_t firewalld_etc_rw_t:dir watch;
 manage_dirs_pattern(firewalld_t, firewalld_etc_rw_t, firewalld_etc_rw_t)
 manage_files_pattern(firewalld_t, firewalld_etc_rw_t, firewalld_etc_rw_t)
-dontaudit firewalld_t firewalld_etc_rw_t:file { relabelfrom relabelto };
+relabel_files_pattern(firewalld_t, firewalld_etc_rw_t, firewalld_etc_rw_t)
 allow firewalld_t firewalld_etc_rw_t:dir watch;
 
 allow firewalld_t firewalld_var_log_t:file append_file_perms;


### PR DESCRIPTION
firewalld[1084]: Traceback (most recent call last):
                 File "/usr/lib/python3.9/site-packages/firewall/core/io/direct.py", line 372, in write
                   shutil.copy2(self.filename, "%s.old" % self.filename)
                 File "/usr/lib64/python3.9/shutil.py", line 445, in copy2
                   copystat(src, dst, follow_symlinks=follow_symlinks)
                 File "/usr/lib64/python3.9/shutil.py", line 388, in copystat
                   _copyxattr(src, dst, follow_symlinks=follow)
                 File "/usr/lib64/python3.9/shutil.py", line 338, in _copyxattr
                   os.setxattr(dst, name, value, follow_symlinks=follow_symlinks)
                 PermissionError: [Errno 13] Permission denied: '/etc/firewalld/direct.xml.old'

                 During handling of the above exception, another exception occurred:

                 Traceback (most recent call last):
                   File "/usr/lib/python3.9/site-packages/firewall/server/decorators.py", line 67, in _impl
                       return func(*args, **kwargs)
                   File "/usr/lib/python3.9/site-packages/firewall/server/config.py", line 1429, in update
                       self.config.get_direct().write()
                   File "/usr/lib/python3.9/site-packages/firewall/core/io/direct.py", line 374, in write
                        raise IOError("Backup of '%s' failed: %s" % (self.filename, msg))
                   OSError: Backup of '/etc/firewalld/direct.xml' failed: [Errno 13] Permission denied: '/etc/firewalld/direct.xml.old'
firewalld[1084]: ERROR: Backup of file '/etc/firewalld/zones/data.xml' failed: [Errno 13] Permission denied: '/etc/firewalld/zones/data.xml.old'

node=localhost type=AVC msg=audit(1704599676.613:35145): avc:  denied  { relabelfrom } for  pid=1084 comm="firewalld" name="data.xml.old" dev="dm-0" ino=1180472 scontext=system_u:system_r:firewalld_t:s0 tcontext=system_u:object_r:firewalld_etc_rw_t:s0 tclass=file permissive=0
node=loalhost type=AVC msg=audit(1704599677.914:35287): avc:  denied  { relabelfrom } for  pid=1084 comm="firewalld" name="direct.xml.old" dev="dm-0" ino=1180671 scontext=system_u:system_r:firewalld_t:s0 tcontext=system_u:object_r:firewalld_etc_rw_t:s0 tclass=file permissive=0
node=localhost type=AVC msg=audit(1704599788.714:41689): avc:  denied  { relabelfrom } for  pid=1084 comm="firewalld" name="data.xml.old" dev="dm-0" ino=1180472 scontext=system_u:system_r:firewalld_t:s0 tcontext=system_u:object_r:firewalld_etc_rw_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1704599788.714:41689): avc:  denied  { relabelto } for  pid=1084 comm="firewalld" name="data.xml.old" dev="dm-0" ino=1180472 scontext=system_u:system_r:firewalld_t:s0 tcontext=system_u:object_r:firewalld_etc_rw_t:s0 tclass=file permissive=1