### PR TITLE
xguest needs 'systemd --user'

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1156,6 +1156,10 @@ template(`userdom_restricted_xwindows_user_template',`
 		')
 
 		optional_policy(`
+			systemd_role_template($1, $1_r, $1_t)
+		')
+
+		optional_policy(`
 			wm_role_template($1, $1_t, $1_application_exec_domain, $1_r)
 		')
 	')


### PR DESCRIPTION
node=localhost type=AVC msg=audit(1703021456.203:565): avc: denied  { search } for  pid=1247 comm="(systemd)" scontext=system_u:system_r:init_t:s0 tcontext=xguest_u:xguest_r:xguest_t:s0 tclass=key permissive=1
node=localhost type=AVC msg=audit(1703021456.203:565): avc: denied  { link } for  pid=1247 comm="(systemd)" scontext=system_u:system_r:init_t:s0 tcontext=xguest_u:xguest_r:xguest_t:s0 tclass=key permissive=1
node=localhost type=AVC msg=audit(1703021456.282:694): avc: denied  { create } for  pid=1247 comm="systemd" name="systemd" scontext=system_u:system_r:init_t:s0 tcontext=xguest_u:object_r:systemd_user_runtime_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1703021456.283:696): avc: denied  { create } for  pid=1247 comm="systemd" name="fifo" scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=fifo_file permissive=1
node=localhost type=AVC msg=audit(1703021456.283:697): avc: denied  { create } for  pid=1247 comm="systemd" name="sock" scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=sock_file permissive=1
node=localhost type=AVC msg=audit(1703021456.283:698): avc: denied  { create } for  pid=1247 comm="systemd" name="chr" scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=chr_file permissive=1
node=localhost type=AVC msg=audit(1703021456.353:812): avc: denied  { create } for  pid=1247 comm="systemd" name="generator" scontext=system_u:system_r:init_t:s0 tcontext=xguest_u:object_r:systemd_user_runtime_unit_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1703021456.419:901): avc: denied  { remove_name } for  pid=1247 comm="systemd" name="generator" dev="tmpfs" ino=10 scontext=system_u:system_r:init_t:s0 tcontext=xguest_u:object_r:systemd_user_runtime_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1703021456.614:2701): avc: denied  { write } for  pid=1247 comm="systemd" name="private" dev="tmpfs" ino=14 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=sock_file permissive=1
node=localhost type=AVC msg=audit(1703021456.643:3029): avc: denied  { create } for  pid=1247 comm="systemd" name="bus" scontext=system_u:system_r:init_t:s0 tcontext=xguest_u:object_r:session_dbusd_runtime_t:s0 tclass=sock_file permissive=1
node=localhost type=AVC msg=audit(1703021456.644:3032): avc: denied  { write } for  pid=1247 comm="systemd" name="bus" dev="tmpfs" ino=15 scontext=system_u:system_r:init_t:s0 tcontext=xguest_u:object_r:session_dbusd_runtime_t:s0 tclass=sock_file permissive=1
node=localhost type=AVC msg=audit(1703021456.645:3047): avc: denied  { create } for  pid=1247 comm="systemd" name=".#invocation:dbus.socket4c7cde17cb0e7a48" scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=lnk_file permissive=1
node=localhost type=AVC msg=audit(1703021456.645:3048): avc: denied  { remove_name } for  pid=1247 comm="systemd" name=".#invocation:dbus.socket4c7cde17cb0e7a48" dev="tmpfs" ino=16 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1703021456.645:3048): avc: denied  { rename } for  pid=1247 comm="systemd" name=".#invocation:dbus.socket4c7cde17cb0e7a48" dev="tmpfs" ino=16 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=lnk_file permissive=1
node=localhost type=AVC msg=audit(1703021456.771:3266): avc: denied  { write } for  pid=1247 comm="systemd" name="notify" dev="tmpfs" ino=38 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_runtime_notify_t:s0 tclass=sock_file permissive=1
node=localhost type=AVC msg=audit(1703021613.118:6433): avc: denied  { create } for  pid=1247 comm="systemd" name=".#invocation:grub-boot-success.service0d86da059b1d9d72" scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=lnk_file permissive=1
node=localhost type=AVC msg=audit(1703021613.118:6434): avc: denied  { remove_name } for  pid=1247 comm="systemd" name=".#invocation:grub-boot-success.service0d86da059b1d9d72" dev="tmpfs" ino=20 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1703021613.118:6434): avc: denied  { rename } for  pid=1247 comm="systemd" name=".#invocation:grub-boot-success.service0d86da059b1d9d72" dev="tmpfs" ino=20 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=lnk_file permissive=1
node=localhost type=AVC msg=audit(1703021613.141:6469): avc: denied  { unlink } for  pid=1247 comm="systemd" name="invocation:grub-boot-success.service" dev="tmpfs" ino=20 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=lnk_file permissive=1
node=localhost type=AVC msg=audit(1703021793.226:6636): avc: denied  { unlink } for  pid=1247 comm="systemd" name="invocation:systemd-tmpfiles-clean.service" dev="tmpfs" ino=21 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_user_runtime_t:s0 tclass=lnk_file permissive=1