### PR TITLE
Allow to specify module version

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4041,3 +4041,6 @@ Sven Vermeulen (27):
       Allow initrc_t to read stunnel configuration
       Introduce exec-check interfaces for passwd binaries and useradd binaries
       chfn_t reads in file context information and executes nscd
+
+Maciej Czarnecki (1):
+      Add support for output module policy version definition

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,10 @@ ifneq ($(OUTPUT_POLICY),)
 	override CHECKPOLICY += -c $(OUTPUT_POLICY)
 endif
 
+ifneq ($(OUTPUT_MODULE),)
+	override CHECKMODULE += -c $(OUTPUT_MODULE)
+endif
+
 ifneq "$(CUSTOM_BUILDOPT)" ""
 	M4PARAM += $(foreach opt,$(CUSTOM_BUILDOPT),-D $(opt)=true)
 endif

--- a/README
+++ b/README
@@ -118,6 +118,10 @@ OUTPUT_POLICY		Integer.  Set the version of the policy created when
 			building a monolithic policy.  This option has no effect
 			on modular policy.
 
+OUTPUT_MODULE		Integer.  Set the version of the module policy created when
+			building a modular policy.  This option has no effect
+			on monolithic policy.
+
 UNK_PERMS		String.  Set the kernel behavior for handling of
 			permissions defined in the kernel but missing from the
 			policy.  The permissions can either be allowed (allow),

--- a/build.conf
+++ b/build.conf
@@ -10,6 +10,13 @@
 # effect for monolithic policies.
 #OUTPUT_POLICY = 33
 
+# Module version
+# By default, checkmodule will create the highest
+# version policy it supports.  Setting this will
+# override the version.  This only has an
+# effect for modular policies.
+#OUTPUT_MODULE = 21
+
 # Policy Type
 # standard, mls, mcs
 TYPE = standard

--- a/support/Makefile.devel
+++ b/support/Makefile.devel
@@ -53,6 +53,11 @@ ifeq "$(TYPE)" "mcs"
 	CHECKMODULE += -M
 endif
 
+# use specific module version if specified
+ifneq ($(OUTPUT_MODULE),)
+	CHECKMODULE += -c $(OUTPUT_MODULE)
+endif
+
 # enable distribution-specific policy
 ifneq ($(DISTRO),)
 	M4PARAM += -D distro_$(DISTRO)


### PR DESCRIPTION
resolves #877

This change introduces an equivalent of  `OUTPUT_POLICY` for policy modules. I was trying to stick to the existing parameter as the reference.
In `Rules.monolothic` there is a check with the kernel policy version using `policyvers`. As far as I can see there is no need for similar logic for the modules.

I've used the max module version displayed by `checkmodule -V` using the current version. Please, let me know if I should use versions defined in the header:
https://github.com/SELinuxProject/selinux/blob/main/libsepol/include/sepol/policydb/policydb.h

Example usage:
```
~ make -f ./Makefile OUTPUT_MODULE=18 mymodule.pp
[...]

~ sedismod module.pp 
Reading policy...
libsepol.policydb_index_others: security:  0 users, 1 roles, 2 types, 0 bools
libsepol.policydb_index_others: security:  1 classes, 0 rules, 0 cond rules
libsepol.policydb_index_others: security:  0 users, 1 roles, 2 types, 0 bools
libsepol.policydb_index_others: security:  1 classes, 0 rules, 0 cond rules
Binary policy module file loaded.
Module name: module
Module version: 1.0
Policy version: 18
```