### PR TITLE
Needed to allow environment variable to process started (for cockpit)

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -376,6 +376,7 @@ interface(`init_daemon_domain',`
 
 		allow $1 init_t:unix_dgram_socket sendto;
 
+		allow init_t $1:process noatsecure;
 		allow init_t $1:process2 { nnp_transition nosuid_transition };
 
 		optional_policy(`


### PR DESCRIPTION
Dec 05 22:41:49 localhost.localdomain cockpit-tls[7887]: cockpit-tls: $RUNTIME_DIRECTORY environment variable must be set to a private directory
Dec 05 22:41:49 localhost.localdomain systemd[1]: cockpit.service: Main process exited, code=exited, status=1/FAILURE
Dec 05 22:41:49 localhost.localdomain systemd[1]: cockpit.service: Failed with result 'exit-code'.