### PR TITLE
Make mta optional in container policy

### DIFF
--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -391,8 +391,6 @@ miscfiles_dontaudit_setattr_fonts_cache_dirs(container_domain)
 miscfiles_read_fonts(container_domain)
 miscfiles_read_generic_certs(container_domain)
 
-mta_dontaudit_read_spool_symlinks(container_domain)
-
 container_rw_device_files(container_domain)
 container_use_container_ptys(container_domain)
 
@@ -454,6 +452,10 @@ optional_policy(`
 	kubernetes_read_tmpfs_symlinks(container_domain)
 	kubernetes_watch_tmpfs_dirs(container_domain)
 	kubernetes_watch_tmpfs_files(container_domain)
+')
+
+optional_policy(`
+	mta_dontaudit_read_spool_symlinks(container_domain)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Don't need to have mta policy loaded when loading container policy.