### PR TITLE
ci: add module storage test 

### DIFF
--- a/.github/workflows/build-policy.yml
+++ b/.github/workflows/build-policy.yml
@@ -108,6 +108,16 @@ jobs:
       run: |
         make validate
 
+    - name: Test module storage
+      working-directory: ${{ inputs.path }}
+      shell: bash
+      if: ${{ matrix.monolithic == 'n' }}
+      run: |
+        temp="${TEST_TOOLCHAIN%\"}"
+        temp="${temp#\"}"
+        echo "compiler-directory = ${temp}/usr/libexec/selinux/hll" | sudo tee -a /etc/selinux/semanage.conf
+        make test-module-storage
+
     - name: Build docs
       working-directory: ${{ inputs.path }}
       shell: bash

--- a/Rules.modular
+++ b/Rules.modular
@@ -232,6 +232,16 @@ validate: $(base_pkg) $(mod_pkgs) $(tmpdir)/all_mods.fc $(builtappfiles)
 
 ########################################
 #
+# Test converting to module storage
+#
+test-module-storage: $(base_pkg) $(mod_pkgs)
+	@echo "Testing module storage for $(NAME)."
+	@test -d $(tmpdir)/policy_root/var/lib/selinux/$(NAME) || mkdir -p $(tmpdir)/policy_root/var/lib/selinux/$(NAME)
+	$(verbose) $(SEMODULE) $(VERBOSE_FLAG) --noreload --store $(NAME) --path $(tmpdir)/policy_root --install *.pp
+	$(verbose) $(SETFILES) -c $(tmpdir)/policy_root/var/lib/selinux/$(NAME)/policy/policy.* $(tmpdir)/policy_root/var/lib/selinux/$(NAME)/contexts/files/file_contexts
+
+########################################
+#
 # Clean the sources
 #
 clean:
@@ -241,4 +251,4 @@ clean:
 	$(verbose) rm -f $(net_contexts) $(net_contexts_nft)
 	$(verbose) rm -fR $(tmpdir)
 
-.PHONY: default all policy base modules install load pure-load clean validate
+.PHONY: default all policy base modules install load pure-load clean validate test-module-storage

--- a/Rules.modular
+++ b/Rules.modular
@@ -225,7 +225,7 @@ validate: $(base_pkg) $(mod_pkgs) $(tmpdir)/all_mods.fc $(builtappfiles)
 	$(verbose) $(SEMOD_LNK) -o $(tmpdir)/test.lnk $(base_pkg) $(mod_pkgs)
 	$(verbose) $(SEMOD_EXP) $(tmpdir)/test.lnk $(tmpdir)/policy.bin
 	@echo "Validating $(NAME) file contexts."
-	$(verbose) $(SETFILES) -q -c $(tmpdir)/policy.bin $(tmpdir)/all_mods.fc
+	$(verbose) $(SETFILES) -c $(tmpdir)/policy.bin $(tmpdir)/all_mods.fc
 	@echo "Validating $(NAME) appconfig."
 	$(verbose) $(validateappconfig) $(builtappconf) $(tmpdir)/policy.bin
 	@echo "Success."

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -228,7 +228,7 @@ $(homedir_template): $(fc)
 #
 $(fcpath): $(fc) $(loadpath) $(userpath)/system.users
 	@echo "Validating $(NAME) file_contexts."
-	$(verbose) $(SETFILES) -q -c $(loadpath) $(fc)
+	$(verbose) $(SETFILES) -c $(loadpath) $(fc)
 	@echo "Installing file_contexts."
 	@$(INSTALL) -d -m 0755 $(@D)
 	$(verbose) $(INSTALL) -m 0644 $(fc) $(fcpath)
@@ -247,7 +247,7 @@ $(fcpath): $(fc) $(loadpath) $(userpath)/system.users
 #
 validate: $(fc) $(polver) $(builtappfiles)
 	@echo "Validating $(NAME) file_contexts."
-	$(verbose) $(SETFILES) -q -c $(polver) $(fc)
+	$(verbose) $(SETFILES) -c $(polver) $(fc)
 	@echo "Validating $(NAME) appconfig."
 	$(verbose) $(validateappconfig) $(builtappconf) $(polver)
 	@echo "Success."


### PR DESCRIPTION
Add test to verify modular policies can be successfully installed from a module storage.

Also drop obsolete setfiles option.