### PR TITLE
Allow fapolicyd to watch /run/netns

### DIFF
--- a/policy/modules/admin/fapolicyd.te
+++ b/policy/modules/admin/fapolicyd.te
@@ -84,6 +84,9 @@ fs_watch_all_fs(fapolicyd_t)
 logging_log_filetrans(fapolicyd_t, fapolicyd_log_t, file)
 logging_send_syslog_msg(fapolicyd_t)
 
+sysnet_watch_sb_netns_dirs(fapolicyd_t)
+sysnet_watch_with_perm_netns_dirs(fapolicyd_t)
+
 fapolicyd_mmap_read_config_files(fapolicyd_t)
 
 optional_policy(`

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -795,6 +795,42 @@ interface(`sysnet_create_netns_dirs',`
 
 ########################################
 ## <summary>
+##	Watch the /run/netns directory for superblock changes
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_watch_sb_netns_dirs',`
+	gen_require(`
+		type ifconfig_runtime_t;
+	')
+
+	allow $1 ifconfig_runtime_t:dir watch_sb;
+')
+
+########################################
+## <summary>
+##	Watch the /run/netns directory with fanofiy masks
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_watch_with_perm_netns_dirs',`
+	gen_require(`
+		type ifconfig_runtime_t;
+	')
+
+	allow $1 ifconfig_runtime_t:dir watch_with_perm;
+')
+
+########################################
+## <summary>
 ##	Create an object in the /run/netns
 ##	directory with a private type.
 ## </summary>


### PR DESCRIPTION
/run/netns is a tmpfs mountpoint

node=localhost type=AVC msg=audit(1738868630.348:1695): avc:  denied  { watch_sb watch_with_perm } for  pid=967 comm="fapolicyd" path="/run/netns" dev="tmpfs" ino=1954

Signed-of-by: Dave Sugar <dsugar100@gmail.com>