### PR TITLE
Communicate with locale via dbus

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1523,6 +1523,27 @@ interface(`systemd_signull_logind',`
 
 ########################################
 ## <summary>
+##   Send and receive messages from
+##   systemd locale over dbus.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_dbus_chat_locale',`
+	gen_require(`
+		type systemd_locale_t;
+		class dbus send_msg;
+	')
+
+	allow $1 systemd_locale_t:dbus send_msg;
+	allow systemd_locale_t $1:dbus send_msg;
+')
+
+########################################
+## <summary>
 ##  List the contents of systemd userdb runtime directories.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -884,11 +884,14 @@ miscfiles_read_localization(systemd_journal_init_t)
 kernel_read_kernel_sysctls(systemd_locale_t)
 
 files_read_etc_files(systemd_locale_t)
+files_read_usr_files(systemd_locale_t)
 
 fs_getattr_all_fs(systemd_locale_t)
 fs_search_cgroup_dirs(systemd_locale_t)
 
 init_stream_connect(systemd_locale_t)
+
+miscfiles_read_localization(systemd_locale_t)
 
 selinux_use_status_page(systemd_locale_t)
 


### PR DESCRIPTION
node=localhost type=USER_AVC msg=audit(1731946583.709:17143): pid=962 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:script_t:s0 tcontext=system_u:system_r:systemd_locale_t:s0 tclass=dbus permissive=1 exe="/usr/bin/dbus-broker" sauid=81 hostname=? addr=? terminal=?'␝UID="dbus" AUID="unset" SAUID="dbus"

Cleanup some denials seen for systemd_locale_t
node=localhost type=AVC msg=audit(1731946409.877:15089): avc:  denied  { read } for  pid=6038 comm="systemd-localed" name="language-fallback-map" dev="dm-0" ino=287302 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1 node=localhost type=AVC msg=audit(1731946409.877:15089): avc:  denied  { open } for  pid=6038 comm="systemd-localed" path="/usr/share/systemd/language-fallback-map" dev="dm-0" ino=287302 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1 node=localhost type=AVC msg=audit(1731946409.877:15090): avc:  denied  { getattr } for  pid=6038 comm="systemd-localed" path="/usr/share/systemd/language-fallback-map" dev="dm-0" ino=287302 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1 node=localhost type=AVC msg=audit(1731946409.885:15092): avc:  denied  { ioctl } for  pid=6038 comm="systemd-localed" path="/usr/share/systemd/language-fallback-map" dev="dm-0" ino=287302 ioctlcmd=0x5401 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=1

node=localhost type=AVC msg=audit(1731946409.877:15086): avc:  denied  { search } for  pid=6038 comm="systemd-localed" name="locale" dev="dm-0" ino=264167 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:locale_t:s0 tclass=dir permissive=1
node=localhost type=AVC msg=audit(1731946409.877:15086): avc:  denied  { read } for  pid=6038 comm="systemd-localed" name="locale-archive.real" dev="dm-0" ino=265820 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:locale_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1731946409.877:15086): avc:  denied  { open } for  pid=6038 comm="systemd-localed" path="/usr/lib/locale/locale-archive" dev="dm-0" ino=265820 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:locale_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1731946409.877:15087): avc:  denied  { getattr } for  pid=6038 comm="systemd-localed" path="/usr/lib/locale/locale-archive" dev="dm-0" ino=265820 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:locale_t:s0 tclass=file permissive=1
node=localhost type=AVC msg=audit(1731946409.877:15088): avc:  denied  { map } for  pid=6038 comm="systemd-localed" path="/usr/lib/locale/locale-archive" dev="dm-0" ino=265820 scontext=system_u:system_r:systemd_locale_t:s0 tcontext=system_u:object_r:locale_t:s0 tclass=file permissive=1