### PR TITLE
label jspawnhelper bin_t

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -210,6 +210,7 @@ ifdef(`distro_gentoo',`
 /usr/lib/gnome-settings-daemon/.* --	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/gvfs/gvfs.*		--	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/ipsec/.*		--	gen_context(system_u:object_r:bin_t,s0)
+/usr/lib/jvm/java.*/lib/jspawnhelper	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/kde4/libexec/.*	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/[^/]+/libexec/kf5/.*	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/mailman/bin(/.*)?		gen_context(system_u:object_r:bin_t,s0)


### PR DESCRIPTION
jspawnhelper is executed when using java's ProcessBuilder.start () or Runtime.exec ().  I'm seeing a denial for 'lib_t:file execute_no_trans' because jspawnhelper was labeled lib_t.  bin_t seems to be more correct as this can be executed.

https://github.com/openjdk/jdk/blob/master/src/java.base/unix/native/jspawnhelper/jspawnhelper.c