### PR TITLE
ssh: allow sshd_t to transition to unconfined_t

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -319,6 +319,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	unconfined_domtrans(sshd_t)
+')
+
+optional_policy(`
 	xserver_domtrans_xauth(sshd_t)
 	xserver_link_xdm_keys(sshd_t)
 ')


### PR DESCRIPTION
```
type=SYSCALL arch=armeb syscall=execve per=PER_LINUX success=no exit=EACCES(Permission denied) a0=0x4f16f0 a1=0xbe9591ac a2=0x4f7158 a3=0xbe9591ac items=0 ppid=490 pid=491 auid=user123 uid=user123 gid=user123 euid=user123 suid=user123 fsuid=user123 egid=user123 sgid=user123 fsgid=user123 tty=pts0 ses=3 comm=sshd exe=/usr/sbin/sshd subj=system_u:system_r:sshd_t:s0 key=(null)

type=AVC avc:  denied  { transition } for  pid=491 comm=sshd path=/usr/bin/bash.bash dev="vda" ino=666 scontext=system_u:system_r:sshd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0 tclass=process
```