### PR TITLE
lldpad: Configure FW-LLDP on i40e NICs.

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -839,6 +839,44 @@ interface(`kernel_dontaudit_write_debugfs_dirs',`
 
 ########################################
 ## <summary>
+##	Write to debugfs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_write_debugfs',`
+	gen_require(`
+		type debugfs_t;
+	')
+
+	write_files_pattern($1, debugfs_t, debugfs_t)
+	read_lnk_files_pattern($1, debugfs_t, debugfs_t)
+	list_dirs_pattern($1, debugfs_t, debugfs_t)
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to write to debugfs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`kernel_dontaudit_write_debugfs',`
+	gen_require(`
+		type debugfs_t;
+	')
+
+	dontaudit $1 debugfs_t:file write_file_perms;
+')
+
+########################################
+## <summary>
 ##	Manage information from the debugging filesystem.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/lldpad.te
+++ b/policy/modules/services/lldpad.te
@@ -5,6 +5,19 @@ policy_module(lldpad)
 # Declarations
 #
 
+## <desc>
+## <p>
+## Permit lldp to automatically disable FW-LLDP on Intel i40e NICs.
+##
+## Related lldp messages:
+##   i40e driver detected for ens10f1, disabling LLDP in firmware
+##   cannot open /sys/kernel/debug/i40e/0000:0f:00.1/command to disable LLDP in firmware for ens10f1: Permission Denied
+##
+## Warning: This allow the lldp daemon to write to debugfs.
+## </p>
+## </desc>
+gen_tunable(lldpad_configure_fw, false)
+
 type lldpad_t;
 type lldpad_exec_t;
 init_daemon_domain(lldpad_t, lldpad_exec_t)
@@ -56,6 +69,10 @@ files_read_etc_files(lldpad_t)
 logging_send_syslog_msg(lldpad_t)
 
 miscfiles_read_localization(lldpad_t)
+
+tunable_policy(`lldpad_configure_fw',`
+	kernel_write_debugfs(lldpad_t)
+')
 
 optional_policy(`
 	fcoe_dgram_send_fcoemon(lldpad_t)


### PR DESCRIPTION
Addresses the error:

```
i40e driver detected for ens10f1, disabling LLDP in firmware
cannot open /sys/kernel/debug/i40e/0000:0f:00.1/command to disable LLDP in firmware for ens10f1: Permission Denied
```

Initial-implementation-by: Benjamin Mare
