### PR TITLE
files context for merged-usr profile on gentoo

### DIFF
--- a/policy/modules/admin/netutils.fc
+++ b/policy/modules/admin/netutils.fc
@@ -20,3 +20,7 @@
 /usr/sbin/send_arp	--	gen_context(system_u:object_r:ping_exec_t,s0)
 /usr/sbin/tcpdump	--	gen_context(system_u:object_r:netutils_exec_t,s0)
 /usr/sbin/traceroute.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)
+
+ifdef(`distro_gentoo',`
+/usr/bin/iftop		--	gen_context(system_u:object_r:netutils_exec_t,s0)
+')

--- a/policy/modules/admin/shutdown.fc
+++ b/policy/modules/admin/shutdown.fc
@@ -9,3 +9,8 @@
 /usr/sbin/shutdown	--	gen_context(system_u:object_r:shutdown_exec_t,s0)
 
 /run/shutdown\.pid	--	gen_context(system_u:object_r:shutdown_runtime_t,s0)
+
+ifdef(`distro_gentoo',`
+/usr/bin/halt		--	gen_context(system_u:object_r:shutdown_exec_t,s0)
+/usr/bin/shutdown	--	gen_context(system_u:object_r:shutdown_exec_t,s0)
+')

--- a/policy/modules/services/smartmon.fc
+++ b/policy/modules/services/smartmon.fc
@@ -8,3 +8,7 @@
 /run/smartd\.pid	--	gen_context(system_u:object_r:fsdaemon_runtime_t,s0)
 
 /var/lib/smartmontools(/.*)?	gen_context(system_u:object_r:fsdaemon_var_lib_t,s0)
+
+ifdef(`distro_gentoo',`
+/usr/bin/update-smart-drivedb	--	gen_context(system_u:object_r:smartmon_update_drivedb_exec_t,s0)
+')

--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -40,6 +40,9 @@ ifdef(`distro_redhat', `
 ifdef(`distro_suse', `
 /usr/sbin/unix2_chkpwd	--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
 ')
+ifdef(`distro_gentoo',`
+/usr/bin/pwhistory_helper	--	gen_context(system_u:object_r:updpwd_exec_t,s0)
+')
 
 /var/cache/coolkey(/.*)?	gen_context(system_u:object_r:auth_cache_t,s0)
 

--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -53,6 +53,10 @@ ifdef(`distro_gentoo',`
 /usr/sbin/upstart	--	gen_context(system_u:object_r:init_exec_t,s0)
 
 ifdef(`distro_gentoo', `
+/usr/bin/rc			--	gen_context(system_u:object_r:rc_exec_t,s0)
+/usr/bin/openrc			--	gen_context(system_u:object_r:rc_exec_t,s0)
+/usr/bin/openrc-init		--	gen_context(system_u:object_r:init_exec_t,s0)
+/usr/bin/openrc-shutdown	--	gen_context(system_u:object_r:init_exec_t,s0)
 /usr/lib/rc/cache(/.*)?		gen_context(system_u:object_r:initrc_state_t,s0)
 /usr/lib/rc/console(/.*)?		gen_context(system_u:object_r:initrc_state_t,s0)
 /usr/lib/rc/init\.d(/.*)?		gen_context(system_u:object_r:initrc_state_t,s0)

--- a/policy/modules/system/lvm.fc
+++ b/policy/modules/system/lvm.fc
@@ -74,6 +74,10 @@
 /usr/bin/vgsplit		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/bin/vgwrapper		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 
+ifdef(`distro_gentoo',`
+/usr/bin/dmeventd		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+')
+
 /usr/lib/lvm-10/.*				--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/lib/lvm-200/.*				--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/lib/systemd/systemd-cryptsetup		--	gen_context(system_u:object_r:lvm_exec_t,s0)


### PR DESCRIPTION
As per https://wiki.gentoo.org/wiki/Merge-usr  new gentoo profiles use merged-usr by default.
That also means: "/sbin and /usr/sbin are both actually merged to /usr/bin"
Hence these updates on files context.