### PR TITLE
files, init: filetrans /run/machine-id etc_runtime_t

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -154,6 +154,7 @@ HOME_ROOT/lost\+found/.*	<<none>>
 /run			-l	gen_context(system_u:object_r:var_run_t,s0)
 /run/shm		-l	gen_context(system_u:object_r:var_run_t,s0)
 /run/.*				<<none>>
+/run/machine-id		--	gen_context(system_u:object_r:etc_runtime_t,s0)
 
 #
 # /selinux

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -3778,6 +3778,25 @@ interface(`files_dontaudit_setattr_etc_runtime_files',`
 
 ########################################
 ## <summary>
+##	Create a machine-id file in
+##	the runtime directory
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_runtime_filetrans_machine_id',`
+	gen_require(`
+		type etc_runtime_t;
+	')
+
+	files_runtime_filetrans($1, etc_runtime_t, file, "machine-id")
+')
+
+########################################
+## <summary>
 ##	Read files in /etc that are dynamically
 ##	created on boot, such as mtab.
 ## </summary>

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -183,6 +183,7 @@ allow init_t init_linkable_keyring_type:key link;
 # For /var/run/shutdown.pid.
 allow init_t init_runtime_t:file manage_file_perms;
 files_runtime_filetrans(init_t, init_runtime_t, file)
+files_runtime_filetrans_machine_id(init_t)
 
 # for /run/initctl
 allow init_t init_runtime_t:fifo_file manage_fifo_file_perms;


### PR DESCRIPTION
```
type=PROCTITLE proctitle=/usr/lib/systemd/systemd-logind

type=SYSCALL arch=armeb syscall=openat per=PER_LINUX success=yes exit=21 a0=AT_FDCWD a1=0xb6eb6c2c a2=O_RDONLY|O_NOCTTY|O_NOFOLLOW|O_CLOEXEC a3=0x0 items=0 ppid=1 pid=435 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-logind exe=/usr/lib/systemd/systemd-logind subj=system_u:system_r:systemd_logind_t:s0 key=(null)

type=AVC avc:  denied  { open } for  pid=435 comm=systemd-logind path=/etc/machine-id dev="tmpfs" ino=13 scontext=system_u:system_r:systemd_logind_t:s0 tcontext=system_u:object_r:init_runtime_t:s0 tclass=file

type=AVC avc:  denied  { read } for  pid=435 comm=systemd-logind name=machine-id dev="tmpfs" ino=13 scontext=system_u:system_r:systemd_logind_t:s0 tcontext=system_u:object_r:init_runtime_t:s0 tclass=file
```

--

[systemd-devel](https://www.spinics.net/lists/systemd-devel/msg09631.html)
Reproduction and suggestion to use dedicated type (TODO)

--

Fedora:

```
$ matchpathcon /run/machine-id
/run/machine-id system_u:object_r:machineid_t:s0
```

[init.fc](https://github.com/fedora-selinux/selinux-policy/blob/v41.33/policy/modules/system/init.fc#L67)

```
$ sesearch --type_transition --class file --source init_t --target var_run_t | grep machine
type_transition init_t var_run_t:file machineid_t machine-id;
```

[init.te](https://github.com/fedora-selinux/selinux-policy/blob/v41.33/policy/modules/system/init.te#L241)