### PR TITLE
Setting bluetooth helper domain for bluetoothctl

### DIFF
--- a/policy/modules/services/bluetooth.fc
+++ b/policy/modules/services/bluetooth.fc
@@ -7,6 +7,7 @@
 
 /usr/bin/blue.*pin	--	gen_context(system_u:object_r:bluetooth_helper_exec_t,s0)
 /usr/bin/bluetoothd	--	gen_context(system_u:object_r:bluetooth_exec_t,s0)
+/usr/bin/bluetoothctl	--	gen_context(system_u:object_r:bluetooth_helper_exec_t,s0)
 /usr/bin/dund	--	gen_context(system_u:object_r:bluetooth_exec_t,s0)
 /usr/bin/hciattach	--	gen_context(system_u:object_r:bluetooth_exec_t,s0)
 /usr/bin/hcid	--	gen_context(system_u:object_r:bluetooth_exec_t,s0)

--- a/policy/modules/services/bluetooth.te
+++ b/policy/modules/services/bluetooth.te
@@ -19,6 +19,7 @@ files_type(bluetooth_conf_rw_t)
 
 type bluetooth_helper_t;
 type bluetooth_helper_exec_t;
+init_system_domain(bluetooth_helper_t, bluetooth_helper_exec_t)
 userdom_user_application_domain(bluetooth_helper_t, bluetooth_helper_exec_t)
 role bluetooth_helper_roles types bluetooth_helper_t;
 
@@ -176,6 +177,8 @@ allow bluetooth_helper_t self:shm create_shm_perms;
 allow bluetooth_helper_t self:unix_stream_socket { accept connectto listen };
 
 allow bluetooth_helper_t bluetooth_t:socket { read write };
+allow bluetooth_helper_t bluetooth_t:fd use;
+allow bluetooth_helper_t bluetooth_t:unix_stream_socket rw_socket_perms;
 
 manage_dirs_pattern(bluetooth_helper_t, bluetooth_helper_tmp_t, bluetooth_helper_tmp_t)
 manage_files_pattern(bluetooth_helper_t, bluetooth_helper_tmp_t, bluetooth_helper_tmp_t)
@@ -203,6 +206,8 @@ files_dontaudit_list_default(bluetooth_helper_t)
 term_dontaudit_use_all_ttys(bluetooth_helper_t)
 
 auth_use_nsswitch(bluetooth_helper_t)
+
+init_use_script_ptys(bluetooth_helper_t)
 
 locallogin_dontaudit_use_fds(bluetooth_helper_t)
 


### PR DESCRIPTION
    Required for fixing the below avc denials -

    1. audit: type=1400 audit(1651238006.276:496):
    avc:  denied  { read write } for  pid=2165 comm="bluetoothd"
    path="socket:[43207]" dev="sockfs" ino=43207
    scontext=system_u:system_r:bluetooth_t:s0-s15:c0.c1023
    tcontext=system_u:system_r:initrc_t:s0-s15:c0.c1023
    tclass=unix_stream_socket permissive=1
    2. audit: type=1400 audit(1651238006.276:497):
    avc:  denied  { getattr } for  pid=2165 comm="bluetoothd"
    path="socket:[43207]" dev="sockfs" ino=43207
    scontext=system_u:system_r:bluetooth_t:s0-s15:c0.c1023
    tcontext=system_u:system_r:initrc_t:s0-s15:c0.c1023
    tclass=unix_stream_socket permissive=1
    3. audit: type=1400 audit(1651238006.272:495):
    avc:  denied  { read write } for  pid=689 comm="dbus-daemon"
    path="socket:[43207]" dev="sockfs" ino=43207
    scontext=system_u:system_r:system_dbusd_t:s0-s15:c0.c1023
    tcontext=system_u:system_r:initrc_t:s0-s15:c0.c1023
    tclass=unix_stream_socket permissive=1
    4. audit[1894]: AVC avc:  denied  { read write } for  pid=1894
    comm="bluetoothctl" path="/dev/pts/0" dev="devpts" ino=3
    scontext=system_u:system_r:bluetooth_helper_t:s0-s15:c0.c1023
    tcontext=system_u:object_r:initrc_devpts_t:s0
    tclass=chr_file permissive=0
    5. audit[2022]: AVC avc:  denied  { use } for  pid=2022
    comm="bluetoothctl" path="socket:[25769]" dev="sockfs" ino=25769
    scontext=system_u:system_r:bluetooth_helper_t:s0-s15:c0.c1023
    tcontext=system_u:system_r:bluetooth_t:s0-s15:c0.c1023
    tclass=fd permissive=0
    6. audit[2006]: AVC avc:  denied  { read write } for  pid=2006
    comm="bluetoothctl" path="socket:[21106]" dev="sockfs" ino=21106
    scontext=system_u:system_r:bluetooth_helper_t:s0-s15:c0.c1023
    tcontext=system_u:system_r:bluetooth_t:s0-s15:c0.c1023
    tclass=unix_stream_socket permissive=0

    Signed-off-by: Naga Bhavani Akella <quic_nakella@quicinc.com>