### PR TITLE
authlogin: fix regex for /etc/tcb

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -3,7 +3,7 @@
 /etc/passwd\.lock	--	gen_context(system_u:object_r:shadow_lock_t,s0)
 /etc/gshadow.*		--	gen_context(system_u:object_r:shadow_t,s0)
 /etc/shadow.*		--	gen_context(system_u:object_r:shadow_t,s0)
-/etc/tcb(/.*)?		--	gen_context(system_u:object_r:shadow_t,s0)
+/etc/tcb/.+/shadow.*	--	gen_context(system_u:object_r:shadow_t,s0)
 /etc/security/opasswd		--	gen_context(system_u:object_r:shadow_history_t,s0)
 /etc/security/opasswd\.old	--	gen_context(system_u:object_r:shadow_history_t,s0)
 
@@ -26,6 +26,7 @@ ifdef(`distro_redhat', `
 /usr/libexec/utempter/utempter	--	gen_context(system_u:object_r:utempter_exec_t,s0)
 ')
 /usr/libexec/chkpwd/tcb_chkpwd	--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
+/usr/libexec/chkpwd/tcb_updpwd	--	gen_context(system_u:object_r:updpwd_exec_t,s0)
 
 /usr/sbin/pam_console_apply	--	gen_context(system_u:object_r:pam_console_exec_t,s0)
 /usr/sbin/pam_timestamp_check	--	gen_context(system_u:object_r:pam_exec_t,s0)


### PR DESCRIPTION
Also add the proper context for the tcb_updpwd binary.

Complements: bc88a1ca4b37df37c3654fc9e5368d7d96b11548