### PR TITLE
systemd: allow systemd_generator_t use user ttys

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -616,6 +616,9 @@ term_use_unallocated_ttys(systemd_generator_t)
 
 udev_read_runtime_files(systemd_generator_t)
 
+# for systemd-getty-generator
+userdom_use_user_ttys(systemd_generator_t)
+
 ifdef(`distro_gentoo',`
 	corecmd_shell_entry_type(systemd_generator_t)
 ')


### PR DESCRIPTION
```
type=PROCTITLE proctitle=/usr/lib/systemd/system-generators/systemd-getty-generator /run/systemd/generator /run/systemd/generator.early /run/systemd/gene

type=SYSCALL arch=armeb syscall=openat per=PER_LINUX success=yes exit=4 a0=AT_FDCWD a1=0xbea41b28 a2=O_RDWR|O_NOCTTY|O_NONBLOCK|O_NOFOLLOW|O_CLOEXEC a3=0x0 items=0 ppid=1106 pid=1109 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-getty-g exe=/usr/lib/systemd/system-generators/systemd-getty-generator subj=system_u:system_r:systemd_generator_t:s0 key=(null)

type=AVC avc:  denied  { open } for  pid=1109 comm=systemd-getty-g path=/dev/ttyAMA0 dev="devtmpfs" ino=2 scontext=system_u:system_r:systemd_generator_t:s0 tcontext=unconfined_u:object_r:user_tty_device_t:s0 tclass=chr_file

type=AVC avc:  denied  { read write } for  pid=1109 comm=systemd-getty-g name=ttyAMA0 dev="devtmpfs" ino=2 scontext=system_u:system_r:systemd_generator_t:s0 tcontext=unconfined_u:object_r:user_tty_device_t:s0 tclass=chr_file 

----

type=PROCTITLE proctitle=/usr/lib/systemd/system-generators/systemd-getty-generator /run/systemd/generator /run/systemd/generator.early /run/systemd/gene

type=SYSCALL arch=armeb syscall=ioctl per=PER_LINUX success=yes exit=0 a0=0x4 a1=TCGETS a2=0xbea41ab0 a3=0xbea41ae4 items=0 ppid=1106 pid=1109 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-getty-g exe=/usr/lib/systemd/system-generators/systemd-getty-generator subj=system_u:system_r:systemd_generator_t:s0 key=(null)

type=AVC avc:  denied  { ioctl } for  pid=1109 comm=systemd-getty-g path=/dev/ttyAMA0 dev="devtmpfs" ino=2 ioctlcmd=TCGETS scontext=system_u:system_r:systemd_generator_t:s0 tcontext=unconfined_u:object_r:user_tty_device_t:s0 tclass=chr_file
```
--

[Fedora](https://github.com/fedora-selinux/selinux-policy/commit/6adfc23f83c3b9078c0245c66095eb78f411bedd#diff-20413b38529167819e3ef86a39929b3638ea684202dc692282e633cd05065969R1322):
```
$ matchpathcon /usr/lib/systemd/system-generators/systemd-getty-generator

/usr/lib/systemd/system-generators/systemd-getty-generator system_u:object_r:systemd_getty_generator_exec_t:s0
```