### PR TITLE
Rework shadow transitions and access

### DIFF
--- a/policy/modules/admin/dpkg.te
+++ b/policy/modules/admin/dpkg.te
@@ -295,7 +295,7 @@ term_use_all_terms(dpkg_script_t)
 
 files_manage_non_auth_files(dpkg_script_t)
 
-auth_etc_filetrans_shadow(dpkg_script_t, "shadow.upwd-write")
+auth_etc_filetrans_shadow(dpkg_script_t)
 auth_manage_shadow(dpkg_script_t)
 
 init_all_labeled_script_domtrans(dpkg_script_t)

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -737,7 +737,7 @@ interface(`auth_manage_shadow',`
 ## </param>
 ## <param name="name" optional="true">
 ##	<summary>
-##	The name of the object being created.
+##	The name of the object being created. (Deprecated)
 ##	</summary>
 ## </param>
 #
@@ -746,7 +746,16 @@ interface(`auth_etc_filetrans_shadow',`
 		type shadow_t;
 	')
 
-	files_etc_filetrans($1, shadow_t, file, $2)
+	ifelse(`$2',`',`
+		files_etc_filetrans($1, shadow_t, file, "shadow")
+		files_etc_filetrans($1, shadow_t, file, "shadow-")
+		files_etc_filetrans($1, shadow_t, file, "shadow.upwd-write")
+		files_etc_filetrans($1, shadow_t, file, "gshadow")
+		files_etc_filetrans($1, shadow_t, file, "gshadow-")
+	',`
+		refpolicywarn(`$0($*) second parameter is deprecated.')
+		files_etc_filetrans($1, shadow_t, file, $2)
+	')
 ')
 
 ########################################
@@ -865,7 +874,10 @@ interface(`auth_rw_shadow_lock',`
 		type shadow_lock_t;
 	')
 
-	rw_files_pattern($1, shadow_lock_t, shadow_lock_t)
+	allow $1 shadow_lock_t:file rw_file_perms;
+	files_etc_filetrans($1, shadow_lock_t, file, ".pwd.lock")
+	files_etc_filetrans($1, shadow_lock_t, file, "passwd.lock")
+	files_etc_filetrans($1, shadow_lock_t, file, "group.lock")
 ')
 
 ########################################

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -415,6 +415,7 @@ term_dontaudit_use_console(updpwd_t)
 term_dontaudit_use_unallocated_ttys(updpwd_t)
 
 auth_manage_shadow(updpwd_t)
+auth_etc_filetrans_shadow(updpwd_t)
 auth_use_nsswitch(updpwd_t)
 
 logging_send_syslog_msg(updpwd_t)


### PR DESCRIPTION
shadow access is tightly controlled, with separate types for the shadow files and the locks.  This patch distinguishes the two by enumerating the backup filenames and lock file names in their associated file transition rules.

Prior to this, the overbroad file transition rules would cause various shadow-manipulating tools to create lock files with the incorrect shadow_t label.