### PR TITLE
systemd: allow notify client to stat socket

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -322,7 +322,7 @@ interface(`systemd_write_notify_socket',`
 
 	init_list_runtime($1)
 	init_unix_stream_socket_sendto($1)
-	allow $1 systemd_runtime_notify_t:sock_file write;
+	allow $1 systemd_runtime_notify_t:sock_file write_sock_file_perms;
 ')
 
 ######################################


### PR DESCRIPTION
Caused by the latest openssh version in Debian sid:

    AVC avc:  denied  { getattr } for  pid=13544 comm="sshd" path="/run/systemd/notify" dev="tmpfs" ino=286 scontext=system_u:system_r:sshd_t:s0 tcontext=system_u:object_r:systemd_runtime_notify_t:s0 tclass=sock_file permissive=0