### PR TITLE
Additional permissions when fapolicyd.conf more strict

### DIFF
--- a/policy/modules/admin/fapolicyd.te
+++ b/policy/modules/admin/fapolicyd.te
@@ -70,14 +70,16 @@ kernel_read_kernel_sysctls(fapolicyd_t)
 
 domain_read_all_domains_state(fapolicyd_t)
 
-files_read_all_files(fapolicyd_t)
+files_mmap_read_all_files(fapolicyd_t)
 files_read_all_symlinks(fapolicyd_t)
 files_runtime_filetrans(fapolicyd_t, fapolicyd_runtime_t, { file fifo_file })
 files_map_usr_files(fapolicyd_t)
 files_watch_all_mountpoints(fapolicyd_t)
 files_watch_all_mount_perm(fapolicyd_t)
+files_watch_all_mount_sb(fapolicyd_t)
 
 fs_getattr_xattr_fs(fapolicyd_t)
+fs_watch_all_fs(fapolicyd_t)
 
 logging_log_filetrans(fapolicyd_t, fapolicyd_log_t, file)
 logging_send_syslog_msg(fapolicyd_t)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -738,6 +738,30 @@ interface(`files_read_all_files',`
 
 ########################################
 ## <summary>
+##	Read and memory map all files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_mmap_read_all_files',`
+	gen_require(`
+		attribute file_type;
+	')
+
+	allow $1 file_type:dir list_dir_perms;
+	mmap_read_files_pattern($1, file_type, file_type)
+
+	optional_policy(`
+		auth_read_shadow($1)
+		auth_map_shadow($1)
+	')
+')
+
+########################################
+## <summary>
 ##	Allow shared library text relocations in all files.
 ## </summary>
 ## <desc>
@@ -1948,6 +1972,24 @@ interface(`files_watch_all_mount_perm',`
 	')
 
 	allow $1 mountpoint:dir watch_with_perm;
+')
+
+########################################
+## <summary>
+##	Watch all mount superblock changes
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_all_mount_sb',`
+	gen_require(`
+		attribute mountpoint;
+	')
+
+	allow $1 mountpoint:dir watch_sb;
 ')
 
 ########################################

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -6676,6 +6676,25 @@ interface(`fs_relabelfrom_all_fs',`
 
 ########################################
 ## <summary>
+##	Watch all filesystems.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_watch_all_fs',`
+	gen_require(`
+		attribute filesystem_type;
+	')
+
+	allow $1 filesystem_type:filesystem watch;
+')
+
+########################################
+## <summary>
 ##	Get the attributes of all directories
 ##	with a filesystem type.
 ## </summary>


### PR DESCRIPTION
When fapolicyd is configured with allow_filesystem_mark = 1 it watches filesysems and mount points 
When fapolicyd is configured with integrituy = sha256 it mmaps files to perform hash

node=localhost type=AVC msg=audit(1726153668.013:418): avc:  denied  { watch } for  pid=1561 comm="fapolicyd" path="/dev/shm" dev="tmpfs" ino=1 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=0
node=localhost type=AVC msg=audit(1726154081.718:403): avc:  denied  { watch } for  pid=1598 comm="fapolicyd" path="/" dev="dm-1" ino=2 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=1
node=localhost type=AVC msg=audit(1726154081.718:403): avc:  denied  { watch_sb } for  pid=1598 comm="fapolicyd" path="/" dev="dm-1" ino=2 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:root_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1726154081.718:402): avc:  denied  { watch_sb } for  pid=1598 comm="fapolicyd" path="/dev/shm" dev="tmpfs" ino=1 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1726154081.721:404): avc:  denied  { watch_sb } for  pid=1598 comm="fapolicyd" path="/boot" dev="sda2" ino=128 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:boot_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1726154081.722:406): avc:  denied  { watch_sb } for  pid=1598 comm="fapolicyd" path="/var" dev="dm-9" ino=2 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:var_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1726154706.227:415): avc:  denied  { map } for  pid=1594 comm="fapolicyd" path="/usr/bin/kmod" dev="dm-1" ino=14600 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:kmod_exec_t:s0 tclass=file permissive=0
node=localhost type=AVC msg=audit(1726154743.367:999): avc:  denied  { map } for  pid=1594 comm="fapolicyd" path="/usr/lib/systemd/systemd" dev="dm-1" ino=17564 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:init_exec_t:s0 tclass=file permissive=0
node=localhost type=AVC msg=audit(1726154743.403:1030): avc:  denied  { map } for  pid=1594 comm="fapolicyd" path="/usr/bin/bash" dev="dm-1" ino=3571 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=0
node=localhost type=AVC msg=audit(1726154807.975:476): avc:  denied  { map } for  pid=1599 comm="fapolicyd" path="/usr/lib/systemd/user-environment-generators/30-systemd-environment-d-generator" dev="dm-1" ino=17589 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:systemd_generator_exec_t:s0 tclass=file permissive=1