### PR TITLE
This is a policy for the ARC milter

### DIFF
--- a/policy/modules/admin/cloudinit.te
+++ b/policy/modules/admin/cloudinit.te
@@ -707,6 +707,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	openarc_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
 	openct_admin(cloud_init_t, system_r)
 ')
 

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -750,6 +750,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	openarc_admin(sysadm_t, sysadm_r)
+')
+
+optional_policy(`
 	openct_admin(sysadm_t, sysadm_r)
 ')
 

--- a/policy/modules/services/openarc.fc
+++ b/policy/modules/services/openarc.fc
@@ -1,0 +1,13 @@
+/etc/openarc/keys(/.*)?                         gen_context(system_u:object_r:openarc_milter_private_key_t,s0)
+
+/etc/rc\.d/init\.d/openarc                  --	gen_context(system_u:object_r:openarc_milter_initrc_exec_t,s0)
+
+/usr/bin/openarc                            --	gen_context(system_u:object_r:openarc_milter_exec_t,s0)
+
+/usr/lib/systemd/system/openarc\.service	--	gen_context(system_u:object_r:openarc_milter_unit_t,s0)
+
+/usr/sbin/openarc                           --	gen_context(system_u:object_r:openarc_milter_exec_t,s0)
+
+/run/openarc(/.*)?                              gen_context(system_u:object_r:openarc_milter_data_t,s0)
+
+/var/run/openarc(/.*)?                          gen_context(system_u:object_r:openarc_milter_data_t,s0)

--- a/policy/modules/services/openarc.if
+++ b/policy/modules/services/openarc.if
@@ -1,0 +1,74 @@
+## <summary>Authenticated Received Chain milter.</summary>
+
+########################################
+## <summary>
+##	Allow a domain to talk to OpenARC via Unix domain socket
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`openarc_stream_connect',`
+	gen_require(`
+		type openarc_milter_data_t, openarc_milter_t;
+	')
+
+	stream_connect_pattern($1, openarc_milter_data_t, openarc_milter_data_t, openarc_milter_t)
+')
+
+########################################
+## <summary>
+##	Reload the openarc service (systemd).
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`openarc_reload',`
+	gen_require(`
+		type openarc_milter_unit_t;
+		class service { reload status };
+	')
+
+	allow $1 openarc_milter_unit_t:service { reload status };
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to
+##	administrate an OpenARC environment.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`openarc_admin',`
+	gen_require(`
+		type openarc_milter_t, openarc_milter_initrc_exec_t, openarc_milter_private_key_t;
+		type openarc_milter_data_t;
+	')
+
+	allow $1 openarc_milter_t:process { ptrace signal_perms };
+	ps_process_pattern($1, openarc_milter_t)
+
+	init_startstop_service($1, $2, openarc_milter_t, openarc_milter_initrc_exec_t)
+
+	files_search_etc($1)
+	admin_pattern($1, openarc_milter_private_key_t)
+
+	files_search_runtime($1)
+	admin_pattern($1, openarc_milter_data_t)
+')

--- a/policy/modules/services/openarc.te
+++ b/policy/modules/services/openarc.te
@@ -1,0 +1,62 @@
+policy_module(openarc)
+
+########################################
+#
+# Declarations
+#
+
+milter_template(openarc)
+
+type openarc_milter_initrc_exec_t;
+init_script_file(openarc_milter_initrc_exec_t)
+
+type openarc_milter_private_key_t;
+files_security_file(openarc_milter_private_key_t)
+
+type openarc_milter_unit_t;
+init_unit_file(openarc_milter_unit_t)
+
+init_daemon_runtime_file(openarc_milter_data_t, dir, "openarc")
+
+########################################
+#
+# Local policy
+#
+
+allow openarc_milter_t self:capability { dac_override dac_read_search setgid setuid };
+allow openarc_milter_t self:process { getsched signal signull };
+allow openarc_milter_t self:unix_stream_socket create_stream_socket_perms;
+
+read_files_pattern(openarc_milter_t, openarc_milter_private_key_t, openarc_milter_private_key_t)
+
+# /proc/sys/kernel/ngroups_max
+kernel_read_kernel_sysctls(openarc_milter_t)
+kernel_read_vm_overcommit_sysctl(openarc_milter_t)
+
+corecmd_exec_shell(openarc_milter_t)
+
+corenet_udp_bind_generic_node(openarc_milter_t)
+corenet_udp_bind_all_unreserved_ports(openarc_milter_t)
+corenet_udp_bind_generic_port(openarc_milter_t)
+
+dev_read_urand(openarc_milter_t)
+# for cpu/online
+dev_read_sysfs(openarc_milter_t)
+
+files_runtime_filetrans(openarc_milter_t, openarc_milter_data_t, { dir file })
+files_read_usr_files(openarc_milter_t)
+files_search_spool(openarc_milter_t)
+
+miscfiles_read_generic_certs(openarc_milter_t)
+
+# Allow OpenARC to send a message to Postmaster in case of an invalid ARC signature.
+mta_sendmail_exec(openarc_milter_t)
+
+optional_policy(`
+	mta_read_config(openarc_milter_t)
+')
+
+optional_policy(`
+	# set up unix socket
+	postfix_search_spool(openarc_milter_t)
+')

--- a/policy/modules/services/postfix.te
+++ b/policy/modules/services/postfix.te
@@ -419,6 +419,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	openarc_stream_connect(postfix_cleanup_t)
+')
+
+optional_policy(`
 	mailman_read_data_files(postfix_cleanup_t)
 ')
 


### PR DESCRIPTION
This policy file particularly targets [OpenARC](https://github.com/flowerysong/OpenARC/). The OpenARC milter is both an open source library for adding Authenticated Received Chain (ARC) support to applications, and an example filter application using the milter protocol.

The policy files are based on the `dkim policy` in this repository, with adaptions where useful.