### PR TITLE
rpm: allow cap_sys_admin for writing security xattrs

### DIFF
--- a/policy/modules/admin/rpm.te
+++ b/policy/modules/admin/rpm.te
@@ -5,6 +5,13 @@ policy_module(rpm)
 # Declarations
 #
 
+## <desc>
+## <p>
+## Enable RPM admin capabilities. Needed to write security.* xattrs
+## </p>
+## </desc>
+gen_tunable(rpm_write_security_xattrs, false)
+
 attribute_role rpm_roles;
 
 type debuginfo_exec_t;
@@ -383,6 +390,10 @@ ifdef(`distro_redhat',`
 
 tunable_policy(`allow_execmem',`
 	allow rpm_script_t self:process execmem;
+')
+
+tunable_policy(`rpm_write_security_xattrs',`
+	allow rpm_t self:capability sys_admin;
 ')
 
 optional_policy(`


### PR DESCRIPTION
type=SYSCALL arch=x86_64 syscall=fsetxattr success=no exit=EPERM(Operation not permitted) comm=dnf exe=/usr/bin/dnf

type=AVC avc: denied { sys_admin } for  pin=17073 comm=dnf capability=sys_admin  scontext=system_u:system_r:rpm_t:0 tcontext=system_u:system_r:rpm_t:0 tclass=capability

IMA file signatures need RPM to write to the security.ima xattr, which require CAP_SYS_ADMIN.