### PR TITLE
systemd: allow systemd-logind to inherit local login file descriptors

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -961,6 +961,7 @@ init_stop_system(systemd_logind_t)
 miscfiles_read_localization(systemd_logind_t)
 
 locallogin_read_state(systemd_logind_t)
+locallogin_use_fds(systemd_logind_t)
 
 seutil_libselinux_linked(systemd_logind_t)
 seutil_read_default_contexts(systemd_logind_t)


### PR DESCRIPTION
Fix reboot timeout error:
$ reboot
Failed to set wall message, ignoring: Failed to activate service 'org.freedesktop.login1': timed out (service_start_timeout=25000ms) Call to Reboot failed: Failed to activate service 'org.freedesktop.login1': timed out (service_start_timeout=25000ms)

avc:  denied  { use } for  pid=287 comm="systemd-logind" path="anon_inode:[pidfd]" dev="anon_inodefs" ino=1044 scontext=system_u:system_r:systemd_logind_t
tcontext=system_u:system_r:local_login_t tclass=fd permissive=0