### PR TITLE
locallogin: remove duplicate interface

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -621,7 +621,7 @@ ifdef(`init_systemd',`
 	')
 
 	optional_policy(`
-		locallogin_use_pidfds(init_t)
+		locallogin_use_fds(init_t)
 	')
 
 	optional_policy(`

--- a/policy/modules/system/locallogin.if
+++ b/policy/modules/system/locallogin.if
@@ -59,24 +59,6 @@ interface(`locallogin_use_fds',`
 
 ########################################
 ## <summary>
-##	Use PIDFDs from local login.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`locallogin_use_pidfds',`
-	gen_require(`
-		type local_login_t;
-	')
-
-	allow $1 local_login_t:fd use;
-')
-
-########################################
-## <summary>
 ##	Do not audit attempts to inherit local login file descriptors.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1077,7 +1077,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	locallogin_use_pidfds(systemd_logind_t)
+	locallogin_use_fds(systemd_logind_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The contents of interface locallogin_use_fds and interface locallogin_use_pidfds are the same, remove the latter.