### PR TITLE
userdomain: allow grant mac_admin capability to security admin

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1497,6 +1497,7 @@ template(`userdom_admin_user_template',`
 #
 interface(`userdom_security_admin_template',`
 	allow $1 self:capability { dac_override dac_read_search };
+	allow $1 self:capability2 mac_admin;
 
 	corecmd_exec_shell($1)
 


### PR DESCRIPTION
cap_mac_admin is required to operate some LSM modules, such as selinux, apparmor, smack, etc. It is necessary to allow the security administrator role to grant this capability.