### PR TITLE
fixdep dbus

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -142,7 +142,6 @@ term_dontaudit_use_all_ptys(chkpwd_t)
 
 auth_read_shadow_history(chkpwd_t)
 auth_use_nsswitch(chkpwd_t)
-auth_use_pam_systemd(chkpwd_t)
 
 logging_send_audit_msgs(chkpwd_t)
 logging_send_syslog_msg(chkpwd_t)
@@ -158,6 +157,10 @@ ifdef(`distro_ubuntu',`
 	optional_policy(`
 		unconfined_domain(chkpwd_t)
 	')
+')
+
+ifdef(`init_systemd',`
+	auth_use_pam_systemd(chkpwd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
auth_use_pam_systemd requires dbus  :  

> /var/lib/selinux/targeted/tmp/modules/400/authlogin/cil:133 =
> (typeattributeset cil_gen_require dbusd_system_bus_client)

See : https://bugs.gentoo.org/941785