### PR TITLE
ssh: fix typo in port forwarding tunable

### DIFF
--- a/policy/modules/apps/xscreensaver.te
+++ b/policy/modules/apps/xscreensaver.te
@@ -10,7 +10,7 @@ policy_module(xscreensaver)
 ##	Grant the xscreensaver domains read access to generic user content
 ##	</p>
 ## </desc>
-gen_tunable(`xscreensaver_read_generic_user_content', true)
+gen_tunable(xscreensaver_read_generic_user_content, true)
 
 attribute_role xscreensaver_roles;
 attribute_role xscreensaver_helper_roles;

--- a/policy/modules/services/apache.if
+++ b/policy/modules/services/apache.if
@@ -32,7 +32,7 @@ template(`apache_content_template',`
 	##	be labeled public_content_rw_t.
 	##	</p>
 	## </desc>
-	gen_tunable(`allow_httpd_$1_script_anon_write', false)
+	gen_tunable(allow_httpd_$1_script_anon_write, false)
 
 	type httpd_$1_content_t, httpdcontent, httpd_ro_content; # customizable
 	files_type(httpd_$1_content_t)

--- a/policy/modules/services/i18n_input.te
+++ b/policy/modules/services/i18n_input.te
@@ -10,7 +10,7 @@ policy_module(i18n_input)
 ##	Grant the i18n_input domains read access to generic user content
 ##	</p>
 ## </desc>
-gen_tunable(`i18n_input_read_generic_user_content', true)
+gen_tunable(i18n_input_read_generic_user_content, true)
 
 type i18n_input_t;
 type i18n_input_exec_t;

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -191,28 +191,28 @@ template(`userdom_user_content_access_template',`
 	##	Grant the $1 domains read access to generic user content
 	##	</p>
 	## </desc>
-	gen_tunable(`$1_read_generic_user_content', true)
+	gen_tunable($1_read_generic_user_content, true)
 
 	## <desc>
 	##	<p>
 	##	Grant the $1 domains read access to all user content
 	##	</p>
 	## </desc>
-	gen_tunable(`$1_read_all_user_content', false)
+	gen_tunable($1_read_all_user_content, false)
 
 	## <desc>
 	##	<p>
 	##	Grant the $1 domains manage rights on generic user content
 	##	</p>
 	## </desc>
-	gen_tunable(`$1_manage_generic_user_content', false)
+	gen_tunable($1_manage_generic_user_content, false)
 
 	## <desc>
 	##	<p>
 	##	Grant the $1 domains manage rights on all user content
 	##	</p>
 	## </desc>
-	gen_tunable(`$1_manage_all_user_content', false)
+	gen_tunable($1_manage_all_user_content, false)
 
 	tunable_policy(`$1_read_generic_user_content',`
 		userdom_list_user_tmp($2)


### PR DESCRIPTION
Extracted from the debian packaging, this was originally authored by Russell Coker.

All credit goes to the original author.