### PR TITLE
Update mcs.if to instruct caller to "use" mcs_constrained and not "remove"

### DIFF
--- a/policy/modules/kernel/mcs.if
+++ b/policy/modules/kernel/mcs.if
@@ -44,7 +44,7 @@ interface(`mcs_constrained',`
 ## <rolecap/>
 #
 interface(`mcs_file_read_all',`
-	refpolicywarn(`$0() has been deprecated, please remove mcs_constrained() instead.')
+	refpolicywarn(`$0() has been deprecated, please use mcs_constrained() instead.')
 ')
 
 ########################################
@@ -60,7 +60,7 @@ interface(`mcs_file_read_all',`
 ## <rolecap/>
 #
 interface(`mcs_file_write_all',`
-	refpolicywarn(`$0() has been deprecated, please remove mcs_constrained() instead.')
+	refpolicywarn(`$0() has been deprecated, please use mcs_constrained() instead.')
 ')
 
 ########################################
@@ -76,7 +76,7 @@ interface(`mcs_file_write_all',`
 ## <rolecap/>
 #
 interface(`mcs_killall',`
-	refpolicywarn(`$0() has been deprecated, please remove mcs_constrained() instead.')
+	refpolicywarn(`$0() has been deprecated, please use mcs_constrained() instead.')
 ')
 
 ########################################
@@ -92,7 +92,7 @@ interface(`mcs_killall',`
 ## </param>
 #
 interface(`mcs_ptrace_all',`
-	refpolicywarn(`$0() has been deprecated, please remove mcs_constrained() instead.')
+	refpolicywarn(`$0() has been deprecated, please use mcs_constrained() instead.')
 ')
 
 ########################################


### PR DESCRIPTION
Fixed deprecated statement in mcs interfaces that instructed caller to 'remove' mcs_constrained()'.