### PR TITLE
authlogin: connect to nsresourced

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -477,6 +477,7 @@ sysnet_dns_name_resolve(nsswitch_domain)
 ifdef(`init_systemd', `
 	systemd_stream_connect_userdb(nsswitch_domain)
 	systemd_stream_connect_homed(nsswitch_domain)
+	systemd_stream_connect_nsresourced(nsswitch_domain)
 ')
 
 tunable_policy(`authlogin_nsswitch_use_ldap',`


### PR DESCRIPTION
Container UID/GID lookups for utilities such as nspawn require nss clients to be able to make nsresourced lookups.