### PR TITLE
firewalld: fix firewalld_t firewalld_tmpfs_t execute

### DIFF
--- a/policy/modules/services/firewalld.te
+++ b/policy/modules/services/firewalld.te
@@ -64,6 +64,7 @@ manage_dirs_pattern(firewalld_t, firewalld_tmpfs_t, firewalld_tmpfs_t)
 manage_files_pattern(firewalld_t, firewalld_tmpfs_t, firewalld_tmpfs_t)
 mmap_read_files_pattern(firewalld_t, firewalld_tmpfs_t, firewalld_tmpfs_t)
 fs_tmpfs_filetrans(firewalld_t, firewalld_tmpfs_t, { dir file })
+can_exec(firewalld_t, firewalld_tmpfs_t)
 
 kernel_read_network_state(firewalld_t)
 kernel_read_system_state(firewalld_t)


### PR DESCRIPTION
```
type=PROCTITLE proctitle=/usr/bin/python3 /usr/sbin/firewalld --nofork --nopid
type=MMAP fd=9 flags=MAP_SHARED
type=SYSCALL arch=armeb syscall=mmap2 per=PER_LINUX success=yes exit=(null)(Unknown error 1238224896) a0=0x0 a1=0x1000 a2=0x5 a3=0x1 items=0 ppid=1 pid=270 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=firewalld exe=/usr/bin/python3.12 subj=system_u:system_r:firewalld_t:s0 key=(null)
type=AVC avc:  denied  { execute } for  pid=270 comm=firewalld path=/memfd:libffi (deleted) dev="tmpfs" ino=44 scontext=system_u:system_r:firewalld_t:s0 tcontext=system_u:object_r:firewalld_tmpfs_t:s0 tclass=file
```

Fedora:
```
$ sesearch -A --source firewalld_t --target firewalld_tmpfs_t --perm execute
allow firewalld_t firewalld_tmpfs_t:file { append create execute getattr ioctl link lock map open read rename setattr unlink watch watch_reads write };
```

https://github.com/fedora-selinux/selinux-policy/blob/v41.33/policy/modules/contrib/firewalld.te#L66