### PR TITLE
Add support for rook-ceph in kubernetes

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -608,6 +608,25 @@ interface(`dev_delete_generic_blk_files',`
 
 ########################################
 ## <summary>
+##	Dontaudit relabelto the generic device
+##	type on block files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`dev_dontaudit_relabelto_generic_blk_files',`
+	gen_require(`
+		type device_t;
+	')
+
+	dontaudit $1 device_t:blk_file relabelto;
+')
+
+########################################
+## <summary>
 ##	Allow getattr for generic character device files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -3237,6 +3237,46 @@ interface(`fs_manage_fusefs_chr_files',`
 
 ########################################
 ## <summary>
+##	Create block files on a FUSEFS
+##	filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_create_fusefs_blk_files',`
+	gen_require(`
+		type fusefs_t;
+	')
+
+	allow $1 fusefs_t:blk_file create_blk_file_perms;
+')
+
+########################################
+## <summary>
+##	Set the attributes of block files on
+##	a FUSEFS filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_setattr_fusefs_blk_files',`
+	gen_require(`
+		type fusefs_t;
+	')
+
+	allow $1 fusefs_t:blk_file setattr_blk_file_perms;
+')
+
+########################################
+## <summary>
 ##	Get the attributes of an hugetlbfs
 ##	filesystem.
 ## </summary>

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -515,6 +515,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	storage_dontaudit_read_fixed_disk(kernel_t)
+')
+
+optional_policy(`
 	unconfined_domain_noaudit(kernel_t)
 ')
 

--- a/policy/modules/services/container.fc
+++ b/policy/modules/services/container.fc
@@ -103,6 +103,9 @@ HOME_DIR/\.docker(/.*)?		gen_context(system_u:object_r:container_conf_home_t,s0)
 /var/lib/etcd(/.*)?             gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/kube-proxy(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
 
+/var/lib/rook(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
+/var/lib/rook/rook-ceph/[^/]+/[^/]+/block	-b	gen_context(system_u:object_r:container_device_t,s0)
+
 /var/local-path-provisioner(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
 
 /var/log/containerd(/.*)?		gen_context(system_u:object_r:container_log_t,s0)

--- a/policy/modules/services/container.if
+++ b/policy/modules/services/container.if
@@ -923,6 +923,25 @@ interface(`container_manage_device_files',`
 
 ########################################
 ## <summary>
+##	Get the attributes of container device
+##	block files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_getattr_device_blk_files',`
+	gen_require(`
+		type container_device_t;
+	')
+
+	allow $1 container_device_t:blk_file getattr;
+')
+
+########################################
+## <summary>
 ##	Read container device block files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/container.if
+++ b/policy/modules/services/container.if
@@ -923,6 +923,24 @@ interface(`container_manage_device_files',`
 
 ########################################
 ## <summary>
+##	Read container device block files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_read_device_blk_files',`
+	gen_require(`
+		type container_device_t;
+	')
+
+	allow $1 container_device_t:blk_file read_blk_file_perms;
+')
+
+########################################
+## <summary>
 ##	Mount on all container devices.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -304,7 +304,7 @@ manage_fifo_files_pattern(container_domain, container_file_t, container_file_t)
 rw_chr_files_pattern(container_domain, container_file_t, container_file_t)
 rw_blk_files_pattern(container_domain, container_file_t, container_file_t)
 allow container_domain container_file_t:dir_file_class_set watch;
-allow container_domain container_file_t:file { entrypoint map };
+allow container_domain container_file_t:file { relabel_file_perms entrypoint map };
 allow container_domain container_file_t:chr_file map;
 
 allow container_domain container_ro_file_t:blk_file read_blk_file_perms;
@@ -469,6 +469,15 @@ optional_policy(`
 	virt_virsh_use_fds(container_domain)
 	virt_virsh_rw_pipes(container_domain)
 	virt_virsh_sigchld(container_domain)
+')
+
+########################################
+#
+# Common container system domain local policy
+#
+
+optional_policy(`
+	kubernetes_read_container_engine_state(container_system_domain)
 ')
 
 ########################################
@@ -957,9 +966,13 @@ domtrans_pattern(container_engine_system_domain, container_ro_file_t, spc_t)
 domtrans_pattern(container_engine_system_domain, container_var_lib_t, spc_t)
 
 allow spc_t self:process { getcap setrlimit };
-allow spc_t self:capability { audit_write chown dac_read_search fowner fsetid net_admin net_raw sys_admin sys_chroot sys_ptrace sys_rawio sys_resource };
+# Normally triggered when rook-ceph executes lvm tools which creates noise.
+# This can be allowed if actually needed.
+dontaudit spc_t self:process setfscreate;
+allow spc_t self:capability { audit_write chown dac_read_search fowner fsetid ipc_lock mknod net_admin net_raw setpcap sys_admin sys_chroot sys_nice sys_ptrace sys_rawio sys_resource };
 allow spc_t self:capability2 { bpf perfmon };
 allow spc_t self:bpf { map_create map_read map_write prog_load prog_run };
+allow spc_t self:key manage_key_perms;
 allow spc_t self:alg_socket create_stream_socket_perms;
 allow spc_t self:netlink_audit_socket { create_netlink_socket_perms nlmsg_relay };
 allow spc_t self:netlink_generic_socket create_socket_perms;
@@ -979,24 +992,43 @@ allow spc_t container_engine_system_domain:fifo_file rw_fifo_file_perms;
 allow spc_t container_engine_tmpfs_t:dir list_dir_perms;
 allow spc_t container_engine_tmpfs_t:chr_file rw_chr_file_perms;
 allow spc_t container_engine_tmpfs_t:lnk_file read_lnk_file_perms;
+# for rook-ceph
+allow spc_t container_engine_tmpfs_t:blk_file rw_blk_file_perms;
 
 # for kubernetes storage class providers
 allow spc_t container_file_t:{ dir file } mounton;
-allow spc_t container_file_t:dir_file_class_set { relabelfrom relabelto };
+allow spc_t container_file_t:dir_file_class_set relabel_blk_file_perms;
+# for rook-ceph
+allow spc_t container_file_t:blk_file manage_blk_file_perms;
 
 allow spc_t container_runtime_t:dir { manage_dir_perms mounton };
 allow spc_t container_runtime_t:file manage_file_perms;
 allow spc_t container_runtime_t:sock_file manage_sock_file_perms;
 
+# for rook-ceph
+allow spc_t container_device_t:file manage_file_perms;
+allow spc_t container_device_t:blk_file { manage_blk_file_perms relabel_blk_file_perms };
+fs_tmpfs_filetrans(spc_t, container_device_t, blk_file)
+
+dev_read_rand(spc_t)
 dev_mount_sysfs(spc_t)
 dev_unmount_sysfs(spc_t)
 dev_remount_sysfs(spc_t)
 dev_mounton_sysfs_dirs(spc_t)
 dev_read_sysfs(spc_t)
+# for rook-ceph
+dev_rw_lvm_control(spc_t)
+dev_rw_generic_blk_files(spc_t)
+dev_write_sysfs(spc_t)
+dev_filetrans(spc_t, container_device_t, blk_file)
+dev_dontaudit_getattr_all_chr_files(spc_t)
+dev_dontaudit_setattr_generic_symlinks(spc_t)
+dev_dontaudit_relabelto_generic_blk_files(spc_t)
 
 fs_read_nsfs_files(spc_t)
 fs_mount_xattr_fs(spc_t)
 fs_unmount_xattr_fs(spc_t)
+fs_remount_xattr_fs(spc_t)
 fs_mount_cgroup(spc_t)
 fs_mounton_cgroup(spc_t)
 fs_manage_cgroup_dirs(spc_t)
@@ -1006,15 +1038,23 @@ fs_create_bpf_dirs(spc_t)
 fs_manage_bpf_files(spc_t)
 fs_manage_bpf_symlinks(spc_t)
 fs_unmount_nsfs(spc_t)
+fs_mount_tmpfs(spc_t)
 fs_list_tmpfs(spc_t)
 fs_watch_tmpfs_dirs(spc_t)
+fs_create_fusefs_blk_files(spc_t)
+fs_setattr_fusefs_blk_files(spc_t)
 
+kernel_get_sysvipc_info(spc_t)
 kernel_load_module(spc_t)
 kernel_request_load_module(spc_t)
 kernel_read_network_state(spc_t)
 kernel_read_vm_overcommit_sysctl(spc_t)
 kernel_rw_kernel_sysctl(spc_t)
 kernel_dontaudit_list_unlabeled(spc_t)
+# for rook-ceph when provisioning volumes
+kernel_read_state(spc_t)
+kernel_setsched(spc_t)
+kernel_getattr_unlabeled_dirs(spc_t)
 
 storage_raw_rw_fixed_disk(spc_t)
 
@@ -1025,10 +1065,19 @@ init_write_runtime_socket(spc_t)
 
 iptables_read_runtime_files(spc_t)
 
+# rook-ceph enumerates LVM devices
+lvm_read_config(spc_t)
+lvm_manage_lock_files(spc_t)
+lvm_manage_runtime_files(spc_t)
+
 modutils_read_module_deps(spc_t)
+
+mount_manage_runtime_files(spc_t)
 
 # for kubernetes debug pods
 term_use_generic_ptys(spc_t)
+
+container_read_all_container_state(spc_t)
 
 container_manage_config_files(spc_t)
 
@@ -1097,6 +1146,9 @@ optional_policy(`
 	kubernetes_watch_runtime_files(spc_t)
 	kubernetes_manage_runtime_symlinks(spc_t)
 	kubernetes_manage_runtime_sock_files(spc_t)
+
+	# for rook-ceph
+	kubernetes_dontaudit_search_engine_keys(spc_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/kubernetes.if
+++ b/policy/modules/services/kubernetes.if
@@ -302,6 +302,44 @@ interface(`kubernetes_mountpoint',`
 
 ########################################
 ## <summary>
+##	Read the process state (/proc/pid) of
+##	kubernetes container engines.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kubernetes_read_container_engine_state',`
+	gen_require(`
+		attribute kubernetes_container_engine_domain;
+	')
+
+	ps_process_pattern($1, kubernetes_container_engine_domain, kubernetes_container_engine_domain)
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to search
+##	kubernetes container engine keys.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`kubernetes_dontaudit_search_engine_keys',`
+	gen_require(`
+		attribute kubernetes_container_engine_domain;
+	')
+
+	dontaudit $1 kubernetes_container_engine_domain:key search;
+')
+
+########################################
+## <summary>
 ##	Allow the specified domain to
 ##	get the process group ID of all
 ##	kubernetes containers.

--- a/policy/modules/services/kubernetes.te
+++ b/policy/modules/services/kubernetes.te
@@ -78,6 +78,9 @@ ps_process_pattern(kubernetes_container_engine_domain, kubernetes_container_doma
 # for kubectl port-forward
 corenet_tcp_connect_all_ports(kubernetes_container_engine_domain)
 
+# for rook-ceph
+dev_create_generic_blk_files(kubernetes_container_engine_domain)
+
 files_getattr_kernel_modules(kubernetes_container_engine_domain)
 # for replicated storage that may be mounted in /mnt
 files_search_mnt(kubernetes_container_engine_domain)
@@ -90,6 +93,9 @@ fs_manage_fusefs_sock_files(kubernetes_container_engine_domain)
 fs_manage_fusefs_symlinks(kubernetes_container_engine_domain)
 fs_mounton_tmpfs(kubernetes_container_engine_domain)
 fs_relabelfrom_tmpfs_dirs(kubernetes_container_engine_domain)
+# for rook-ceph
+fs_create_fusefs_blk_files(kubernetes_container_engine_domain)
+fs_setattr_fusefs_blk_files(kubernetes_container_engine_domain)
 
 # for relabeling newly provisioned persistent volumes
 kernel_list_unlabeled(kubernetes_container_engine_domain)
@@ -294,6 +300,7 @@ kernel_rw_net_sysctls(kubelet_t)
 kernel_rw_vm_overcommit_sysctl(kubelet_t)
 
 storage_getattr_fixed_disk_dev(kubelet_t)
+storage_dontaudit_read_fixed_disk(kubelet_t)
 
 auth_use_nsswitch(kubelet_t)
 
@@ -302,6 +309,8 @@ init_read_state(kubelet_t)
 iptables_domtrans(kubelet_t)
 iptables_getattr_runtime_files(kubelet_t)
 iptables_read_state(kubelet_t)
+
+fstools_domtrans(kubelet_t)
 
 logging_send_syslog_msg(kubelet_t)
 
@@ -328,6 +337,7 @@ dbus_list_system_bus_runtime(kubelet_t)
 dbus_system_bus_client(kubelet_t)
 
 container_read_config(kubelet_t)
+container_getattr_device_blk_files(kubelet_t)
 container_getattr_fs(kubelet_t)
 # read /run/docker.pid
 container_read_runtime_files(kubelet_t)

--- a/policy/modules/system/fstools.te
+++ b/policy/modules/system/fstools.te
@@ -201,6 +201,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	container_read_device_blk_files(fsadm_t)
+')
+
+optional_policy(`
 	# for smartctl cron jobs
 	cron_system_entry(fsadm_t, fsadm_exec_t)
 ')

--- a/policy/modules/system/fstools.te
+++ b/policy/modules/system/fstools.te
@@ -138,6 +138,8 @@ fs_list_auto_mountpoints(fsadm_t)
 fs_search_tmpfs(fsadm_t)
 fs_getattr_tmpfs_dirs(fsadm_t)
 fs_read_tmpfs_symlinks(fsadm_t)
+# for kubernetes if kubelet calls losetup
+fs_ioctl_cgroup_dirs(fsadm_t)
 # for fstrim
 files_manage_boot_dirs(fsadm_t)
 # Recreate /mnt/cdrom.

--- a/policy/modules/system/lvm.if
+++ b/policy/modules/system/lvm.if
@@ -172,6 +172,44 @@ interface(`lvm_create_lock_dirs',`
 	files_add_entry_lock_dirs($1)
 ')
 
+########################################
+## <summary>
+##	Manage lvm_lock_t files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`lvm_manage_lock_files',`
+	gen_require(`
+		type lvm_lock_t;
+	')
+
+	manage_files_pattern($1, lvm_lock_t, lvm_lock_t)
+')
+
+########################################
+## <summary>
+##	Manage LVM runtime files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`lvm_manage_runtime_files',`
+	gen_require(`
+		type lvm_runtime_t;
+	')
+
+	manage_files_pattern($1, lvm_runtime_t, lvm_runtime_t)
+')
+
 ######################################
 ## <summary>
 ##	All of the rules required to

--- a/policy/modules/system/mount.if
+++ b/policy/modules/system/mount.if
@@ -326,3 +326,21 @@ interface(`mount_rw_runtime_files',`
 
 	rw_files_pattern($1, mount_runtime_t, mount_runtime_t)
 ')
+
+########################################
+## <summary>
+##	Manage mount runtime files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`mount_manage_runtime_files',`
+	gen_require(`
+		type mount_runtime_t;
+	')
+
+	manage_files_pattern($1, mount_runtime_t, mount_runtime_t)
+')

--- a/policy/modules/system/mount.te
+++ b/policy/modules/system/mount.te
@@ -26,6 +26,10 @@ fs_image_file(mount_loopback_t)
 type mount_runtime_t;
 files_runtime_file(mount_runtime_t)
 
+optional_policy(`
+	kubernetes_mountpoint(mount_runtime_t)
+')
+
 type mount_tmp_t;
 files_tmp_file(mount_tmp_t)
 


### PR DESCRIPTION
Various fixes which allows rook-ceph to operate using the kubernetes policy.