### PR TITLE
selinuxutil: make policykit optional

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -500,11 +500,13 @@ corecmd_exec_bin(selinux_dbus_t)
 files_read_etc_symlinks(selinux_dbus_t)
 files_list_usr(selinux_dbus_t)
 
-policykit_dbus_chat(selinux_dbus_t)
-
 miscfiles_read_localization(selinux_dbus_t)
 
 seutil_domtrans_semanage(selinux_dbus_t)
+
+optional_policy(`
+	policykit_dbus_chat(selinux_dbus_t)
+')
 
 ########################################
 #


### PR DESCRIPTION
Make policykit optional to avoid a potential build error.