### PR TITLE
systemd: make xdg optional

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -313,10 +313,16 @@ init_unit_file(systemd_user_manager_unit_t)
 
 type systemd_conf_home_t;
 init_unit_file(systemd_conf_home_t)
-xdg_config_content(systemd_conf_home_t)
+
+optional_policy(`
+	xdg_config_content(systemd_conf_home_t)
+')
 
 type systemd_data_home_t;
-xdg_data_content(systemd_data_home_t)
+userdom_user_home_content(systemd_data_home_t)
+optional_policy(`
+	xdg_data_content(systemd_data_home_t)
+')
 
 type systemd_user_runtime_notify_t;
 userdom_user_runtime_content(systemd_user_runtime_notify_t)


### PR DESCRIPTION
Make xdg optional to avoid a potential build error.