### PR TITLE
Sepolicy changes for bluez to access uhid

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -4864,10 +4864,10 @@ interface(`dev_rw_tpm',`
 #
 interface(`dev_rw_uhid',`
         gen_require(`
-                type uhid_device_t;
+                type device_t, uhid_device_t;
         ')
 
-        allow $1 uhid_device_t:chr_file rw_chr_file_perms;
+        rw_chr_files_pattern($1, device_t, uhid_device_t)
 ')
 
 ########################################

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -4851,6 +4851,25 @@ interface(`dev_rw_tpm',`
 	rw_chr_files_pattern($1, device_t, tpm_device_t)
 ')
 
+#####################
+## <summary>
+##	Allow open/read/write uhid device
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed rw to uhid device
+##	to communicate with uhid input node
+##	</summary>
+## </param>
+#
+interface(`dev_rw_uhid',`
+        gen_require(`
+                type uhid_device_t;
+        ')
+
+        allow $1 uhid_device_t:chr_file rw_chr_file_perms;
+')
+
 ########################################
 ## <summary>
 ##	Read from pseudo random number generator devices (e.g., /dev/urandom).
@@ -5857,22 +5876,4 @@ interface(`dev_unconfined',`
 	')
 
 	typeattribute $1 devices_unconfined_type;
-')
-
-#####################
-## <summary>
-## Allow open/read/write uhid device
-## </summary>
-## <param name="domain">
-##  <summary>
-##  Domain allowed rw to uhid device
-##  to communicate with uhid input node
-##  </summary>
-## </param>
-#
-interface(`dev_rw_uhid',`
-        gen_require(`
-                type uhid_device_t;
-        ')
-        allow $1 uhid_device_t:chr_file rw_chr_file_perms ;
 ')

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -5858,3 +5858,21 @@ interface(`dev_unconfined',`
 
 	typeattribute $1 devices_unconfined_type;
 ')
+
+#####################
+## <summary>
+## Allow open/read/write uhid device
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed rw to uhid device
+##  to communicate with uhid input node
+##  </summary>
+## </param>
+#
+interface(`dev_rw_uhid',`
+        gen_require(`
+                type uhid_device_t;
+        ')
+        allow $1 uhid_device_t:chr_file rw_chr_file_perms ;
+')

--- a/policy/modules/services/bluetooth.te
+++ b/policy/modules/services/bluetooth.te
@@ -104,6 +104,7 @@ dev_rw_generic_usb_dev(bluetooth_t)
 dev_read_urand(bluetooth_t)
 dev_rw_input_dev(bluetooth_t)
 dev_rw_wireless(bluetooth_t)
+dev_rw_uhid(bluetooth_t)
 
 domain_use_interactive_fds(bluetooth_t)
 domain_dontaudit_search_all_domains_state(bluetooth_t)


### PR DESCRIPTION
Resolve selinux premission for HID

Below avc denials that are fixed with this patch -

avc:  denied  { read write } for  pid=656 comm="bluetoothd" name="uhid" dev="devtmpfs" ino=841 scontext=system_u:system_r:bluetooth_t:s0-s15:c0.c1023 tcontext=system_u:object_r:uhid_device_t:s0 tclass=chr_file permissive=0

Submitted-by: Amisha Jain <quic_amisjain@quicinc.com>