### PR TITLE
filesystem: support bcachefs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,8 +366,8 @@ ifneq "$(filter xserver.te,$(base_mods) $(mod_mods))" ""
 endif
 
 # filesystems to be used in labeling targets
-filesystems = $(shell mount | grep -v "context=" | $(GREP) -v '\((|.*,)bind(,.*|)\)' | $(AWK) '/(ext[234]|btrfs| xfs| jfs).*rw/{print $$3}';)
-fs_names := "btrfs ext2 ext3 ext4 xfs jfs"
+filesystems = $(shell mount | grep -v "context=" | $(GREP) -v '\((|.*,)bind(,.*|)\)' | $(AWK) '/(ext[234]|bcachefs|btrfs| xfs| jfs).*rw/{print $$3}';)
+fs_names := "bcachefs btrfs ext2 ext3 ext4 xfs jfs"
 
 ########################################
 #

--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -16,6 +16,7 @@
 /dev/audio.*		-c	gen_context(system_u:object_r:sound_device_t,s0)
 /dev/autofs.*		-c	gen_context(system_u:object_r:autofs_device_t,s0)
 /dev/beep		-c	gen_context(system_u:object_r:sound_device_t,s0)
+/dev/bcachefs[0-9]*-ctl	-c	gen_context(system_u:object_r:lvm_control_t,s0)
 /dev/btrfs-control	-c	gen_context(system_u:object_r:lvm_control_t,s0)
 /dev/cachefiles		-c	gen_context(system_u:object_r:cachefiles_device_t,s0)
 /dev/cec.*		-c	gen_context(system_u:object_r:v4l_device_t,s0)

--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -23,6 +23,7 @@ sid fs gen_context(system_u:object_r:fs_t,s0)
 
 # Use xattrs for the following filesystem types.
 # Requires that a security xattr handler exist for the filesystem.
+fs_use_xattr bcachefs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr btrfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr encfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr erofs gen_context(system_u:object_r:fs_t,s0);


### PR DESCRIPTION
security xattrs were added to bcachefs some days ago, so I think it's time to add selinux policy for it.

I tested on my gentoo boxes.