### PR TITLE
userdomain: allow administrative user to get attributes of shadow his…

### DIFF
--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -747,6 +747,25 @@ interface(`auth_etc_filetrans_shadow',`
 
 ########################################
 ## <summary>
+##	Get the attributes of the shadow history file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_getattr_shadow_history',`
+	gen_require(`
+		type shadow_history_t;
+	')
+
+	files_search_etc($1)
+	allow $1 shadow_history_t:file getattr;
+')
+
+########################################
+## <summary>
 ##	Read the shadow history file.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1428,6 +1428,7 @@ template(`userdom_admin_user_template',`
 	term_use_all_terms($1_t)
 
 	auth_getattr_shadow($1_t)
+	auth_getattr_shadow_history($1_t)
 	# Manage almost all files
 	files_manage_non_auth_files($1_t)
 	files_map_non_auth_files($1_t)


### PR DESCRIPTION
…tory file

Before the patch:
root@qemux86-64:~# ls -lZ /etc/security/opasswd
-?????????? ? ?    ?    ?                                    ?  ? /etc/security/opasswd

After the patch:
root@qemux86-64:~# ls -lZ /etc/security/opasswd
-rw-------. 1 root root user_u:object_r:shadow_history_t 237 Jun 30 12:03 /etc/security/opasswd