### PR TITLE
Adding Sepolicy rules to allow pulseaudio to access bluetooth sockets.

### DIFF
--- a/policy/modules/apps/pulseaudio.te
+++ b/policy/modules/apps/pulseaudio.te
@@ -63,6 +63,7 @@ allow pulseaudio_t self:fifo_file rw_fifo_file_perms;
 allow pulseaudio_t self:unix_stream_socket { accept connectto listen };
 allow pulseaudio_t self:unix_dgram_socket sendto;
 allow pulseaudio_t self:netlink_kobject_uevent_socket create_socket_perms;
+allow pulseaudio_t self:bluetooth_socket create_stream_socket_perms;
 
 allow pulseaudio_t pulseaudio_home_t:dir manage_dir_perms;
 allow pulseaudio_t pulseaudio_home_t:file mmap_manage_file_perms;
@@ -318,3 +319,4 @@ optional_policy(`
 optional_policy(`
 	unconfined_signull(pulseaudio_client)
 ')
+


### PR DESCRIPTION
pulseaudio uses bluetooth sockets for HFP-AG and
HSP-HS profile to do SLC and SCO connection with
remote.

avc:  denied  { create } for  pid=1271 comm="pulseaudio" scontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tcontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tclass=bluetooth_socket permissive=1

avc:  denied  { bind } for  pid=1271 comm="pulseaudio" scontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tcontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tclass=bluetooth_socket permissive=1

avc:  denied  { listen } for  pid=1271 comm="pulseaudio" scontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tcontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tclass=bluetooth_socket permissive=1

avc:  denied  { accept } for  pid=1271 comm="pulseaudio" scontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tcontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tclass=bluetooth_socket permissive=1

avc:  denied  { getopt } for  pid=1271 comm="bluetooth" scontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tcontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tclass=bluetooth_socket permissive=1

avc:  denied  { setopt } for  pid=1271 comm="bluetooth" scontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tcontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tclass=bluetooth_socket permissive=1

avc:  denied  { read } for  pid=1271 comm="bluetooth" scontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tcontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tclass=bluetooth_socket permissive=1

avc:  denied  { write } for  pid=1271 comm="bluetooth" scontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tcontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tclass=bluetooth_socket permissive=1

avc:  denied  { shutdown } for  pid=137606 comm="pulseaudio" scontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tcontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tclass=bluetooth_socket permissive=1

avc:  denied  { connect } for  pid=137606 comm="pulseaudio" scontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tcontext=system_u:system_r:pulseaudio_t:s0-s15:c0.c1023 tclass=bluetooth_socket permissive=1