### PR TITLE
Adding SE Policy rules to allow usage of unix stream sockets by dbus …

### DIFF
--- a/policy/modules/services/bluetooth.if
+++ b/policy/modules/services/bluetooth.if
@@ -187,6 +187,28 @@ interface(`bluetooth_dontaudit_read_helper_state',`
 	dontaudit $1 bluetooth_helper_t:file read_file_perms;
 ')
 
+#####################################
+## <summary>
+##	Connect to bluetooth over a unix domain
+##	stream socket. The socket can be used
+##      for read and write. This is required for
+#       bluetooth helper context.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`bluetooth_use_inherited_helper_stream_sockets',`
+	gen_require(`
+		type bluetooth_helper_t;
+	')
+
+	allow $1 bluetooth_helper_t:unix_stream_socket rw_socket_perms;
+	allow $1 bluetooth_helper_t:fd use;
+')
+
 ########################################
 ## <summary>
 ##	All of the rules required to

--- a/policy/modules/services/bluetooth.te
+++ b/policy/modules/services/bluetooth.te
@@ -76,6 +76,9 @@ filetrans_pattern(bluetooth_t, bluetooth_conf_t, bluetooth_conf_rw_t, { dir file
 allow bluetooth_t bluetooth_lock_t:file manage_file_perms;
 files_lock_filetrans(bluetooth_t, bluetooth_lock_t, file)
 
+bluetooth_use_inherited_helper_stream_sockets(bluetooth_t)
+
+
 manage_dirs_pattern(bluetooth_t, bluetooth_tmp_t, bluetooth_tmp_t)
 manage_files_pattern(bluetooth_t, bluetooth_tmp_t, bluetooth_tmp_t)
 files_tmp_filetrans(bluetooth_t, bluetooth_tmp_t, { dir file })

--- a/policy/modules/services/bluetooth.te
+++ b/policy/modules/services/bluetooth.te
@@ -76,9 +76,6 @@ filetrans_pattern(bluetooth_t, bluetooth_conf_t, bluetooth_conf_rw_t, { dir file
 allow bluetooth_t bluetooth_lock_t:file manage_file_perms;
 files_lock_filetrans(bluetooth_t, bluetooth_lock_t, file)
 
-bluetooth_use_inherited_helper_stream_sockets(bluetooth_t)
-
-
 manage_dirs_pattern(bluetooth_t, bluetooth_tmp_t, bluetooth_tmp_t)
 manage_files_pattern(bluetooth_t, bluetooth_tmp_t, bluetooth_tmp_t)
 files_tmp_filetrans(bluetooth_t, bluetooth_tmp_t, { dir file })
@@ -92,6 +89,8 @@ manage_sock_files_pattern(bluetooth_t, bluetooth_runtime_t, bluetooth_runtime_t)
 files_runtime_filetrans(bluetooth_t, bluetooth_runtime_t, { file sock_file })
 
 can_exec(bluetooth_t, bluetooth_helper_exec_t)
+
+bluetooth_use_inherited_helper_stream_sockets(bluetooth_t)
 
 kernel_read_kernel_sysctls(bluetooth_t)
 kernel_read_system_state(bluetooth_t)

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -266,6 +266,7 @@ optional_policy(`
 
 optional_policy(`
 	bluetooth_use(system_dbusd_t)
+	bluetooth_use_inherited_helper_stream_sockets(system_dbusd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
…and bluetooth contexts when Gatt notifications are turned on by remote.

Below are the avc denials that are resolved -

1. AVC avc:  denied  { use } for  pid=916 comm="dbus-daemon" path="socket:[71126]" dev="sockfs" ino=71126
scontext=system_u:system_r:system_dbusd_t:s0-s15:c0.c1023 tcontext=system_u:system_r:bluetooth_helper_t:s0-s15:c0.c1023 tclass=fd permissive=0

2. AVC avc:  denied  { read write } for  pid=913 comm="dbus-daemon" path="socket:[25037]" dev="sockfs" ino=25037
scontext=system_u:system_r:system_dbusd_t:s0-s15:c0.c1023 tcontext=system_u:system_r:bluetooth_helper_t:s0-s15:c0.c1023 tclass=unix_stream_socket permissive=0

3. AVC avc:  denied  { use } for  pid=910 comm="bluetoothd" path="socket:[23966]" dev="sockfs" ino=23966
scontext=system_u:system_r:bluetooth_t:s0-s15:c0.c1023 tcontext=system_u:system_r:bluetooth_helper_t:s0-s15:c0.c1023 tclass=fd permissive=0

4. AVC avc:  denied  { read write } for  pid=2229 comm="bluetoothd" path="socket:[27264]" dev="sockfs" ino=27264
scontext=system_u:system_r:bluetooth_t:s0-s15:c0.c1023 tcontext=system_u:system_r:bluetooth_helper_t:s0-s15:c0.c1023 tclass=unix_stream_socket permissive=0