### PR TITLE
networkmanager: Watch systemd directories for nm-session-monitor.

### DIFF
--- a/policy/modules/services/networkmanager.te
+++ b/policy/modules/services/networkmanager.te
@@ -343,7 +343,11 @@ optional_policy(`
 
 optional_policy(`
 	systemd_read_logind_runtime_files(NetworkManager_t)
+	systemd_watch_logind_runtime_dirs(NetworkManager_t)
 	systemd_read_logind_sessions_files(NetworkManager_t)
+	systemd_watch_logind_sessions_dirs(NetworkManager_t)
+	systemd_read_machines(NetworkManager_t)
+	systemd_watch_machines_dirs(NetworkManager_t)
 	systemd_write_inherited_logind_inhibit_pipes(NetworkManager_t)
 ')
 


### PR DESCRIPTION
Specifically:
- /run/systemd/sessions/
- /run/systemd/users/
- /run/systemd/machines/

Also add rule for reading systemd_machined_runtime_t to complete the access patterns.

Fixes #881 