### PR TITLE
Makefile: drop duplicate quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,9 @@ ifdef TEST_TOOLCHAIN
 python_path_plat := $(shell python3 -c "import sysconfig; print(sysconfig.get_path('platlib', vars={'platbase': '/usr', 'base': '/usr'}))")
 python_path_pure := $(shell python3 -c "import sysconfig; print(sysconfig.get_path('purelib', vars={'platbase': '/usr', 'base': '/usr'}))")
 ifdef PYTHONPATH
-python_path := "$(TEST_TOOLCHAIN)$(python_path_plat):$(TEST_TOOLCHAIN)$(python_path_pure):$(PYTHONPATH)"
+python_path := $(TEST_TOOLCHAIN)$(python_path_plat):$(TEST_TOOLCHAIN)$(python_path_pure):$(PYTHONPATH)
 else
-python_path := "$(TEST_TOOLCHAIN)$(python_path_plat):$(TEST_TOOLCHAIN)$(python_path_pure)"
+python_path := $(TEST_TOOLCHAIN)$(python_path_plat):$(TEST_TOOLCHAIN)$(python_path_pure)
 endif
 tc_usrbindir := env LD_LIBRARY_PATH="$(TEST_TOOLCHAIN)/lib:$(TEST_TOOLCHAIN)/usr/lib" PYTHONPATH="$(python_path)" $(TEST_TOOLCHAIN)$(BINDIR)
 tc_usrsbindir := env LD_LIBRARY_PATH="$(TEST_TOOLCHAIN)/lib:$(TEST_TOOLCHAIN)/usr/lib" PYTHONPATH="$(python_path)" $(TEST_TOOLCHAIN)$(SBINDIR)


### PR DESCRIPTION
The variable is used quoted.

Improves: https://github.com/SELinuxProject/refpolicy/commit/f9595d30ff5b6323777928591a45a4cb241dd87b