### PR TITLE
Adding Sepolicy rules to allow bluetoothctl and dbus-daemon to access unix stream sockets.

### DIFF
--- a/policy/modules/apps/pulseaudio.te
+++ b/policy/modules/apps/pulseaudio.te
@@ -193,7 +193,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	bluetooth_stream_connect(pulseaudio_t)
+	bluetooth_use(pulseaudio_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/bluetooth.if
+++ b/policy/modules/services/bluetooth.if
@@ -85,6 +85,30 @@ interface(`bluetooth_stream_connect',`
 	stream_connect_pattern($1, bluetooth_runtime_t, bluetooth_runtime_t, bluetooth_t)
 ')
 
+#####################################
+## <summary>
+##	Connect to bluetooth over a unix domain
+##	stream socket. The socket can be used
+##      for read and write.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`bluetooth_use',`
+	gen_require(`
+		type bluetooth_t;
+	')
+
+	files_search_runtime($1)
+	allow $1 bluetooth_t:bluetooth_socket rw_socket_perms;
+	allow $1 bluetooth_t:unix_stream_socket rw_socket_perms;
+	allow $1 bluetooth_t:fd use;
+	bluetooth_stream_connect($1)
+')
+
 ########################################
 ## <summary>
 ##	Execute bluetooth in the bluetooth domain.

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -262,7 +262,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	bluetooth_stream_connect(system_dbusd_t)
+	bluetooth_use(system_dbusd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/obex.te
+++ b/policy/modules/services/obex.te
@@ -31,7 +31,7 @@ miscfiles_read_localization(obex_t)
 userdom_search_user_home_content(obex_t)
 
 optional_policy(`
-	bluetooth_stream_connect(obex_t)
+	bluetooth_use(obex_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Required for using acquire-notify, acquire-write options (Gatt Client) and Sending notifications (Gatt Server)

Below are the avc denials that are fixed with this patch -

1. audit: type=1400 audit(315966559.395:444): avc:  denied  { use } for  pid=710 comm="dbus-daemon" path="socket:[13196]" dev="sockfs" ino=13196
scontext=system_u:system_r:system_dbusd_t:s0-s15:c0.c1023 tcontext=system_u:system_r:bluetooth_t:s0-s15:c0.c1023 tclass=fd permissive=0
2. audit: type=1400 audit(315999854.939:523): avc:  denied  { read write } for  pid=812 comm="dbus-daemon" path="socket:[99469]" dev="sockfs" ino=99469
scontext=system_u:system_r:system_dbusd_t:s0-s15:c0.c1023 tcontext=system_u:system_r:bluetooth_t:s0-s15:c0.c1023 tclass=bluetooth_socket permissive=1

Submitted-by: Naga Bhavani Akella <quic_nakella@quicinc.com>
https://lore.kernel.org/selinux-refpolicy/fe989e5b-82f7-406b-8264-6a2734418ba9@quicinc.com/T/#t