### PR TITLE
secadm: remove duplicate policies

### DIFF
--- a/policy/modules/roles/secadm.te
+++ b/policy/modules/roles/secadm.te
@@ -15,45 +15,14 @@ userdom_security_admin_template(secadm_t, secadm_r)
 # Local policy
 #
 
-allow secadm_t self:capability { dac_override dac_read_search };
-
-corecmd_exec_shell(secadm_t)
-
-dev_relabel_all_dev_nodes(secadm_t)
-
-domain_obj_id_change_exemption(secadm_t)
-
-mls_process_read_all_levels(secadm_t)
-mls_file_read_all_levels(secadm_t)
 mls_file_write_all_levels(secadm_t)
-mls_file_upgrade(secadm_t)
-mls_file_downgrade(secadm_t)
 
 auth_role(secadm, secadm_t, secadm_application_exec_domain, secadm_r)
-files_relabel_non_auth_files(secadm_t)
-auth_relabel_shadow(secadm_t)
 
-init_exec(secadm_t)
-
-logging_read_audit_log(secadm_t)
-logging_read_generic_logs(secadm_t)
-logging_read_audit_config(secadm_t)
 logging_watch_audit_log(secadm_t)
 
 optional_policy(`
-	aide_run(secadm_t, secadm_r)
-')
-
-optional_policy(`
 	auditadm_role_change(secadm_r)
-')
-
-optional_policy(`
-	dmesg_exec(secadm_t)
-')
-
-optional_policy(`
-	netlabel_run_mgmt(secadm_t, secadm_r)
 ')
 
 optional_policy(`


### PR DESCRIPTION
There are some duplicate policies in secadm, which are defined in userdom_security_admin_template() and remove them in secadm.