### PR TITLE
libraries: drop space in empty line

### DIFF
--- a/policy/modules/system/libraries.fc
+++ b/policy/modules/system/libraries.fc
@@ -281,7 +281,7 @@ HOME_DIR/\.mozilla/plugins/nprhapengine\.so.* --	gen_context(system_u:object_r:t
 /usr/lib/acroread/.+\.api		--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/lib/acroread/(.*/)?ADMPlugin\.apl	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/lib/.*/program(/.*)?\.so			gen_context(system_u:object_r:lib_t,s0)
-') dnl end distro_redhat
+')dnl end distro_redhat
 
 #
 # /var


### PR DESCRIPTION
Drop a line containing a single space from the file context file to avoid SELint stumble on it:

    libraries.mod.fc:   130: (E): Bad file context format (E-002)