### PR TITLE
Fix complaints in STIG about unlabeled device files

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -23,6 +23,7 @@
 /dev/crash		-c	gen_context(system_u:object_r:crash_device_t,mls_systemhigh)
 /dev/dahdi/.*		-c	gen_context(system_u:object_r:sound_device_t,s0)
 /dev/dax[0-9]\.[0-9]	-c	gen_context(system_u:object_r:dax_device_t,mls_systemhigh)
+/dev/dma_heap/.+	-c	gen_context(system_u:object_r:dma_device_t,s0)
 /dev/dmfm		-c	gen_context(system_u:object_r:sound_device_t,s0)
 /dev/dmmidi.*		-c	gen_context(system_u:object_r:sound_device_t,s0)
 /dev/drm_dp_aux[0-9]*	-c	gen_context(system_u:object_r:xserver_misc_device_t,s0)
@@ -121,6 +122,7 @@
 /dev/tlk[0-3]		-c	gen_context(system_u:object_r:v4l_device_t,s0)
 /dev/tpm[0-9]*		-c	gen_context(system_u:object_r:tpm_device_t,s0)
 /dev/tpmrm[0-9]*	-c	gen_context(system_u:object_r:tpm_device_t,s0)
+/dev/udmabuf		-c	gen_context(system_u:object_r:dma_device_t,s0)
 /dev/uinput		-c	gen_context(system_u:object_r:event_device_t,s0)
 /dev/uio[0-9]+		-c	gen_context(system_u:object_r:userio_device_t,s0)
 /dev/urandom		-c	gen_context(system_u:object_r:urandom_device_t,s0)
@@ -199,6 +201,7 @@ ifdef(`distro_suse', `
 /dev/usb/mdc800.*	-c	gen_context(system_u:object_r:scanner_device_t,s0)
 /dev/usb/scanner.*	-c	gen_context(system_u:object_r:scanner_device_t,s0)
 
+/dev/userfaultfd	-c	gen_context(system_u:object_r:userfaultfd_device_t,s0)
 /dev/vmbus/hv_kvp	-c	gen_context(system_u:object_r:hyperv_kvp_device_t,s0)
 /dev/vmbus/hv_vss	-c	gen_context(system_u:object_r:hyperv_vss_device_t,s0)
 

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -2012,6 +2012,24 @@ interface(`dev_rw_dlm_control',`
 
 ########################################
 ## <summary>
+##      Read and write the the dma device
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`dev_rw_dma_dev',`
+	gen_require(`
+		type device_t, dma_device_t;
+	')
+
+	rw_chr_files_pattern($1, device_t, dma_device_t)
+')
+
+########################################
+## <summary>
 ##	getattr the dri devices.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -102,6 +102,12 @@ dev_node(dax_device_t)
 type dlm_control_device_t;
 dev_node(dlm_control_device_t)
 
+#
+# Type for /dev/dma_heap/* devices
+#
+type dma_device_t;
+dev_node(dma_device_t)
+
 type dri_device_t;
 dev_node(dri_device_t)
 
@@ -378,6 +384,12 @@ optional_policy(`
 #
 type usbmon_device_t;
 dev_node(usbmon_device_t)
+
+#
+# Type for /dev/userfaultfd
+#
+type userfaultfd_device_t;
+dev_node(userfaultfd_device_t)
 
 #
 # userio_device_t is the type for /dev/uio[0-9]+


### PR DESCRIPTION
Added label for userfaultfd, udmabuf and dma_heap based on what is in fedora-policy
    
