### PR TITLE
Allow systemd to pass down sig mask

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -189,6 +189,7 @@ interface(`init_domain',`
 
 		allow $1 init_t:unix_stream_socket { getattr read write ioctl };
 
+		allow init_t $1:process siginh;
 		allow init_t $1:process2 { nnp_transition nosuid_transition };
 
 		# StandardInputText uses a memfd rw shm segment.


### PR DESCRIPTION
IgnoreSIGPIPE is a feature that requires systemd to passdown the signal mask down to the fork process. To allow this the siginh permission must be allowed for all process domains that can be forked by systemd.