### PR TITLE
Need search perms on cert_t/tls_privkey_t when using private types

### DIFF
--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -23,9 +23,9 @@
 ##	</p>
 ##	<p>
 ##	type mycertfile_t;
-##	cert_type(mycertfile_t)
+##	miscfiles_cert_type(mycertfile_t)
 ##	allow mydomain_t mycertfile_t:file read_file_perms;
-##	files_search_etc(mydomain_t)
+##	miscfiles_search_generic_cert_dirs(mydomain_t)
 ##	</p>
 ## </desc>
 ## <param name="type">
@@ -68,9 +68,9 @@ interface(`miscfiles_cert_type',`
 ##	</p>
 ##	<p>
 ##	type mytlsprivkeyfile_t;
-##	tls_privkey_type(mytlsprivkeyfile_t)
+##	miscfiles_tls_privkey_type(mytlsprivkeyfile_t)
 ##	allow mydomain_t mytlsprivkeyfile_t:file read_file_perms;
-##	files_search_etc(mydomain_t)
+##	miscfiles_search_tls_privkey_dirs(mydomain_t)
 ##	</p>
 ## </desc>
 ## <param name="type">
@@ -108,6 +108,26 @@ interface(`miscfiles_read_all_certs',`
 	allow $1 cert_type:dir list_dir_perms;
 	read_files_pattern($1, cert_type, cert_type)
 	read_lnk_files_pattern($1, cert_type, cert_type)
+')
+
+########################################
+## <summary>
+##	Search generic SSL/TLS directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`miscfiles_search_generic_cert_dirs',`
+	gen_require(`
+		type cert_t;
+	')
+
+	files_search_etc($1)
+	allow $1 cert_t:dir search_dir_perms;
 ')
 
 ########################################
@@ -207,6 +227,27 @@ interface(`miscfiles_mounton_generic_cert_dirs',`
 	')
 
 	allow $1 cert_t:dir mounton;
+')
+
+
+########################################
+## <summary>
+##	Search SSL/TLS private key directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`miscfiles_search_tls_privkey_dirs',`
+	gen_require(`
+		type tls_privkey_t;
+	')
+
+	miscfiles_search_generic_cert_dirs($1)
+	allow $1 tls_privkey_t:dir search_dir_perms;
 ')
 
 ########################################


### PR DESCRIPTION
Even if you create a private key for a certificate in /etc/pki/tls/certs or private key in /etc/pki/tls/private as those directories are labeled cert_t and tls_privkey_t. So you need dir search perms to be able to access your new key type.

node=localhost type=AVC msg=audit(1731898795.566:33533): avc:  denied  { search } for  pid=961 comm="monitor" name="private" dev="dm-0" ino=524539 scontext=system_u:system_r:monitor_t:s0 tcontext=system_u:object_r:tls_privkey_t:s0 tclass=dir permissive=1`