### PR TITLE
systemd: allow logind to use locallogin pidfds

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1071,6 +1071,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	locallogin_use_pidfds(systemd_logind_t)
+')
+
+optional_policy(`
 	modemmanager_dbus_chat(systemd_logind_t)
 ')
 


### PR DESCRIPTION
Allow systemd-logind to use locallogin pidfds.