### PR TITLE
Allow interactive user terminal output for the NetLabel management tool

### DIFF
--- a/policy/modules/system/netlabel.te
+++ b/policy/modules/system/netlabel.te
@@ -22,6 +22,8 @@ allow netlabel_mgmt_t self:netlink_generic_socket create_socket_perms;
 
 kernel_read_network_state(netlabel_mgmt_t)
 
+domain_use_interactive_fds(netlabel_mgmt_t)
+
 files_read_etc_files(netlabel_mgmt_t)
 
 seutil_use_newrole_fds(netlabel_mgmt_t)


### PR DESCRIPTION
Allow interactive user terminal output for the NetLabel management tool.

---
 policy/modules/system/netlabel.te |    2 ++
 1 file changed, 2 insertions(+)