### PR TITLE
Need map perm for cockpit 300.4

### DIFF
--- a/policy/modules/services/cockpit.if
+++ b/policy/modules/services/cockpit.if
@@ -49,7 +49,7 @@ template(`cockpit_role_template',`
 	files_tmpfs_file($1_cockpit_tmpfs_t)
 	dev_filetrans($2, $1_cockpit_tmpfs_t, file)
 
-	allow $2 $1_cockpit_tmpfs_t:file { manage_file_perms execute };
+	allow $2 $1_cockpit_tmpfs_t:file { mmap_manage_file_perms execute };
 
 	dev_dontaudit_execute_dev_nodes($2)
 


### PR DESCRIPTION
node=localhost type=AVC msg=audit(1714870999.370:3558): avc:  denied  { map } for  pid=7081 comm="cockpit-bridge" path=2F6465762F23373933202864656C6574656429 dev="devtmpfs" ino=793 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:staff_cockpit_tmpfs_t:s0 tclass=file permissive=0