### PR TITLE
Add setcap to knotd / add knotc_initrc_domtrans

### DIFF
--- a/policy/modules/services/knot.if
+++ b/policy/modules/services/knot.if
@@ -47,6 +47,25 @@ interface(`knot_run_client',`
 
 ########################################
 ## <summary>
+##      Execute knotc in knot init
+##      scripts in the initrc domain.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed to transition.
+##      </summary>
+## </param>
+#
+interface(`knotc_initrc_domtrans',`
+        gen_require(`
+                type knot_initrc_exec_t;
+        ')
+
+        init_labeled_script_domtrans($1, knot_initrc_exec_t)
+')
+
+########################################
+## <summary>
 ##      Read knot config files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/knot.te
+++ b/policy/modules/services/knot.te
@@ -38,7 +38,7 @@ files_type(knot_var_lib_t)
 #
 
 allow knotd_t self:capability { dac_override dac_read_search setgid setpcap setuid };
-allow knotd_t self:process { getcap getsched setsched signal_perms };
+allow knotd_t self:process { getcap getsched setcap setsched signal_perms };
 allow knotd_t self:tcp_socket create_stream_socket_perms;
 allow knotd_t self:udp_socket create_socket_perms;
 allow knotd_t self:unix_stream_socket create_stream_socket_perms;


### PR DESCRIPTION
allow capabilities as it's the default behavior now

allow knotc cmd in init script: knotc conf-check (by default)

See https://github.com/CZ-NIC/knot/blob/master/distro/common/knot.service