### PR TITLE
systemd: allow reading /dev/cpu/0/msr

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -209,6 +209,7 @@ corecmd_exec_chroot(init_t)
 corecmd_exec_bin(init_t)
 
 dev_read_sysfs(init_t)
+dev_read_cpuid(init_t)
 # Early devtmpfs
 dev_rw_generic_chr_files(init_t)
 


### PR DESCRIPTION
To detect confidential virtualization on AMD processors, systemd as of v254 needs to perform an MSR read.