### PR TITLE
systemd: Add log env to systemd-machine-id-setup.

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1253,6 +1253,8 @@ kernel_read_system_state(systemd_machine_id_setup_t)
 init_read_runtime_files(systemd_machine_id_setup_t)
 init_read_state(systemd_machine_id_setup_t)
 
+systemd_log_parse_environment(systemd_machine_id_setup_t)
+
 ########################################
 #
 # modules-load local policy


### PR DESCRIPTION
Fixes #889 