### PR TITLE
locallogin: dontaudit sulogin_t checkpoint_restore

### DIFF
--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -236,6 +236,7 @@ optional_policy(`
 
 allow sulogin_t self:capability { dac_read_search sys_admin sys_tty_config };
 dontaudit sulogin_t self:capability dac_override;
+dontaudit sulogin_t self:capability2 checkpoint_restore;
 allow sulogin_t self:process setexec;
 allow sulogin_t self:fd use;
 allow sulogin_t self:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
```
type=PROCTITLE proctitle=/usr/sbin/sulogin

type=SYSCALL arch=armeb syscall=ioctl per=PER_LINUX success=yes exit=0 a0=0x3 a1=0x5457 a2=0xbec20a90 a3=0xbec20a40 items=0 ppid=277 pid=278 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=ttyS0 ses=unset comm=sulogin exe=/usr/sbin/sulogin.util-linux subj=system_u:system_r:sulogin_t:s0 key=(null)

type=AVC avc:  denied  { checkpoint_restore } for  pid=278 comm=sulogin capability=checkpoint_restore  scontext=system_u:system_r:sulogin_t:s0 tcontext=system_u:system_r:sulogin_t:s0 tclass=capability2
```

--

[Checkpoint/Restore In Userspace](https://criu.org/Main_Page)

--

Fedora:
```
$ sesearch --dontaudit --source sulogin_t --target sulogin_t --class capability2
dontaudit sulogin_t sulogin_t:capability2 checkpoint_restore;
```

[Issue - SELinux is preventing sulogin from using the 'checkpoint_restore' capabilities](https://bugzilla.redhat.com/show_bug.cgi?id=2265391)

https://github.com/fedora-selinux/selinux-policy/commit/853dc2b6436ca5f2d7cb984bde3b000358829109