### PR TITLE
init: Move common rules out of daemon/system interfaces.

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -127,11 +127,12 @@ interface(`init_unit_file',`
 #
 interface(`init_script_domain',`
 	gen_require(`
+		attribute init_domain_type;
 		attribute init_script_domain_type, init_script_file_type;
 		attribute init_run_all_scripts_domain;
 	')
 
-	typeattribute $1 init_script_domain_type;
+	typeattribute $1 init_script_domain_type, init_domain_type;
 	typeattribute $2 init_script_file_type;
 
 	domain_type($1)
@@ -140,16 +141,6 @@ interface(`init_script_domain',`
 	role system_r types $1;
 
 	domtrans_pattern(init_run_all_scripts_domain, $2, $1)
-
-	ifdef(`init_systemd',`
-		gen_require(`
-			type init_t;
-		')
-
-		allow $1 init_t:unix_stream_socket { getattr ioctl read write };
-
-		allow init_t $1:process2 { nnp_transition nosuid_transition };
-	')
 ')
 
 ########################################
@@ -169,33 +160,18 @@ interface(`init_script_domain',`
 #
 interface(`init_domain',`
 	gen_require(`
+		attribute init_domain_type;
 		type init_t;
 		role system_r;
 	')
 
 	domain_type($1)
 	domain_entry_file($1, $2)
+	typeattribute $1 init_domain_type;
 
 	role system_r types $1;
 
 	domtrans_pattern(init_t, $2, $1)
-
-	allow init_t $1:process rlimitinh;
-
-	ifdef(`init_systemd',`
-		gen_require(`
-			type init_tmpfs_t;
-		')
-
-		allow $1 init_t:unix_stream_socket { getattr ioctl read write };
-
-		allow init_t $1:process siginh;
-		allow init_t $1:process2 { nnp_transition nosuid_transition };
-
-		# StandardInputText uses a memfd rw shm segment.
-		# Cannot deny writes or it breaks.
-		allow $1 init_tmpfs_t:file rw_inherited_file_perms;
-	')
 ')
 
 ########################################
@@ -275,35 +251,6 @@ interface(`init_spec_daemon_domain',`
 	role system_r types $1;
 
 	spec_domtrans_pattern(init_t, $2, $1)
-
-	allow init_t $1:process rlimitinh;
-
-	ifdef(`init_systemd',`
-		gen_require(`
-			type init_tmpfs_t;
-		')
-
-		allow $1 init_t:unix_stream_socket { getattr ioctl read write };
-
-		allow init_t $1:process2 { nnp_transition nosuid_transition };
-
-		# StandardInputText uses a memfd rw shm segment.
-		# Cannot deny writes or it breaks.
-		allow $1 init_tmpfs_t:file rw_inherited_file_perms;
-	')
-
-	# daemons started from init will
-	# inherit fds from init for the console
-	init_dontaudit_use_fds($1)
-	term_dontaudit_use_console($1)
-
-	# init script ptys are the stdin/out/err
-	# when using run_init
-	init_use_script_ptys($1)
-
-	ifdef(`direct_sysadm_daemon',`
-		userdom_dontaudit_use_user_terminals($1)
-	')
 ')
 
 ########################################
@@ -343,7 +290,7 @@ interface(`init_spec_daemon_domain',`
 #
 interface(`init_daemon_domain',`
 	gen_require(`
-		type init_t, initrc_t;
+		type initrc_t;
 		role system_r;
 		attribute daemon;
 	')
@@ -357,39 +304,8 @@ interface(`init_daemon_domain',`
 
 	domtrans_pattern(initrc_t, $2, $1)
 
-	# daemons started from init will
-	# inherit fds from init for the console
-	init_dontaudit_use_fds($1)
-	term_dontaudit_use_console($1)
-
-	# init script ptys are the stdin/out/err
-	# when using run_init
-	init_use_script_ptys($1)
-
-	allow init_t $1:process rlimitinh;
-
-	ifdef(`direct_sysadm_daemon',`
-		userdom_dontaudit_use_user_terminals($1)
-	')
-
 	ifdef(`init_systemd',`
 		init_domain($1, $2)
-
-		allow $1 init_t:unix_dgram_socket sendto;
-
-		allow init_t $1:process noatsecure;
-		allow init_t $1:process2 { nnp_transition nosuid_transition };
-
-		# for /run/systemd/private
-		init_write_runtime_socket($1)
-
-		optional_policy(`
-			systemd_stream_connect_socket_proxyd($1)
-		')
-	')
-
-	optional_policy(`
-		nscd_use($1)
 	')
 ')
 
@@ -558,8 +474,6 @@ interface(`init_system_domain',`
 
 	ifdef(`init_systemd',`
 		init_domain($1, $2)
-
-		allow initrc_t $1:process2 { nnp_transition nosuid_transition };
 	')
 ')
 

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -37,6 +37,7 @@ gen_tunable(init_daemons_use_tty, false)
 ## </desc>
 gen_tunable(init_mounton_non_security, false)
 
+attribute init_domain_type;
 attribute init_mountpoint_type;
 attribute init_path_unit_loc_type;
 attribute init_script_domain_type;
@@ -94,7 +95,7 @@ type initctl_t;
 files_type(initctl_t)
 mls_trusted_object(initctl_t)
 
-type initrc_t, init_script_domain_type, init_run_all_scripts_domain;
+type initrc_t, init_script_domain_type, init_run_all_scripts_domain, init_domain_type;
 type initrc_exec_t, init_script_file_type;
 init_domain(initrc_t, initrc_exec_t)
 
@@ -313,14 +314,8 @@ ifdef(`init_systemd',`
 	allow init_t daemon:unix_dgram_socket create_socket_perms;
 	allow init_t daemon:tcp_socket create_stream_socket_perms;
 	allow init_t daemon:udp_socket create_socket_perms;
-	allow daemon init_t:unix_dgram_socket sendto;
 
 	allow init_run_all_scripts_domain systemdunit:service { start status stop };
-
-	allow systemprocess init_t:unix_dgram_socket sendto;
-	allow systemprocess init_t:unix_stream_socket { append getattr ioctl read write };
-
-	allow daemon init_t:unix_stream_socket { append getattr ioctl read write };
 
 	# systemd must be able to renice processes in other
 	# slices when containers are started and stopped
@@ -1551,6 +1546,42 @@ optional_policy(`
 
 ########################################
 #
+# Rules applied to init domains.
+#
+# On SysVinit systems, these are domains started out of the inittab.
+# On systemd systems, this is all domains started by pid1: the union of
+# daemon, systemprocess, init scripts, and domains using init_domain().
+#
+
+# These rules are here instead of above in init_t/initrc_t sections to ensure
+# consistent behavior across all init domains.
+allow { init_t initrc_t } { daemon init_domain_type init_script_domain_type systemprocess }:process { noatsecure rlimitinh };
+allow { init_t initrc_t } { daemon init_domain_type init_script_domain_type systemprocess }:process2 { nnp_transition nosuid_transition };
+
+ifdef(`init_systemd',`
+	allow init_t init_domain_type:process siginh;
+
+	allow init_domain_type init_t:unix_stream_socket { append getattr ioctl read write };
+
+	# StandardInputText uses a memfd rw shm segment.
+	# Cannot deny writes or it breaks.
+	allow init_domain_type init_tmpfs_t:file rw_inherited_file_perms;
+
+	fs_search_cgroup_dirs(init_domain_type)
+
+	# for /run/systemd/private
+	init_write_runtime_socket(init_domain_type)
+
+	# Type=notify
+	systemd_write_notify_socket(init_domain_type)
+
+	optional_policy(`
+		systemd_stream_connect_socket_proxyd(init_domain_type)
+	')
+')
+
+########################################
+#
 # Rules applied to all daemons
 #
 
@@ -1571,8 +1602,13 @@ ifdef(`init_systemd',`
 
 	fs_search_cgroup_dirs(daemon)
 
-	# need write to /var/run/systemd/notify
-	systemd_write_notify_socket(daemon)
+	optional_policy(`
+		systemd_stream_connect_socket_proxyd(daemon)
+	')
+
+	optional_policy(`
+		nscd_use(daemon)
+	')
 ')
 
 tunable_policy(`init_daemons_use_tty',`
@@ -1604,6 +1640,7 @@ optional_policy(`
 	userdom_dontaudit_rw_all_users_stream_sockets(daemon)
 	userdom_dontaudit_read_user_tmp_files(daemon)
 	userdom_dontaudit_write_user_tmp_files(daemon)
+	userdom_dontaudit_use_user_terminals(daemon)
 ')
 
 ########################################
@@ -1617,4 +1654,5 @@ optional_policy(`
 	userdom_dontaudit_search_user_home_dirs(systemprocess)
 	userdom_dontaudit_rw_all_users_stream_sockets(systemprocess)
 	userdom_dontaudit_write_user_tmp_files(systemprocess)
+	userdom_dontaudit_use_user_terminals(systemprocess)
 ')


### PR DESCRIPTION
Move common daemon and system process rules to `init.te` for consistent permissions.