### PR TITLE
systemd: allow systemd-hostnamed and systemd-rfkill to get attributes…

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -817,6 +817,7 @@ files_read_etc_files(systemd_hostnamed_t)
 files_read_etc_runtime_files(systemd_hostnamed_t)
 
 fs_getattr_all_fs(systemd_hostnamed_t)
+fs_getattr_nsfs_files(systemd_hostnamed_t)
 
 init_delete_runtime_files(systemd_hostnamed_t)
 init_read_runtime_files(systemd_hostnamed_t)
@@ -1704,6 +1705,7 @@ manage_files_pattern(systemd_rfkill_t, systemd_rfkill_var_lib_t, systemd_rfkill_
 init_var_lib_filetrans(systemd_rfkill_t, systemd_rfkill_var_lib_t, dir)
 
 fs_getattr_all_fs(systemd_rfkill_t)
+fs_getattr_nsfs_files(systemd_rfkill_t)
 
 kernel_getattr_proc(systemd_rfkill_t)
 kernel_read_kernel_sysctls(systemd_rfkill_t)


### PR DESCRIPTION
… of nsfs inodes