### PR TITLE
Setup sudo log file type

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -37,6 +37,7 @@ template(`sudo_role_template',`
 
 	gen_require(`
 		type sudo_exec_t;
+		type sudo_log_t;
 		attribute sudodomain;
 	')
 
@@ -73,6 +74,10 @@ template(`sudo_role_template',`
 	allow $1_sudo_t self:unix_stream_socket connectto;
 	allow $1_sudo_t self:key manage_key_perms;
 	dontaudit $1_sudo_t self:capability { dac_read_search sys_ptrace };
+
+	allow $1_sudo_t sudo_log_t:dir add_entry_dir_perms;
+	allow $1_sudo_t sudo_log_t:file { append_file_perms create_file_perms };
+	logging_log_filetrans($1_sudo_t, sudo_log_t, file)
 
 	# allow getting the process group of the parent process
 	allow $1_sudo_t $2:process getpgid;

--- a/policy/modules/admin/sudo.te
+++ b/policy/modules/admin/sudo.te
@@ -29,6 +29,9 @@ attribute sudodomain;
 type sudo_exec_t;
 application_executable_file(sudo_exec_t)
 
+type sudo_log_t;
+logging_log_file(sudo_log_t)
+
 tunable_policy(`sudo_all_tcp_connect_http_port',`
 	corenet_tcp_connect_http_port(sudodomain)
 ')


### PR DESCRIPTION
When using the sudoers option logfile=/var/log/sudo.log it needs to create (and append) to the log file.

node=test123 type=AVC msg=audit(1731031593.322:16399): avc:  denied  { write } for  pid=5792 comm="sudo" name="/" dev="dm-5" ino=2 scontext=toor_u:staff_r:staff_sudo_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=dir permissive=1
node=test123 type=AVC msg=audit(1731031593.322:16399): avc:  denied  { add_name } for  pid=5792 comm="sudo" name="sudo.log" scontext=toor_u:staff_r:staff_sudo_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=dir permissive=1
node=test123 type=AVC msg=audit(1731031593.322:16399): avc:  denied  { create } for  pid=5792 comm="sudo" name="sudo.log" scontext=toor_u:staff_r:staff_sudo_t:s0 tcontext=toor_u:object_r:var_log_t:s0 tclass=file permissive=1
node=test123 type=AVC msg=audit(1731031593.322:16399): avc:  denied  { append open } for  pid=5792 comm="sudo" path="/var/log/sudo.log" dev="dm-5" ino=32 scontext=toor_u:staff_r:staff_sudo_t:s0 tcontext=toor_u:object_r:var_log_t:s0 tclass=file permissive=1
node=test123 type=AVC msg=audit(1731031593.322:16400): avc:  denied  { lock } for  pid=5792 comm="sudo" path="/var/log/sudo.log" dev="dm-5" ino=32 scontext=toor_u:staff_r:staff_sudo_t:s0 tcontext=toor_u:object_r:var_log_t:s0 tclass=file permissive=1
node=test123 type=AVC msg=audit(1731031593.322:16401): avc:  denied  { getattr } for  pid=5792 comm="sudo" path="/var/log/sudo.log" dev="dm-5" ino=32 scontext=toor_u:staff_r:staff_sudo_t:s0 tcontext=toor_u:object_r:var_log_t:s0 tclass=file permissive=1