### PR TITLE
SELint updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: SELinuxProject/selint
-        # support exclusions in interface arguments
-        ref: 'v1.3.0'
+        ref: 'v1.5.0'
         path: selint
 
     - name: Build SELint

--- a/policy/modules/apps/chromium.if
+++ b/policy/modules/apps/chromium.if
@@ -136,7 +136,6 @@ interface(`chromium_domtrans',`
 	gen_require(`
 		type chromium_t;
 		type chromium_exec_t;
-		class dbus send_msg;
 	')
 
 	corecmd_search_bin($1)

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -563,7 +563,7 @@ allow kern_unconfined proc_type:file { manage_file_perms relabel_file_perms exec
 allow kern_unconfined sysctl_type:dir { manage_dir_perms relabel_dir_perms append map execute quotaon mounton execmod watch };
 allow kern_unconfined sysctl_type:file { manage_file_perms relabel_file_perms exec_file_perms quotaon mounton watch };
 
-allow kern_unconfined kernel_t:system { ipc_info syslog_read syslog_mod syslog_console module_request module_load halt reboot status start stop enable disable reload };
+allow kern_unconfined kernel_t:system { ipc_info syslog_read syslog_mod syslog_console module_request module_load halt reboot status start stop enable disable reload }; #selint-disable:W-001
 
 allow kern_unconfined unlabeled_t:file { manage_file_perms relabel_file_perms exec_file_perms quotaon mounton watch };
 allow kern_unconfined unlabeled_t:lnk_file  { manage_lnk_file_perms relabel_lnk_file_perms append map execute quotaon mounton open execmod watch };

--- a/policy/modules/services/devicekit.te
+++ b/policy/modules/services/devicekit.te
@@ -57,10 +57,6 @@ optional_policy(`
 	devicekit_dbus_chat_power(devicekit_t)
 ')
 
-optional_policy(`
-	xserver_dbus_chat_xdm(devicekit_power_t)
-')
-
 ########################################
 #
 # Disk local policy
@@ -303,6 +299,10 @@ optional_policy(`
 
 	optional_policy(`
 		rpm_dbus_chat(devicekit_power_t)
+	')
+
+	optional_policy(`
+		xserver_dbus_chat_xdm(devicekit_power_t)
 	')
 ')
 

--- a/policy/modules/services/devicekit.te
+++ b/policy/modules/services/devicekit.te
@@ -53,7 +53,8 @@ miscfiles_read_localization(devicekit_t)
 optional_policy(`
 	dbus_system_bus_client(devicekit_t)
 
-	allow devicekit_t { devicekit_disk_t devicekit_power_t }:dbus send_msg;
+	devicekit_dbus_chat_disk(devicekit_t)
+	devicekit_dbus_chat_power(devicekit_t)
 ')
 
 optional_policy(`
@@ -153,8 +154,6 @@ userdom_search_user_home_dirs(devicekit_disk_t)
 
 optional_policy(`
 	dbus_system_bus_client(devicekit_disk_t)
-
-	allow devicekit_disk_t devicekit_t:dbus send_msg;
 
 	optional_policy(`
 		policykit_dbus_chat(devicekit_disk_t)
@@ -293,8 +292,6 @@ optional_policy(`
 optional_policy(`
 	dbus_system_bus_client(devicekit_power_t)
 	init_dbus_chat(devicekit_power_t)
-
-	allow devicekit_power_t devicekit_t:dbus send_msg;
 
 	optional_policy(`
 		networkmanager_dbus_chat(devicekit_power_t)

--- a/policy/modules/services/postgresql.if
+++ b/policy/modules/services/postgresql.if
@@ -28,13 +28,11 @@
 #
 template(`postgresql_role',`
 	gen_require(`
-		class db_database all_db_database_perms;
 		class db_schema all_db_schema_perms;
 		class db_table all_db_table_perms;
 		class db_sequence all_db_sequence_perms;
 		class db_view all_db_view_perms;
 		class db_procedure all_db_procedure_perms;
-		class db_language all_db_language_perms;
 		class db_column all_db_column_perms;
 		class db_tuple all_db_tuple_perms;
 		class db_blob all_db_blob_perms;
@@ -462,13 +460,11 @@ interface(`postgresql_stream_connect',`
 #
 interface(`postgresql_unpriv_client',`
 	gen_require(`
-		class db_database all_db_database_perms;
 		class db_schema all_db_schema_perms;
 		class db_table all_db_table_perms;
 		class db_sequence all_db_sequence_perms;
 		class db_view all_db_view_perms;
 		class db_procedure all_db_procedure_perms;
-		class db_language all_db_language_perms;
 		class db_column all_db_column_perms;
 		class db_tuple all_db_tuple_perms;
 		class db_blob all_db_blob_perms;

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -367,7 +367,7 @@ template(`xserver_common_x_domain_template',`
 		attribute input_xevent_type;
 
 		class x_drawable all_x_drawable_perms;
-		class x_property all_x_property_perms;
+		#class x_property all_x_property_perms;
 		class x_event all_x_event_perms;
 		class x_synthetic_event all_x_synthetic_event_perms;
 	')

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1186,6 +1186,7 @@ interface(`init_dontaudit_search_keys',`
 #
 interface(`init_start_system',`
 	gen_require(`
+		class system { start };
 		type init_t;
 	')
 
@@ -1204,6 +1205,7 @@ interface(`init_start_system',`
 #
 interface(`init_stop_system',`
 	gen_require(`
+		class system { stop };
 		type init_t;
 	')
 
@@ -1222,6 +1224,7 @@ interface(`init_stop_system',`
 #
 interface(`init_get_system_status',`
 	gen_require(`
+		class system { status };
 		type init_t;
 	')
 
@@ -1240,6 +1243,7 @@ interface(`init_get_system_status',`
 #
 interface(`init_enable',`
 	gen_require(`
+		class system { enable };
 		type init_t;
 	')
 
@@ -1258,6 +1262,7 @@ interface(`init_enable',`
 #
 interface(`init_disable',`
 	gen_require(`
+		class system { disable };
 		type init_t;
 	')
 
@@ -1276,6 +1281,7 @@ interface(`init_disable',`
 #
 interface(`init_reload',`
 	gen_require(`
+		class system { reload };
 		type init_t;
 	')
 
@@ -1294,6 +1300,7 @@ interface(`init_reload',`
 #
 interface(`init_reboot_system',`
 	gen_require(`
+		class system { reboot };
 		type init_t;
 	')
 
@@ -1312,6 +1319,7 @@ interface(`init_reboot_system',`
 #
 interface(`init_shutdown_system',`
 	gen_require(`
+		class system { halt };
 		type init_t;
 	')
 
@@ -1390,7 +1398,6 @@ interface(`init_dbus_chat',`
 interface(`init_run_bpf',`
 	gen_require(`
 		type init_t;
-		class bpf prog_run;
 	')
 
 	allow $1 init_t:bpf prog_run;

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -258,6 +258,11 @@ seutil_read_default_contexts(init_t)
 miscfiles_read_localization(init_t)
 
 ifdef(`init_systemd',`
+	gen_require(`
+		class service { status start stop };
+		class system { status reboot halt reload };
+	')
+
 	# handle instances where an old labeled init script is encountered.
 	typeattribute init_t init_run_all_scripts_domain;
 
@@ -1113,6 +1118,10 @@ ifdef(`enable_mls',`
 ')
 
 ifdef(`init_systemd',`
+	gen_require(`
+		class service { stop start status reload };
+		class system { start stop status reboot halt reload };
+	')
 	allow initrc_t init_t:system { start stop status reboot halt reload };
 
 	manage_files_pattern(initrc_t, initrc_lock_t, initrc_lock_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -22,6 +22,8 @@
 #
 template(`systemd_role_template',`
 	gen_require(`
+		class service { reload start status stop };
+		class system { disable enable reload start stop status };
 		attribute systemd_user_session_type, systemd_log_parse_env_type;
 		attribute systemd_user_activated_sock_file_type, systemd_user_unix_stream_activated_socket_type;
 		type systemd_analyze_exec_t;
@@ -407,6 +409,7 @@ template(`systemd_read_user_manager_state',`
 #
 template(`systemd_user_manager_system_start',`
 	gen_require(`
+		class system { start };
 		type $1_systemd_t;
 	')
 
@@ -431,6 +434,7 @@ template(`systemd_user_manager_system_start',`
 #
 template(`systemd_user_manager_system_stop',`
 	gen_require(`
+		class system { stop };
 		type $1_systemd_t;
 	')
 
@@ -455,6 +459,7 @@ template(`systemd_user_manager_system_stop',`
 #
 template(`systemd_user_manager_system_status',`
 	gen_require(`
+		class system { status };
 		type $1_systemd_t;
 	')
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1095,6 +1095,10 @@ optional_policy(`
 
 	dbus_connect_system_bus(systemd_machined_t)
 	dbus_system_bus_client(systemd_machined_t)
+
+	optional_policy(`
+		unconfined_dbus_send(systemd_machined_t)
+	')
 ')
 
 ########################################
@@ -1375,10 +1379,6 @@ optional_policy(`
 	dbus_system_bus_client(systemd_nspawn_t)
 
 	systemd_dbus_chat_machined(systemd_nspawn_t)
-
-	optional_policy(`
-		unconfined_dbus_send(systemd_machined_t)
-	')
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1247,8 +1247,6 @@ allow systemd_nspawn_t self:udp_socket create_socket_perms;
 
 allow systemd_nspawn_t systemd_journal_t:dir search;
 
-allow systemd_nspawn_t systemd_machined_t:dbus send_msg;
-
 allow systemd_nspawn_t systemd_nspawn_runtime_t:dir manage_dir_perms;
 allow systemd_nspawn_t systemd_nspawn_runtime_t:file manage_file_perms;
 init_runtime_filetrans(systemd_nspawn_t, systemd_nspawn_runtime_t, dir)
@@ -1374,9 +1372,9 @@ tunable_policy(`systemd_nspawn_labeled_namespace',`
 ')
 
 optional_policy(`
-	allow systemd_machined_t systemd_nspawn_t:dbus send_msg;
-
 	dbus_system_bus_client(systemd_nspawn_t)
+
+	systemd_dbus_chat_machined(systemd_nspawn_t)
 
 	optional_policy(`
 		unconfined_dbus_send(systemd_machined_t)

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -31,7 +31,6 @@ interface(`unconfined_domain_noaudit',`
 		class dbus all_dbus_perms;
 		class nscd all_nscd_perms;
 		class passwd all_passwd_perms;
-		class service all_service_perms;
 	')
 
 	unconfined_stub($1)

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -56,6 +56,10 @@ ifdef(`direct_sysadm_daemon',`
 ')
 
 ifdef(`init_systemd',`
+	gen_require(`
+		class system { status start stop reload };
+	')
+
 	# for systemd-analyze
 	init_service_status(unconfined_t)
 	# for systemd --user:


### PR DESCRIPTION
* Bump SELint to version 1.5

* userspace class declaration tweaks for SELint 1.5

  SELint version 1.5 emits issues for missing or unused declarations of userspace classes:

      init.te:            270: (W): No explicit declaration for userspace class system.  You should access it via interface call or use a require block. (W-001)
      init.te:            312: (W): No explicit declaration for userspace class service.  You should access it via interface call or use a require block. (W-001)
      init.te:           1116: (W): No explicit declaration for userspace class system.  You should access it via interface call or use a require block. (W-001)
      init.te:           1124: (W): No explicit declaration for userspace class service.  You should access it via interface call or use a require block. (W-001)
      init.te:           1132: (W): No explicit declaration for userspace class service.  You should access it via interface call or use a require block. (W-001)
      init.te:           1136: (W): No explicit declaration for userspace class service.  You should access it via interface call or use a require block. (W-001)
      init.te:           1137: (W): No explicit declaration for userspace class service.  You should access it via interface call or use a require block. (W-001)
      unconfined.te:       64: (W): No explicit declaration for userspace class system.  You should access it via interface call or use a require block. (W-001)
      systemd.te:        1250: (W): No explicit declaration for userspace class dbus.  You should access it via interface call or use a require block. (W-001)
      systemd.te:        1377: (W): No explicit declaration for userspace class dbus.  You should access it via interface call or use a require block. (W-001)
      devicekit.te:        56: (W): No explicit declaration for userspace class dbus.  You should access it via interface call or use a require block. (W-001)
      devicekit.te:       157: (W): No explicit declaration for userspace class dbus.  You should access it via interface call or use a require block. (W-001)
      devicekit.te:       297: (W): No explicit declaration for userspace class dbus.  You should access it via interface call or use a require block. (W-001)
      kernel.te:          566: (W): No explicit declaration for userspace class system.  You should access it via interface call or use a require block. (W-001)
      chromium.if:        139: (W): Class dbus is listed in require block but not used in interface (W-003)
      init.if:           1192: (W): Class system is used in interface but not required (W-002)
      init.if:           1210: (W): Class system is used in interface but not required (W-002)
      init.if:           1228: (W): Class system is used in interface but not required (W-002)
      init.if:           1246: (W): Class system is used in interface but not required (W-002)
      init.if:           1264: (W): Class system is used in interface but not required (W-002)
      init.if:           1282: (W): Class system is used in interface but not required (W-002)
      init.if:           1300: (W): Class system is used in interface but not required (W-002)
      init.if:           1318: (W): Class system is used in interface but not required (W-002)
      init.if:           1393: (W): Class bpf is listed in require block but is not a userspace class (W-003)
      unconfined.if:       34: (W): Class service is listed in require block but not used in interface (W-003)
      systemd.if:         144: (W): Class system is used in interface but not required (W-002)
      systemd.if:         159: (W): Class service is used in interface but not required (W-002)
      systemd.if:         160: (W): Class service is used in interface but not required (W-002)
      systemd.if:         413: (W): Class system is used in interface but not required (W-002)
      systemd.if:         437: (W): Class system is used in interface but not required (W-002)
      systemd.if:         461: (W): Class system is used in interface but not required (W-002)
      postgresql.if:       31: (W): Class db_database is listed in require block but not used in interface (W-003)
      postgresql.if:       37: (W): Class db_language is listed in require block but not used in interface (W-003)
      postgresql.if:      465: (W): Class db_database is listed in require block but not used in interface (W-003)
      postgresql.if:      471: (W): Class db_language is listed in require block but not used in interface (W-003)
      xserver.if:         370: (W): Class x_property is listed in require block but not used in interface (W-003)
      Found the following issue counts:
      W-001: 14
      W-002: 14
      W-003: 8

* Two trivial reorderings