### PR TITLE
Permit init_t (systemd) to start a detached screen/tmux session

### DIFF
--- a/policy/modules/apps/screen.if
+++ b/policy/modules/apps/screen.if
@@ -138,3 +138,20 @@ interface(`screen_dontaudit_getattr_sock_file',`
 
 	dontaudit $1 screen_runtime_t:sock_file getattr;
 ')
+
+########################################
+## <summary>
+##      Permit running screen
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+interface(`screen_exec',`
+	gen_require(`
+		type screen_exec_t;
+	')
+
+	allow $1 screen_exec_t:file mmap_exec_file_perms;
+')

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -72,6 +72,10 @@ optional_policy(`
 	kubernetes_mountpoint(init_t)
 ')
 
+optional_policy(`
+	screen_exec(init_t)
+')
+
 #
 # init_runtime_t is the type for /var/run/shutdown.pid and /var/run/systemd.
 #


### PR DESCRIPTION
This policy tweak permits running a screen/tmux session via a system service/unit file.

Given the interactive nature of the process it might be worth putting behind a boolean...