### PR TITLE
Define context for `.mylogin.cnf`

### DIFF
--- a/policy/modules/services/mysql.fc
+++ b/policy/modules/services/mysql.fc
@@ -1,4 +1,5 @@
 HOME_DIR/\.my\.cnf	--	gen_context(system_u:object_r:mysqld_home_t,s0)
+HOME_DIR/\.mylogin\.cnf	 --	 gen_context(system_u:object_r:mysqld_home_t,s0)
 
 /etc/my\.cnf	--	gen_context(system_u:object_r:mysqld_etc_t,s0)
 /etc/my\.cnf\.d(/.*)?	gen_context(system_u:object_r:mysqld_etc_t,s0)


### PR DESCRIPTION
`.mylogin.cnf` is created by `mysql_config_editor`. The file location is the current user's home directory on non-Windows systems: https://dev.mysql.com/doc/refman/9.0/en/mysql-config-editor.html.