### PR TITLE
Set correct type on /etc/machine-info to net_conf_t

### DIFF
--- a/policy/modules/system/sysnetwork.fc
+++ b/policy/modules/system/sysnetwork.fc
@@ -20,6 +20,7 @@ ifdef(`distro_debian',`
 /etc/hosts\.deny.*	--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/hostname		--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/denyhosts.*	--	gen_context(system_u:object_r:net_conf_t,s0)
+/etc/machine-info	--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/resolv\.conf.*	--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/yp\.conf.*		--	gen_context(system_u:object_r:net_conf_t,s0)
 


### PR DESCRIPTION
Set the type on /etc/machine-info to net_conf_t so hostnamectl can manipulate it (CRUD)

When attempting to set the PRETTY_HOSTNAME (e.g. hostnamectl --pretty hostname "My Pretty Host") you will receive these denials in the audit log:
`node=talon-source type=AVC msg=audit(1713748477.775:17769): avc:  denied  { create } for  pid=3012 comm="systemd-hostnam" name=".#machine-infocuJGLW" scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=1

node=talon-source type=AVC msg=audit(1713748477.775:17769): avc:  denied  { write } for  pid=3012 comm="systemd-hostnam" path="/etc/.#machine-infocuJGLW" dev="dm-1" ino=1180584 scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=1

node=talon-source type=PATH msg=audit(1713748477.775:17769): item=1 name="/etc/.#machine-infocuJGLW" inode=1180584 dev=fd:01 mode=0100600 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:etc_t:s0 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0OUID="root" OGID="root"

node=talon-source type=AVC msg=audit(1713748477.775:17770): avc:  denied  { setattr } for  pid=3012 comm="systemd-hostnam" name=".#machine-infocuJGLW" dev="dm-1" ino=1180584 scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=1

node=talon-source type=AVC msg=audit(1713748477.776:17771): avc:  denied  { rename } for  pid=3012 comm="systemd-hostnam" name=".#machine-infocuJGLW" dev="dm-1" ino=1180584 scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=1

node=talon-source type=PATH msg=audit(1713748477.776:17771): item=2 name="/etc/.#machine-infocuJGLW" inode=1180584 dev=fd:01 mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:etc_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0OUID="root" OGID="root"

node=talon-source type=PATH msg=audit(1713748477.776:17771): item=3 name="/etc/machine-info" inode=1180584 dev=fd:01 mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:etc_t:s0 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0OUID="root" OGID="root"

node=talon-source type=PATH msg=audit(1713748497.093:17897): item=0 name="/etc/machine-info" inode=1180584 dev=fd:01 mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:etc_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0OUID="root" OGID="root`


This is on a Rocky 9 system where the default type is etc_t.  Setting the type to net_conf_t allows the command to succeed without error.
