### PR TITLE
systemd: various changes

### DIFF
--- a/policy/modules/admin/bootloader.te
+++ b/policy/modules/admin/bootloader.te
@@ -91,6 +91,7 @@ dev_rw_nvram(bootloader_t)
 
 fs_getattr_xattr_fs(bootloader_t)
 fs_getattr_dos_fs(bootloader_t)
+fs_getattr_autofs(bootloader_t)
 fs_getattr_tmpfs(bootloader_t)
 fs_read_tmpfs_symlinks(bootloader_t)
 #Needed for EFI

--- a/policy/modules/admin/bootloader.te
+++ b/policy/modules/admin/bootloader.te
@@ -89,9 +89,9 @@ dev_dontaudit_write_sysfs_files(bootloader_t)
 # needed on some hardware
 dev_rw_nvram(bootloader_t)
 
+fs_list_auto_mountpoints(bootloader_t)
 fs_getattr_xattr_fs(bootloader_t)
 fs_getattr_dos_fs(bootloader_t)
-fs_getattr_autofs(bootloader_t)
 fs_getattr_tmpfs(bootloader_t)
 fs_read_tmpfs_symlinks(bootloader_t)
 #Needed for EFI

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -4,6 +4,7 @@
 /etc/udev/hwdb\.bin			--	gen_context(system_u:object_r:systemd_hwdb_t,s0)
 
 /run/log/journal(/.*)?				gen_context(system_u:object_r:systemd_journal_t,s0)
+/run/log/systemd(/.*)?				gen_context(system_u:object_r:systemd_log_t,s0)
 
 /usr/bin/journalctl				--	gen_context(system_u:object_r:systemd_journalctl_exec_t,s0)
 /usr/bin/systemd-analyze		--	gen_context(system_u:object_r:systemd_analyze_exec_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1111,6 +1111,9 @@ tunable_policy(`systemd_logind_get_bootloader',`
 	fs_list_dos(systemd_logind_t)
 	fs_read_dos_files(systemd_logind_t)
 
+	# automounted bootloader partitions have dosfs_t for contents inside them, so we only need to allow getattr
+	fs_getattr_autofs(systemd_logind_t)
+
 	files_search_boot(systemd_logind_t)
 ')
 # systemd-logind uses util-linux's blkid in order to find the ESP (EFI System Partition).


### PR DESCRIPTION
systemd stores some early boot log files here, such as the userspace measurement event log for TPMs. The logfiles stored here aren't sensitive enough to warrant their own type, so let's just reuse systemd_log_t.