### PR TITLE
cron: Remove too greedy file context grab

### DIFF
--- a/policy/modules/services/cron.fc
+++ b/policy/modules/services/cron.fc
@@ -35,7 +35,6 @@
 /run/cron(d)?\.reboot	--	gen_context(system_u:object_r:crond_runtime_t,s0)
 /run/fcron\.fifo	-s	gen_context(system_u:object_r:crond_runtime_t,s0)
 /run/fcron\.pid	--	gen_context(system_u:object_r:crond_runtime_t,s0)
-/run/.*cron.*	--	gen_context(system_u:object_r:crond_runtime_t,s0)
 
 /var/spool/anacron(/.*)?	gen_context(system_u:object_r:system_cron_spool_t,s0)
 /var/spool/at(/.*)?	gen_context(system_u:object_r:user_cron_spool_t,s0)


### PR DESCRIPTION
This regexp will match lots of unintended files, for example things created by tempfile patterns (could include "cron"), and also things inside subdirectories.

It feels like a better approach would be to find actual directories used, or at the very least to limit it to files directly under /run.

It's possible just removing it is too harsh, but I feel at least it should be changed.