### PR TITLE
sshd: label sshd-session as sshd_exec_t

### DIFF
--- a/policy/modules/services/ssh.fc
+++ b/policy/modules/services/ssh.fc
@@ -8,6 +8,7 @@ HOME_DIR/\.ssh(/.*)?			gen_context(system_u:object_r:ssh_home_t,s0)
 /usr/bin/ssh-keygen		--	gen_context(system_u:object_r:ssh_keygen_exec_t,s0)
 /usr/bin/sshd			--	gen_context(system_u:object_r:sshd_exec_t,s0)
 
+/usr/lib/misc/sshd-session	--	gen_context(system_u:object_r:sshd_exec_t,s0)
 /usr/lib/openssh/ssh-keysign	--	gen_context(system_u:object_r:ssh_keysign_exec_t,s0)
 /usr/lib/ssh/ssh-keysign	--	gen_context(system_u:object_r:ssh_keysign_exec_t,s0)
 


### PR DESCRIPTION
OpenSSH 9.8 splits out much of the session code from the main sshd binary into a new sshd-session binary. Allow the sshd server to execute this binary by labeling it as sshd_exec_t.