### PR TITLE
If mta module is not installed useradd fails to create mailbox files

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -504,6 +504,7 @@ corecmd_exec_bin(useradd_t)
 domain_use_interactive_fds(useradd_t)
 domain_read_all_domains_state(useradd_t)
 
+files_dontaudit_search_spool(useradd_t)
 files_manage_etc_files(useradd_t)
 files_search_var_lib(useradd_t)
 files_relabel_etc_files(useradd_t)


### PR DESCRIPTION
Just quiet down the denial seen in enforcing.

node=asdf type=AVC msg=audit(1731544222.422:251879): avc:  denied  { search } for  pid=14952 comm="useradd" name="spool" dev="dm-8" ino=1179650 scontext=system_u:system_r:useradd_t:s0 tcontext=system_u:object_r:var_spool_t:s0 tclass=dir permissive=0
node=asdf type=AVC msg=audit(1731545219.734:272283): avc:  denied  { search } for  pid=19939 comm="useradd" name="spool" dev="dm-8" ino=1179650 scontext=system_u:system_r:useradd_t:s0 tcontext=system_u:object_r:var_spool_t:s0 tclass=dir permissive=1
node=asdf type=AVC msg=audit(1731545219.734:272283): avc:  denied  { write } for  pid=19939 comm="useradd" name="mail" dev="dm-8" ino=1179652 scontext=system_u:system_r:useradd_t:s0 tcontext=system_u:object_r:var_spool_t:s0 tclass=dir permissive=1
node=asdf type=AVC msg=audit(1731545219.734:272283): avc:  denied  { add_name } for  pid=19939 comm="useradd" name="dsugar" scontext=system_u:system_r:useradd_t:s0 tcontext=system_u:object_r:var_spool_t:s0 tclass=dir permissive=1
node=asdf type=AVC msg=audit(1731545219.734:272283): avc:  denied  { create } for  pid=19939 comm="useradd" name="dsugar" scontext=system_u:system_r:useradd_t:s0 tcontext=system_u:object_r:var_spool_t:s0 tclass=file permissive=1
node=asdf type=AVC msg=audit(1731545219.734:272283): avc:  denied  { write open } for  pid=19939 comm="useradd" path="/var/spool/mail/dsugar" dev="dm-8" ino=1179671 scontext=system_u:system_r:useradd_t:s0 tcontext=system_u:object_r:var_spool_t:s0 tclass=file permissive=1
node=asdf type=AVC msg=audit(1731545219.734:272285): avc:  denied  { setattr } for  pid=19939 comm="useradd" name="dsugar" dev="dm-8" ino=1179671 scontext=system_u:system_r:useradd_t:s0 tcontext=system_u:object_r:var_spool_t:s0 tclass=file permissive=1