### PR TITLE
Fix mislabeling of /etc/shadow

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -390,6 +390,7 @@ allow updpwd_t self:fifo_file rw_fifo_file_perms;
 allow updpwd_t self:unix_stream_socket create_stream_socket_perms;
 allow updpwd_t self:unix_dgram_socket create_socket_perms;
 
+files_etc_filetrans(updpwd_t, shadow_t, file, "nshadow")
 files_etc_filetrans(updpwd_t, shadow_history_t, file)
 allow updpwd_t shadow_history_t:file manage_file_perms;
 


### PR DESCRIPTION
/etc/shadow was getting labeled shadow_history_t due to the fact that when /usr/sbin/unix_update (labeled updpwd_exec_t) creates the temporary /etc/nshadow, it was getting shadow_history_t. When /etc/nshadow was renamed to /etc/shadow, shadow_history_t was retained, causing an issue.

This change is causing updpwd_t to label /etc/nshadow as shadow_t so when moved, /etc/shadow has the correct type.