### PR TITLE
add netlink_xperm policy capability and nlmsg permission definitions

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -600,6 +600,7 @@ inherits socket
 {
 	nlmsg_read
 	nlmsg_write
+	nlmsg
 }
 
 class obsolete_netlink_firewall_socket
@@ -614,6 +615,7 @@ inherits socket
 {
 	nlmsg_read
 	nlmsg_write
+	nlmsg
 }
 
 class netlink_nflog_socket
@@ -624,6 +626,7 @@ inherits socket
 {
 	nlmsg_read
 	nlmsg_write
+	nlmsg
 }
 
 class netlink_selinux_socket
@@ -637,6 +640,7 @@ inherits socket
 	nlmsg_relay
 	nlmsg_readpriv
 	nlmsg_tty_audit
+	nlmsg
 }
 
 class obsolete_netlink_ip6fw_socket

--- a/policy/policy_capabilities
+++ b/policy/policy_capabilities
@@ -114,3 +114,19 @@ policycap nnp_nosuid_transition;
 # common file/socket: ioctl { 0x5450 0x5451 }
 #
 #policycap ioctl_skip_cloexec;
+
+# Enable netlink xperms support. Requires libsepol 3.8+
+# and kernel 6.13.
+#
+# Checks enabled:
+# netlink_route_socket: nlmsg { nlmsg_type }
+# netlink_tcpdiag_socket: nlmsg { nlmsg_type }
+# netlink_xfrm_socket: nlmsg { nlmsg_type }
+# netlink_audit_socket: nlmsg { nlmsg_type }
+#
+# Checks disabled:
+# netlink_route_socket: nlmsg_read nlmsg_write
+# netlink_tcpdiag_socket: nlmsg_read nlmsg_write
+# netlink_xfrm_socket: nlmsg_read nlmsg_write
+# netlink_audit_socket: nlmsg_read nlmsg_write nlmsg_relay nlmsg_readpriv nlmsg_tty_audit
+#policycap netlink_xperm;


### PR DESCRIPTION
Add the netlink_xperm policy capability and nlmsg permission definitions. The policy capability is commented-out/disabled by default. Enabling it will require the next release version of libsepol (3.8+) and the next release version of the kernel (6.13+). When the policy capability is enabled, the kernel switches from checking the current nlmsg_read/write/... permissions to always checking a single nlmsg permission with the nlmsg_type value as an extended permission.

nlmsg permission is not added to the *_netlink_socket_perms macros to avoid unwittingly allowing all netlink message types when/if this policy capability is enabled.