### PR TITLE
systemd: allow system --user to get attributes of nsfs inodes

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -99,6 +99,7 @@ template(`systemd_role_template',`
 	files_watch_etc_dirs($1_systemd_t)
 
 	fs_getattr_xattr_fs($1_systemd_t)
+	fs_getattr_nsfs_files($1_systemd_t)
 	fs_manage_cgroup_files($1_systemd_t)
 	fs_watch_cgroup_files($1_systemd_t)
 
@@ -152,6 +153,11 @@ template(`systemd_role_template',`
 	files_list_runtime($1_systemd_tmpfiles_t)
 	files_read_etc_files($1_systemd_tmpfiles_t)
 
+	fs_getattr_nsfs_files($1_systemd_tmpfiles_t)
+
+	init_read_state($1_systemd_tmpfiles_t)
+
+	kernel_dontaudit_getattr_proc($1_systemd_tmpfiles_t)
 	kernel_read_kernel_sysctls($1_systemd_tmpfiles_t)
 	kernel_read_system_state($1_systemd_tmpfiles_t)
 


### PR DESCRIPTION
Fixes:
avc:  denied  { getattr } for  pid=502 comm="systemd" path="cgroup:[4026531835]" dev="nsfs" ino=4026531835 scontext=root:sysadm_r:sysadm_systemd_t
tcontext=system_u:object_r:nsfs_t tclass=file permissive=0

avc:  denied  { getattr } for  pid=502 comm="systemd" path="pid:[4026531836]" dev="nsfs" ino=4026531836
scontext=root:sysadm_r:sysadm_systemd_t
tcontext=system_u:object_r:nsfs_t tclass=file permissive=0

avc:  denied  { getattr } for  pid=506 comm="30-systemd-envi" path="cgroup:[4026531835]" dev="nsfs" ino=4026531835 scontext=root:sysadm_r:sysadm_systemd_t
tcontext=system_u:object_r:nsfs_t tclass=file permissive=0

avc:  denied  { getattr } for  pid=506 comm="30-systemd-envi" path="pid:[4026531836]" dev="nsfs" ino=4026531836
scontext=root:sysadm_r:sysadm_systemd_t
tcontext=system_u:object_r:nsfs_t tclass=file permissive=0

avc:  denied  { getattr } for  pid=508 comm="systemd-tmpfile" path="cgroup:[4026531835]" dev="nsfs" ino=4026531835 scontext=root:sysadm_r:sysadm_systemd_tmpfiles_t
tcontext=system_u:object_r:nsfs_t tclass=file permissive=0

avc:  denied  { getattr } for  pid=508 comm="systemd-tmpfile" path="pid:[4026531836]" dev="nsfs" ino=4026531836
scontext=root:sysadm_r:sysadm_systemd_tmpfiles_t
tcontext=system_u:object_r:nsf _t tclass=file permissive=0

avc:  denied  { search } for  pid=508 comm="systemd-tmpfile" name="1" dev="proc" ino=575 scontext=root:sysadm_r:sysadm_systemd_tmpfiles_t tcontext=system_u:system_r:init_t tclass=dir permissive=0

avc:  denied  { getattr } for  pid=508 comm="systemd-tmpfile" name="/" dev="proc" ino=1 scontext=root:sysadm_r:sysadm_systemd_tmpfiles_t tcontext=system_u:object_r:proc_t tclass=filesystem permissive=0