### PR TITLE
Fix the apps/screen module

### DIFF
--- a/policy/modules/apps/screen.if
+++ b/policy/modules/apps/screen.if
@@ -52,6 +52,7 @@ template(`screen_role_template',`
 	#
 
 	dontaudit $1_screen_t self:capability sys_tty_config;
+	allow $1_screen_t self:capability { chown fowner };
 
 	dontaudit $1_screen_t self:cap_userns sys_ptrace;
 
@@ -88,6 +89,8 @@ template(`screen_role_template',`
 	auth_use_nsswitch($1_screen_t)
 
 	userdom_user_home_domtrans($1_screen_t, $2)
+
+	screen_manage_home_sockets($1_screen_t)
 
 	tunable_policy(`use_samba_home_dirs',`
 		fs_cifs_domtrans($1_screen_t, $2)
@@ -154,4 +157,22 @@ interface(`screen_exec',`
 	')
 
 	allow $1 screen_exec_t:file mmap_exec_file_perms;
+')
+
+########################################
+## <summary>
+##	Manage screen home sock files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`screen_manage_home_sockets',`
+	gen_require(`
+		type screen_home_t;
+	')
+
+	manage_sock_files_pattern($1, screen_home_t, screen_home_t)
 ')


### PR DESCRIPTION
Add the minimum set of additional permissions to the screen module, as required to run version 5 of the application.

 policy/modules/apps/screen.if |   21 +++++++++++++++++++++
 1 file changed, 21 insertions(+)