### PR TITLE
chronyd: fix dac_read_search denials

### DIFF
--- a/policy/modules/services/chronyd.te
+++ b/policy/modules/services/chronyd.te
@@ -54,7 +54,7 @@ logging_log_file(chronyd_var_log_t)
 # chronyd local policy
 #
 
-allow chronyd_t self:capability { chown dac_override ipc_lock setgid setuid sys_resource sys_time };
+allow chronyd_t self:capability { chown dac_override dac_read_search ipc_lock setgid setuid sys_resource sys_time };
 allow chronyd_t self:process { getcap setcap setrlimit signal };
 allow chronyd_t self:shm create_shm_perms;
 allow chronyd_t self:fifo_file rw_fifo_file_perms;
@@ -134,7 +134,7 @@ optional_policy(`
 # chronyc local policy
 #
 
-allow chronyc_t self:capability { dac_override };
+allow chronyc_t self:capability { dac_override dac_read_search };
 allow chronyc_t self:process { signal };
 allow chronyc_t self:udp_socket create_socket_perms;
 allow chronyc_t self:netlink_route_socket create_netlink_socket_perms;


### PR DESCRIPTION
```
avc:  denied  { dac_read_search }
comm=chronyd
capability=dac_read_search
scontext=system_u:system_r:chronyd_t:s0
tcontext=system_u:system_r:chronyd_t:s0
tclass=capability
```

--

Fedora
[chronyd_t](https://github.com/fedora-selinux/selinux-policy/blob/281599ec3a5f0cc0d423b98bb76c71c1a5d76870/policy/modules/contrib/chronyd.te#L55)
[chronyc_t](https://github.com/fedora-selinux/selinux-policy/blob/281599ec3a5f0cc0d423b98bb76c71c1a5d76870/policy/modules/contrib/chronyd.te#L257)

--

[Why all the DAC_READ_SEARCH AVC messages? (Dan Walsh)](https://danwalsh.livejournal.com/77140.html)