### PR TITLE
filesystem: Add labeling for pidfs.

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -165,6 +165,10 @@ type oprofilefs_t;
 fs_type(oprofilefs_t)
 genfscon oprofilefs / gen_context(system_u:object_r:oprofilefs_t,s0)
 
+type pidfs_t;
+fs_type(pidfs_t)
+genfscon pidfs_t / gen_context(system_u:object_r:pidfs_t,s0)
+
 type pstore_t;
 fs_type(pstore_t)
 files_mountpoint(pstore_t)


### PR DESCRIPTION
Add task SID labeling for `pidfs`, which is the new backing pseudo filesystem for `pidfd`s.

The existing rules will allow domains to open pidfds and use them internally, but other domains will require additional access (`fd` and `file`) when passing around the pidfd.