### PR TITLE
systemd: Fix systemd_write_notify_socket().

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1020,12 +1020,12 @@ interface(`init_unix_stream_socket_connectto',`
 ##	</summary>
 ## </param>
 #
-interface(`init_unix_stream_socket_sendto',`
+interface(`init_unix_dgram_socket_sendto',`
 	gen_require(`
 		type init_t;
 	')
 
-	allow $1 init_t:unix_stream_socket sendto;
+	allow $1 init_t:unix_dgram_socket sendto;
 ')
 
 ########################################

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -323,7 +323,7 @@ interface(`systemd_write_notify_socket',`
 	')
 
 	init_list_runtime($1)
-	init_unix_stream_socket_sendto($1)
+	init_unix_dgram_socket_sendto($1)
 	allow $1 systemd_runtime_notify_t:sock_file write_sock_file_perms;
 ')
 


### PR DESCRIPTION
The notify socket is SOCK_DGRAM. See sd_notify(3) NOTES section for details.