### PR TITLE
Add new module for incus (container and VM manager)

### DIFF
--- a/policy/modules/apps/qemu.te
+++ b/policy/modules/apps/qemu.te
@@ -13,6 +13,14 @@ policy_module(qemu)
 ## </desc>
 gen_tunable(qemu_full_network, false)
 
+## <desc>
+##	<p>
+##	Determine whether qemu can be
+##	managed by incus.
+##	</p>
+## </desc>
+gen_tunable(qemu_incus_managed, false)
+
 attribute_role qemu_roles;
 roleattribute system_r qemu_roles;
 
@@ -45,6 +53,35 @@ tunable_policy(`qemu_full_network',`
 	corenet_udp_bind_all_ports(qemu_t)
 	corenet_tcp_bind_all_ports(qemu_t)
 	corenet_tcp_connect_all_ports(qemu_t)
+')
+
+optional_policy(`
+	tunable_policy(`qemu_incus_managed',`
+		incus_stream_connect_daemon(qemu_t)
+
+		files_create_generic_tmp_named_sockets(qemu_t)
+
+		kernel_read_kernel_sysctls(qemu_t)
+		kernel_read_vm_overcommit_sysctl(qemu_t)
+
+		# incus VMs do not start otherwise
+		allow qemu_t self:capability { dac_override dac_read_search setuid setgid };
+		allow qemu_t qemu_tmpfs_t:file mmap_read_file_perms;
+
+		# this is due to incus lack of selinux support for VMs
+		# see https://github.com/lxc/incus/issues/1037
+		kernel_rw_unlabeled_files(qemu_t)
+		kernel_rw_unlabeled_dirs(qemu_t)
+		kernel_manage_unlabeled_symlinks(qemu_t)
+
+		container_manage_engine_tmp_files(qemu_t)
+		container_manage_log_files(qemu_t)
+		container_manage_runtime_files(qemu_t)
+		container_manage_runtime_sock_files(qemu_t)
+	')
+
+	storage_raw_read_fixed_disk_cond(qemu_t, qemu_incus_managed)
+	storage_raw_write_fixed_disk_cond(qemu_t, qemu_incus_managed)
 ')
 
 optional_policy(`

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -4988,7 +4988,7 @@ interface(`dev_relabel_all_sysfs',`
 #
 interface(`dev_setattr_all_sysfs',`
     gen_require(`
-        attribute sysfs_types;
+	attribute sysfs_types;
     ')
 
     allow $1 sysfs_types:dir { search_dir_perms setattr };
@@ -5026,11 +5026,11 @@ interface(`dev_rw_tpm',`
 ## </param>
 #
 interface(`dev_rw_uhid',`
-        gen_require(`
-                type device_t, uhid_device_t;
-        ')
+	gen_require(`
+		type device_t, uhid_device_t;
+	')
 
-        rw_chr_files_pattern($1, device_t, uhid_device_t)
+	rw_chr_files_pattern($1, device_t, uhid_device_t)
 ')
 
 ########################################

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -146,6 +146,25 @@ interface(`dev_remount_fs',`
 
 ########################################
 ## <summary>
+##	Allow to watch filesystem and to
+##	watch and watch_sb dir.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to allow
+##	</summary>
+## </param>
+interface(`dev_watch_dev_fs',`
+	gen_require(`
+		type device_t;
+	')
+
+	allow $1 device_t:filesystem watch;
+	allow $1 device_t:dir { watch watch_sb };
+')
+
+########################################
+## <summary>
 ##	Watch the directories in /dev.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7721,11 +7721,11 @@ interface(`files_runtime_filetrans_lock_dir',`
 ## </param>
 #
 interface(`files_create_all_spool_sockets',`
-        gen_require(`
-                attribute spoolfile;
-        ')
+	gen_require(`
+		attribute spoolfile;
+	')
 
-        allow $1 spoolfile:sock_file create_sock_file_perms;
+	allow $1 spoolfile:sock_file create_sock_file_perms;
 ')
 
 ########################################
@@ -7739,11 +7739,11 @@ interface(`files_create_all_spool_sockets',`
 ## </param>
 #
 interface(`files_delete_all_spool_sockets',`
-        gen_require(`
-                attribute spoolfile;
-        ')
+	gen_require(`
+		attribute spoolfile;
+	')
 
-        allow $1 spoolfile:sock_file delete_sock_file_perms;
+	allow $1 spoolfile:sock_file delete_sock_file_perms;
 ')
 
 ########################################

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -4633,8 +4633,7 @@ interface(`files_mmap_read_kernel_modules',`
 	')
 
 	allow $1 modules_object_t:dir list_dir_perms;
-	read_files_pattern($1, modules_object_t, modules_object_t)
-	allow $1 modules_object_t:file map;
+	mmap_read_files_pattern($1, modules_object_t, modules_object_t)
 	read_lnk_files_pattern($1, modules_object_t, modules_object_t)
 ')
 

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -454,6 +454,25 @@ interface(`files_dontaudit_getattr_all_tmpfs_files',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to unlink
+##	sockets in tmp_t directories
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`files_dontaudit_delete_generic_tmp_named_sockets',`
+	gen_require(`
+		type tmp_t;
+	')
+
+	dontaudit $1 tmp_t:sock_file unlink;
+')
+
+########################################
+## <summary>
 ##	Get the attributes of all directories.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7191,7 +7191,7 @@ interface(`files_exec_runtime',`
 
 ########################################
 ## <summary>
-##	Dontaudit attempt to execute generic programs in /var/run in the caller domain.
+##	Dontaudit attempts to execute generic programs in /var/run in the caller domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7536,6 +7536,24 @@ interface(`files_create_all_runtime_pipes',`
 
 ########################################
 ## <summary>
+##     Create tmp_t sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_create_generic_tmp_named_sockets',`
+        gen_require(`
+                type tmp_t;
+        ')
+
+	create_sock_files_pattern($1, tmp_t, tmp_t)
+')
+
+########################################
+## <summary>
 ##     Delete all runtime named pipes
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -2821,7 +2821,7 @@ interface(`fs_setattr_efivarfs_files',`
 ########################################
 ## <summary>
 ##	Create, read, write, and delete files
-##	on a efivarfs filesystem.
+##	on an efivarfs filesystem.
 ##      - contains Linux Kernel configuration options for UEFI systems
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -2586,8 +2586,7 @@ interface(`fs_mmap_read_dos_files',`
 		type dosfs_t;
 	')
 
-	read_files_pattern($1, dosfs_t, dosfs_t)
-	allow $1 dosfs_t:file map;
+	mmap_read_files_pattern($1, dosfs_t, dosfs_t)
 ')
 
 ########################################

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -2582,9 +2582,9 @@ interface(`fs_read_dos_files',`
 ## </param>
 #
 interface(`fs_mmap_read_dos_files',`
-        gen_require(`
-                type dosfs_t;
-        ')
+	gen_require(`
+		type dosfs_t;
+	')
 
 	read_files_pattern($1, dosfs_t, dosfs_t)
 	allow $1 dosfs_t:file map;
@@ -2620,12 +2620,12 @@ interface(`fs_manage_dos_files',`
 ## </param>
 #
 interface(`fs_list_ecryptfs',`
-        gen_require(`
-                type ecryptfs_t;
-        ')
+	gen_require(`
+		type ecryptfs_t;
+	')
 
-        allow $1 ecryptfs_t:dir list_dir_perms;
-        read_lnk_files_pattern($1, ecryptfs_t, ecryptfs_t)
+	allow $1 ecryptfs_t:dir list_dir_perms;
+	read_lnk_files_pattern($1, ecryptfs_t, ecryptfs_t)
 ')
 
 ########################################
@@ -2641,11 +2641,11 @@ interface(`fs_list_ecryptfs',`
 ## <rolecap/>
 #
 interface(`fs_manage_ecryptfs_dirs',`
-        gen_require(`
-                type ecryptfs_t;
-        ')
+	gen_require(`
+		type ecryptfs_t;
+	')
 
-        allow $1 ecryptfs_t:dir manage_dir_perms;
+	allow $1 ecryptfs_t:dir manage_dir_perms;
 ')
 
 ########################################
@@ -2661,11 +2661,11 @@ interface(`fs_manage_ecryptfs_dirs',`
 ## <rolecap/>
 #
 interface(`fs_manage_ecryptfs_files',`
-        gen_require(`
-                type ecryptfs_t;
-        ')
+	gen_require(`
+		type ecryptfs_t;
+	')
 
-        manage_files_pattern($1, ecryptfs_t, ecryptfs_t)
+	manage_files_pattern($1, ecryptfs_t, ecryptfs_t)
 ')
 
 ########################################
@@ -2680,11 +2680,11 @@ interface(`fs_manage_ecryptfs_files',`
 ## </param>
 #
 interface(`fs_manage_ecryptfs_named_sockets',`
-        gen_require(`
-                type ecryptfs_t;
-        ')
+	gen_require(`
+		type ecryptfs_t;
+	')
 
-        manage_sock_files_pattern($1, ecryptfs_t, ecryptfs_t)
+	manage_sock_files_pattern($1, ecryptfs_t, ecryptfs_t)
 ')
 
 ########################################
@@ -3763,11 +3763,11 @@ interface(`fs_rw_hugetlbfs_files',`
 ## </param>
 #
 interface(`fs_mmap_rw_hugetlbfs_files',`
-        gen_require(`
-                type hugetlbfs_t;
-        ')
+	gen_require(`
+		type hugetlbfs_t;
+	')
 
-        fs_rw_hugetlbfs_files($1)
+	fs_rw_hugetlbfs_files($1)
 	allow $1 hugetlbfs_t:file map;
 ')
 
@@ -6650,7 +6650,7 @@ interface(`fs_getattr_tracefs',`
 		type tracefs_t;
 	')
 
-        allow $1 tracefs_t:filesystem getattr;
+	allow $1 tracefs_t:filesystem getattr;
 ')
 
 ########################################
@@ -6724,7 +6724,7 @@ interface(`fs_search_tracefs',`
 		type tracefs_t;
 	')
 
-        allow $1 tracefs_t:dir search_dir_perms;
+	allow $1 tracefs_t:dir search_dir_perms;
 ')
 
 ########################################
@@ -6743,7 +6743,7 @@ interface(`fs_getattr_tracefs_files',`
 		type tracefs_t;
 	')
 
-        allow $1 tracefs_t:file getattr;
+	allow $1 tracefs_t:file getattr;
 ')
 
 ########################################

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -622,6 +622,44 @@ interface(`fs_getattr_binfmt_misc_fs',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to getattr a
+##	binfmt_misc_fs
+##	filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_getattr_binfmt_misc_fs',`
+	gen_require(`
+		type binfmt_misc_fs_t;
+	')
+
+	dontaudit $1 binfmt_misc_fs_t:filesystem getattr;
+')
+
+########################################
+## <summary>
+##	Mount binfmt_misc_fs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_mount_binfmt_misc_fs',`
+	gen_require(`
+		type binfmt_misc_fs_t;
+	')
+
+	allow $1 binfmt_misc_fs_t:filesystem mount;
+')
+
+########################################
+## <summary>
 ##	Get the attributes of directories on
 ##	binfmt_misc filesystems.
 ## </summary>
@@ -2269,6 +2307,25 @@ interface(`fs_cifs_domtrans',`
 	domain_auto_transition_pattern($1, cifs_t, $2)
 ')
 
+########################################
+## <summary>
+##	Do not audit attempts to getattr a configfs
+##	filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_getattr_configfs',`
+	gen_require(`
+		type configfs_t;
+	')
+
+	dontaudit $1 configfs_t:filesystem getattr;
+')
+
 #######################################
 ## <summary>
 ##	Create, read, write, and delete dirs
@@ -2305,6 +2362,25 @@ interface(`fs_manage_configfs_files',`
 	')
 
 	manage_files_pattern($1, configfs_t, configfs_t)
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to remount a configfs
+##	filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_remount_configfs',`
+	gen_require(`
+		type configfs_t;
+	')
+
+	dontaudit $1 configfs_t:filesystem remount;
 ')
 
 ########################################
@@ -2627,6 +2703,62 @@ interface(`fs_getattr_efivarfs',`
 	')
 
 	allow $1 efivarfs_t:filesystem getattr;
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to getattr an efivarfs
+##	filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_getattr_efivarfs',`
+	gen_require(`
+		type efivarfs_t;
+	')
+
+	dontaudit $1 efivarfs_t:filesystem getattr;
+')
+
+########################################
+## <summary>
+##	Remount an efivarfs filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_remount_efivarfs',`
+	gen_require(`
+		type efivarfs_t;
+	')
+
+	allow $1 efivarfs_t:filesystem remount;
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to remount an efivarfs
+##	filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_remount_efivarfs',`
+	gen_require(`
+		type efivarfs_t;
+	')
+
+	dontaudit $1 efivarfs_t:filesystem remount;
 ')
 
 ########################################
@@ -5009,6 +5141,25 @@ interface(`fs_getattr_pstorefs',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to get
+##	attributes of dirs on a pstorefs filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_getattr_pstorefs',`
+	gen_require(`
+		type pstore_t;
+	')
+
+	dontaudit $1 pstore_t:filesystem getattr;
+')
+
+########################################
+## <summary>
 ##	Get the attributes of directories
 ##	of a pstore filesystem.
 ## </summary>
@@ -5120,6 +5271,43 @@ interface(`fs_delete_pstore_files',`
 
 	delete_files_pattern($1, pstore_t, pstore_t)
 	dev_search_sysfs($1)
+')
+
+########################################
+## <summary>
+##	Remount a pstorefs filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain sllowd access.
+##	</summary>
+## </param>
+#
+interface(`fs_remount_pstorefs',`
+	gen_require(`
+		type pstore_t;
+	')
+
+	allow $1 pstore_t:filesystem remount;
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to remount a pstorefs
+##	filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_remount_pstorefs',`
+	gen_require(`
+		type pstore_t;
+	')
+
+	dontaudit $1 pstore_t:filesystem remount;
 ')
 
 ########################################
@@ -5266,6 +5454,24 @@ interface(`fs_setattr_ramfs_dirs',`
 	')
 
 	allow $1 ramfs_t:dir setattr;
+')
+
+########################################
+## <summary>
+##	List directories on a ramfs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_list_ramfs_dirs',`
+	gen_require(`
+		type ramfs_t;
+	')
+
+	allow $1 ramfs_t:dir list_dir_perms;
 ')
 
 ########################################
@@ -6114,6 +6320,24 @@ interface(`fs_read_tmpfs_files',`
 
 ########################################
 ## <summary>
+##      Read and map generic tmpfs files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_mmap_read_tmpfs_files',`
+	gen_require(`
+		type tmpfs_t;
+	')
+
+	mmap_read_files_pattern($1, tmpfs_t, tmpfs_t)
+')
+
+########################################
+## <summary>
 ##	Read and write generic tmpfs files.
 ## </summary>
 ## <param name="domain">
@@ -6431,6 +6655,25 @@ interface(`fs_getattr_tracefs',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to get the
+##	attributes of a trace filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_getattr_tracefs',`
+	gen_require(`
+		type tracefs_t;
+	')
+
+	dontaudit $1 tracefs_t:filesystem getattr;
+')
+
+########################################
+## <summary>
 ##	Get attributes of dirs on tracefs filesystem.
 ## </summary>
 ## <param name="domain">
@@ -6445,6 +6688,25 @@ interface(`fs_getattr_tracefs_dirs',`
 	')
 
 	allow $1 tracefs_t:dir getattr;
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to get
+##	attributes of dirs on tracefs filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_getattr_tracefs_dirs',`
+	gen_require(`
+		type tracefs_t;
+	')
+
+	dontaudit $1 tracefs_t:dir getattr;
 ')
 
 ########################################
@@ -6519,6 +6781,25 @@ interface(`fs_create_tracefs_dirs',`
 	')
 
 	allow $1 tracefs_t:dir { create rw_dir_perms };
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to remount a tracefs
+##	filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_remount_tracefs',`
+	gen_require(`
+		type tracefs_t;
+	')
+
+	dontaudit $1 tracefs_t:filesystem remount;
 ')
 
 ########################################

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -5466,7 +5466,7 @@ interface(`fs_setattr_ramfs_dirs',`
 ##	</summary>
 ## </param>
 #
-interface(`fs_list_ramfs_dirs',`
+interface(`fs_list_ramfs',`
 	gen_require(`
 		type ramfs_t;
 	')

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -711,6 +711,25 @@ interface(`kernel_getattr_debugfs',`
 
 ########################################
 ## <summary>
+##	Do not audit attempt to getattr a debugfs
+##	filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`kernel_dontaudit_getattr_debugfs',`
+        gen_require(`
+                type debugfs_t;
+        ')
+
+        dontaudit $1 debugfs_t:filesystem getattr;
+')
+
+########################################
+## <summary>
 ##	Mount a kernel debugging filesystem.
 ## </summary>
 ## <param name="domain">
@@ -761,6 +780,25 @@ interface(`kernel_remount_debugfs',`
 	')
 
 	allow $1 debugfs_t:filesystem remount;
+')
+
+########################################
+## <summary>
+##	Do not audit attempt to remount a debugfs
+##	filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`kernel_dontaudit_remount_debugfs',`
+        gen_require(`
+                type debugfs_t;
+        ')
+
+        dontaudit $1 debugfs_t:filesystem remount;
 ')
 
 ########################################

--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -188,6 +188,39 @@ interface(`storage_raw_write_fixed_disk',`
 
 ########################################
 ## <summary>
+##	Allow the caller to directly write to a fixed disk
+##	if a tunable is set.
+##	This is extremely dangerous as it can bypass the
+##	SELinux protections for filesystem objects, and
+##	should only be used by trusted domains.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="tunable">
+##	<summary>
+##	Tunable to depend on
+##	</summary>
+## </param>
+#
+interface(`storage_raw_write_fixed_disk_cond',`
+	gen_require(`
+		attribute fixed_disk_raw_write;
+		type fixed_disk_device_t;
+	')
+
+	typeattribute $1 fixed_disk_raw_write;
+	tunable_policy(`$2', `
+		dev_list_all_dev_nodes($1)
+		allow $1 fixed_disk_device_t:blk_file write_blk_file_perms;
+		allow $1 fixed_disk_device_t:chr_file write_chr_file_perms;
+	')
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts made by the caller to write
 ##	fixed disk device nodes.
 ## </summary>

--- a/policy/modules/kernel/terminal.if
+++ b/policy/modules/kernel/terminal.if
@@ -168,6 +168,44 @@ interface(`term_remount_devpts',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to remount
+##	devpts_t filesystem
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`term_dontaudit_remount_devpts',`
+	gen_require(`
+		type devpts_t;
+	')
+
+	dontaudit $1 devpts_t:filesystem remount;
+')
+
+########################################
+## <summary>
+##	Unmount a devpts_t filesystem
+## </summary>
+## <param name="domain">
+##	<summary>
+##	The type of the process to unmount it
+##	</summary>
+## </param>
+#
+interface(`term_unmount_devpts',`
+	gen_require(`
+		type devpts_t;
+	')
+
+	allow $1 devpts_t:filesystem unmount;
+')
+
+########################################
+## <summary>
 ##	Create directory /dev/pts.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -749,7 +749,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-        nsd_admin(sysadm_t, sysadm_r)
+	nsd_admin(sysadm_t, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -530,6 +530,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	incus_stream_connect_daemon(sysadm_t, sysadm_r)
+')
+
+optional_policy(`
 	inn_admin(sysadm_t, sysadm_r)
 ')
 

--- a/policy/modules/services/container.fc
+++ b/policy/modules/services/container.fc
@@ -28,6 +28,11 @@ HOME_DIR/\.docker(/.*)?		gen_context(system_u:object_r:container_conf_home_t,s0)
 /usr/lib/systemd/system/containerd.*	--	gen_context(system_u:object_r:container_engine_unit_t,s0)
 /usr/lib/systemd/system/container-.*	--	gen_context(system_u:object_r:container_unit_t,s0)
 
+/usr/bin/incus-.*		gen_context(system_u:object_r:container_engine_exec_t,s0)
+/usr/lib/systemd/system/incus.*	gen_context(system_u:object_r:container_engine_unit_t,s0)
+/usr/libexec/incus(/.*)?	gen_context(system_u:object_r:container_engine_exec_t,s0)
+/usr/share/lxcfs/.*		gen_context(system_u:object_r:container_engine_exec_t,s0)
+
 /usr/sbin/runc	--	gen_context(system_u:object_r:container_engine_exec_t,s0)
 
 /opt/cni(/.*)?		gen_context(system_u:object_r:container_plugin_t,s0)
@@ -50,7 +55,9 @@ HOME_DIR/\.docker(/.*)?		gen_context(system_u:object_r:container_conf_home_t,s0)
 /run/containerd(/.*)?		gen_context(system_u:object_r:container_runtime_t,s0)
 /run/containerd/[^/]+/sandboxes/[^/]+/shm(/.*)?		gen_context(system_u:object_r:container_engine_tmpfs_t,s0)
 
+/run/incus(/.*)?		gen_context(system_u:object_r:container_runtime_t,s0)
 /run/ipcns(/.*)?		gen_context(system_u:object_r:container_runtime_t,s0)
+/run/lxc(/.*)?			gen_context(system_u:object_r:container_runtime_t,s0)
 /run/pidns(/.*)?		gen_context(system_u:object_r:container_runtime_t,s0)
 /run/userns(/.*)?		gen_context(system_u:object_r:container_runtime_t,s0)
 /run/utsns(/.*)?		gen_context(system_u:object_r:container_runtime_t,s0)
@@ -58,6 +65,7 @@ HOME_DIR/\.docker(/.*)?		gen_context(system_u:object_r:container_conf_home_t,s0)
 /run/user/%{USERID}/netns(/.*)?		gen_context(system_u:object_r:container_runtime_t,s0)
 
 /var/cache/containers(/.*)?		gen_context(system_u:object_r:container_engine_cache_t,s0)
+/var/cache/incus(/.*)?			gen_context(system_u:object_r:container_var_lib_t,s0)
 
 /var/lib/cni(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/containers(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
@@ -93,6 +101,13 @@ HOME_DIR/\.docker(/.*)?		gen_context(system_u:object_r:container_conf_home_t,s0)
 /var/lib/containerd/[^/]+/sandboxes(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/containerd/[^/]+/snapshots(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
 
+/var/lib/incus(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
+/var/lib/incus/storage-pools/[^/]+/containers(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
+/var/lib/incus/storage-pools/[^/]+/containers/.*/rootfs(/.*)?	<<none>>
+/var/lib/incus/storage-pools/[^/]+/virtual-machines/.*		<<none>>
+
+/var/lib/lxc(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
+
 /var/lib/kubelet(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/kubelet/device-plugins(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/kubelet/pods(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
@@ -114,6 +129,7 @@ HOME_DIR/\.docker(/.*)?		gen_context(system_u:object_r:container_conf_home_t,s0)
 /var/log/containerd(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/containers(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/crio(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
+/var/log/incus(/.*)? 		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/pods(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 
 /var/log/kubelet(/.*)?		gen_context(system_u:object_r:container_log_t,s0)

--- a/policy/modules/services/container.if
+++ b/policy/modules/services/container.if
@@ -498,6 +498,63 @@ interface(`container_runtime_named_socket_activation',`
 
 ########################################
 ## <summary>
+##	Allow the specified domain to manage
+##	container engine tmpfs directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_manage_engine_tmpfs_dirs',`
+	gen_require(`
+		type container_engine_tmpfs_t;
+	')
+
+	manage_dirs_pattern($1, container_engine_tmpfs_t, container_engine_tmpfs_t)
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to manage
+##	container engine tmpfs files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_manage_engine_tmpfs_files',`
+	gen_require(`
+		type container_engine_tmpfs_t;
+	')
+
+	manage_files_pattern($1, container_engine_tmpfs_t, container_engine_tmpfs_t)
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to manage
+##	container engine tmpfs symlinks.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_manage_engine_tmpfs_symlinks',`
+	gen_require(`
+		type container_engine_tmpfs_t;
+	')
+
+	manage_lnk_files_pattern($1, container_engine_tmpfs_t, container_engine_tmpfs_t)
+')
+
+########################################
+## <summary>
 ##	Allow the specified domain to search
 ##	container engine temporary directories.
 ## </summary>
@@ -534,6 +591,25 @@ interface(`container_read_engine_tmp_files',`
 
 	container_search_engine_tmp($1)
 	allow $1 container_engine_tmp_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to execute
+##	container engine temporary files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_exec_engine_tmp_files',`
+	gen_require(`
+		type container_engine_tmp_t;
+	')
+
+	can_exec($1, container_engine_tmp_t)
 ')
 
 ########################################
@@ -1090,6 +1166,98 @@ interface(`container_read_device_blk_files',`
 
 ########################################
 ## <summary>
+##	Watch container tmpfs directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_watch_tmpfs_dirs',`
+	gen_require(`
+		type container_tmpfs_t;
+	')
+
+	allow $1 container_tmpfs_t:dir watch;
+')
+
+########################################
+## <summary>
+##	Read container tmpfs files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_read_tmpfs_files',`
+	gen_require(`
+		type container_tmpfs_t;
+	')
+
+	read_files_pattern($1, container_tmpfs_t, container_tmpfs_t)
+')
+
+########################################
+## <summary>
+##	Watch container tmpfs files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_watch_tmpfs_files',`
+	gen_require(`
+		type container_tmpfs_t;
+	')
+
+	allow $1 container_tmpfs_t:file watch;
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to create
+##	container chr files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_create_tmpfs_chr_files',`
+	gen_require(`
+		type container_tmpfs_t;
+	')
+
+	allow $1 container_tmpfs_t:chr_file create_chr_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to delete
+##	container chr files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_delete_tmpfs_chr_files',`
+	gen_require(`
+		type container_tmpfs_t;
+	')
+
+	allow $1 container_tmpfs_t:chr_file delete_chr_file_perms;
+')
+
+########################################
+## <summary>
 ##	Mount on all container devices.
 ## </summary>
 ## <param name="domain">
@@ -1104,6 +1272,24 @@ interface(`container_mounton_all_devices',`
 	')
 
 	allow $1 container_device_t:dir_file_class_set mounton;
+')
+
+########################################
+## <summary>
+##	Lock container ptys.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_lock_container_ptys',`
+	gen_require(`
+		type container_devpts_t;
+	')
+
+	allow $1 container_devpts_t:chr_file lock;
 ')
 
 ########################################
@@ -1140,6 +1326,24 @@ interface(`container_use_container_ptys',`
 	')
 
 	allow $1 container_devpts_t:chr_file rw_term_perms;
+')
+
+########################################
+## <summary>
+##	Watch container ptys.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_watch_container_ptys',`
+	gen_require(`
+		type container_devpts_t;
+	')
+
+	allow $1 container_devpts_t:chr_file watch;
 ')
 
 ########################################

--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -193,7 +193,16 @@ container_domain_template(container)
 typealias container_t alias svirt_lxc_net_t;
 typeattribute container_t container_system_domain, container_user_domain, container_net_domain;
 optional_policy(`
+	incus_container(container_t)
+')
+optional_policy(`
 	kubernetes_container(container_t)
+')
+
+container_domain_template(container_init)
+typeattribute container_init_t container_system_domain, container_user_domain, container_net_domain;
+optional_policy(`
+	incus_container(container_init_t)
 ')
 
 container_engine_domain_template(container_engine)
@@ -215,6 +224,9 @@ optional_policy(`
 type spc_t, container_domain, container_net_domain, container_system_domain, privileged_container_domain;
 domain_type(spc_t)
 role system_r types spc_t;
+optional_policy(`
+	incus_container(spc_t)
+')
 optional_policy(`
 	kubernetes_container(spc_t)
 ')
@@ -627,6 +639,102 @@ tunable_policy(`container_use_userns_sysadmin || container_use_sysadmin',`
 optional_policy(`
 	rpm_read_db(container_t)
 ')
+
+########################################
+#
+# Init container local policy
+#
+# Containers with additional permissions
+# required to run an init system
+
+allow container_init_t self:process { getcap setrlimit };
+allow container_init_t self:bpf prog_load;
+allow container_init_t self:netlink_netfilter_socket create_socket_perms;
+allow container_init_t self:netlink_generic_socket create_socket_perms;
+allow container_init_t self:unix_dgram_socket lock;
+
+allow container_init_t container_devpts_t:chr_file { setattr watch watch_reads };
+allow container_init_t container_engine_tmpfs_t:dir { mounton write };
+allow container_init_t container_file_t:dir mounton;
+allow container_init_t container_file_t:file mounton;
+allow container_init_t container_file_t:filesystem unmount;
+allow container_init_t container_tmpfs_t:dir mounton;
+allow container_init_t container_tmpfs_t:file mounton;
+allow container_init_t container_tmpfs_t:sock_file watch;
+
+container_create_tmpfs_chr_files(container_init_t)
+container_delete_tmpfs_chr_files(container_init_t)
+container_getattr_fs(container_init_t)
+container_lock_container_ptys(container_init_t)
+container_remount_fs(container_init_t)
+container_watch_tmpfs_dirs(container_init_t)
+container_watch_tmpfs_files(container_init_t)
+
+auth_use_nsswitch(container_init_t)
+
+corenet_rw_tun_tap_dev(container_init_t)
+
+dev_getattr_mtrr_dev(container_init_t)
+dev_mounton_sysfs_dirs(container_init_t)
+dev_read_rand(container_init_t)
+dev_read_sysfs(container_init_t)
+dev_read_urand(container_init_t)
+dev_remount_fs(container_init_t)
+dev_remount_sysfs(container_init_t)
+dev_unmount_fs(container_init_t)
+dev_write_sysfs(container_init_t)
+
+files_read_kernel_modules(container_init_t)
+
+fs_manage_cgroup_dirs(container_init_t)
+fs_manage_cgroup_files(container_init_t)
+fs_create_tracefs_dirs(container_init_t)
+fs_dontaudit_remount_configfs(container_init_t)
+fs_dontaudit_remount_efivarfs(container_init_t)
+fs_dontaudit_remount_pstorefs(container_init_t)
+fs_dontaudit_remount_tracefs(container_init_t)
+fs_mount_cgroup(container_init_t)
+fs_mount_ramfs(container_init_t)
+fs_mount_tmpfs(container_init_t)
+fs_read_nsfs_files(container_init_t)
+fs_list_ramfs(container_init_t)
+fs_remount_cgroup(container_init_t)
+fs_remount_fusefs(container_init_t)
+fs_remount_tmpfs(container_init_t)
+fs_remount_xattr_fs(container_init_t)
+fs_rw_cgroup_files(container_init_t)
+fs_setattr_ramfs_dirs(container_init_t)
+fs_unmount_ramfs(container_init_t)
+fs_unmount_tmpfs(container_init_t)
+fs_unmount_xattr_fs(container_init_t)
+fs_watch_cgroup_files(container_init_t)
+
+kernel_dontaudit_remount_debugfs(container_init_t)
+kernel_dontaudit_request_load_module(container_init_t)
+kernel_get_sysvipc_info(container_init_t)
+kernel_mounton_kernel_sysctl_files(container_init_t)
+kernel_mounton_message_if(container_init_t)
+kernel_read_fs_sysctls(container_init_t)
+kernel_read_irq_sysctls(container_init_t)
+kernel_read_network_state(container_init_t)
+kernel_read_psi(container_init_t)
+kernel_read_vm_overcommit_sysctl(container_init_t)
+kernel_remount_proc(container_init_t)
+kernel_rw_unix_sysctls(container_domain)
+
+logging_send_audit_msgs(container_init_t)
+
+selinux_remount_fs(container_init_t)
+
+storage_getattr_fixed_disk_dev(container_init_t)
+storage_getattr_fuse_dev(container_init_t)
+storage_rw_fuse(container_init_t)
+
+term_dontaudit_remount_devpts(container_init_t)
+term_unmount_devpts(container_init_t)
+term_use_generic_ptys(container_init_t)
+
+userdom_use_user_ptys(container_init_t)
 
 ########################################
 #

--- a/policy/modules/services/dnsmasq.te
+++ b/policy/modules/services/dnsmasq.te
@@ -131,6 +131,12 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_read_resolved_runtime(dnsmasq_t)
+	systemd_list_resolved_runtime(dnsmasq_t)
+	systemd_watch_resolved_runtime_dirs(dnsmasq_t)
+')
+
+optional_policy(`
 	tftp_read_content(dnsmasq_t)
 ')
 

--- a/policy/modules/services/dnsmasq.te
+++ b/policy/modules/services/dnsmasq.te
@@ -103,6 +103,13 @@ optional_policy(`
 ')
 
 optional_policy(`
+	incus_stream_connect_daemon(dnsmasq_t)
+	container_manage_var_lib_files(dnsmasq_t)
+	container_manage_log_files(dnsmasq_t)
+	container_search_var_lib(dnsmasq_t)
+')
+
+optional_policy(`
 	dbus_connect_system_bus(dnsmasq_t)
 	dbus_system_bus_client(dnsmasq_t)
 ')

--- a/policy/modules/services/incus.fc
+++ b/policy/modules/services/incus.fc
@@ -1,0 +1,4 @@
+/usr/bin/incus	--	gen_context(system_u:object_r:incusc_exec_t,s0)
+/usr/bin/incus-benchmark	--	gen_context(system_u:object_r:incusc_exec_t,s0)
+/usr/bin/incus-user	--	gen_context(system_u:object_r:incusd_exec_t,s0)
+/usr/bin/incusd		--	gen_context(system_u:object_r:incusd_exec_t,s0)

--- a/policy/modules/services/incus.if
+++ b/policy/modules/services/incus.if
@@ -1,0 +1,276 @@
+## <summary>Policy for incus</summary>
+
+########################################
+## <summary>
+##      Associated the specified domain to
+##      be a domain which is capable of
+##      operating as a container domain
+##      which can be controlled by incus.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`incus_container',`
+	gen_require(`
+		attribute incus_container_domain;
+	')
+
+	typeattribute $1 incus_container_domain;
+')
+
+########################################
+## <summary>
+##	Execute incus CLI in the incus CLI domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`incus_domtrans_cli',`
+	gen_require(`
+		type incusc_t, incusc_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, incusc_exec_t, incusc_t)
+')
+
+########################################
+## <summary>
+##	Execute incus CLI in the incus CLI
+##	domain, and allow the specified role
+##	the incus CLI domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	The role to be allowed the incus domain.
+##	</summary>
+## </param>
+#
+interface(`incus_run_cli',`
+	gen_require(`
+		type incusc_t;
+	')
+
+	role $2 types incusc_t;
+
+	incus_domtrans_cli($1)
+')
+
+########################################
+## <summary>
+##	Execute incus in the incus user domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+#interface(`incus_domtrans_user_daemon',`
+#	gen_require(`
+#		type incusd_user_t, incusd_exec_t;
+#	')
+#
+#	corecmd_search_bin($1)
+#	domtrans_pattern($1, incusd_exec_t, incusd_user_t)
+#')
+
+########################################
+## <summary>
+##	Execute incus in the incus user
+##	domain, and allow the specified
+##	role the incus user domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	The role to be allowed the incus domain.
+##	</summary>
+## </param>
+#
+#interface(`incus_run_user_daemon',`
+#	gen_require(`
+#		type incusd_user_t;
+#	')
+#
+#	role $2 types incusd_user_t;
+#
+#	incus_domtrans_user_daemon($1)
+#')
+
+########################################
+## <summary>
+##	Execute incus CLI in the incus CLI
+##	user domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`incus_domtrans_user_cli',`
+	gen_require(`
+		type incusc_user_t, incusc_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, incusc_exec_t, incusc_user_t)
+')
+
+########################################
+## <summary>
+##	Execute incus CLI in the incus CLI
+##	user domain, and allow the specified
+##	role the incus CLI user domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	The role to be allowed the incus
+##	user domain.
+##	</summary>
+## </param>
+#
+interface(`incus_run_user_cli',`
+	gen_require(`
+		type incusc_user_t;
+	')
+
+	role $2 types incusc_user_t;
+
+	incus_domtrans_user_cli($1)
+')
+
+########################################
+## <summary>
+##	Connect to the incus daemon
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+interface(`incus_stream_connect_daemon',`
+	gen_require(`
+		type incusd_t;
+	')
+
+	allow $1 incusd_t:unix_stream_socket { connectto rw_socket_perms };
+')
+
+########################################
+## <summary>
+##	Role access for rootless incus.
+## </summary>
+## <param name="role_prefix">
+##	<summary>
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+#template(`incus_user_role',`
+#	gen_require(`
+#		type incusd_user_t;
+#		type incusd_exec_t;
+#	')
+#
+#	role $4 types incusd_user_t;
+#
+#	incus_run_user_daemon($3, $4)
+#	incus_run_user_cli($3, $4)
+#
+#	ifdef(`init_systemd',`
+#		systemd_user_daemon_domain($1, incusd_exec_t, incusd_user_t)
+#		systemd_user_send_systemd_notify($1, incusd_user_t)
+#	')
+#
+#	optional_policy(`
+#		dbus_spec_session_bus_client($1, incusd_user_t)
+#	')
+#
+#	optional_policy(`
+#		rootlesskit_role($1, $2, $3, $4)
+#	')
+#')
+
+########################################
+## <summary>
+##	Send signals to the rootless incus daemon.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+#interface(`incus_signal_user_daemon',`
+#	gen_require(`
+#		type incusd_user_t;
+#	')
+#
+#	allow $1 incusd_user_t:process signal;
+#')
+
+########################################
+## <summary>
+##	All of the rules required to
+##	administrate a incus
+##	environment.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`incus_admin',`
+	incus_run_cli($1, $2)
+
+	optional_policy(`
+		rootlesskit_run($1, $2)
+	')
+')

--- a/policy/modules/services/incus.te
+++ b/policy/modules/services/incus.te
@@ -1,0 +1,198 @@
+policy_module(incus)
+
+########################################
+#
+# Declarations
+#
+
+## <desc>
+##	<p>
+##	Allow incusd to mount filesystems inside
+##	lxc containers that might be required
+##	by some legacy init systems.
+##	</p>
+## </desc>
+gen_tunable(incus_lxc_legacy_mounts, false)
+
+# common attribute for all container domains
+# that may be used with incus
+attribute incus_container_domain;
+
+container_engine_domain_template(incusd)
+container_system_engine(incusd_t)
+
+type incusd_exec_t;
+container_engine_executable_file(incusd_exec_t)
+init_daemon_domain(incusd_t, incusd_exec_t)
+
+type incusc_exec_t;
+container_engine_executable_file(incusc_exec_t)
+
+type incusc_t;
+application_domain(incusc_t, incusc_exec_t)
+
+type incusc_user_t;
+application_domain(incusc_user_t, incusc_exec_t)
+
+ifdef(`enable_mls',`
+	init_ranged_daemon_domain(incusd_t, incusd_exec_t, s0 - mls_systemhigh)
+')
+
+########################################
+#
+# incus daemon local policy
+
+allow incusd_t self:process getattr;
+dontaudit incusd_t self:capability sys_module;
+allow incusd_t self:anon_inode { create map read write };
+allow incusd_t self:io_uring sqpoll;
+allow incusd_t self:netlink_kobject_uevent_socket create_socket_perms;
+allow incusd_t self:vsock_socket create_stream_socket_perms;
+
+# incusd needs to manage the host network
+allow incusd_t self:rawip_socket create_socket_perms;
+allow incusd_t self:tun_socket { create relabelfrom relabelto };
+
+# mounton access to /proc/sys/kernel/random/boot_id
+kernel_mounton_kernel_sysctl_files(incusd_t)
+
+# incusd wants to load netdev-phys*
+kernel_request_load_module(incusd_t)
+
+kernel_setsched(incusd_t)
+
+# for bridge management
+dev_create_sysfs_files(incusd_t)
+dev_write_sysfs(incusd_t)
+
+dev_getattr_vhost_dev(incusd_t)
+
+# incusd won't start without access to /dev/urandom
+dev_read_urand(incusd_t)
+
+# losetup required for instance creation
+dev_rw_loop_control(incusd_t)
+dev_rw_vhost(incusd_t)
+
+# required for fanotify on /dev/zvol/zdata/incus/virtual-machines/.#vm1.block...
+dev_watch_dev_fs(incusd_t)
+
+# read /etc/machine-id
+files_read_etc_runtime_files(incusd_t)
+
+# incus apparmor support wants to handle /sys/kernel/tracing
+fs_dontaudit_getattr_configfs(incusd_t)
+fs_dontaudit_getattr_tracefs(incusd_t)
+fs_dontaudit_getattr_tracefs_dirs(incusd_t)
+fs_dontaudit_remount_configfs(incusd_t)
+fs_dontaudit_remount_tracefs(incusd_t)
+
+fs_dontaudit_manage_fusefs_files(incusd_t)
+fs_getattr_binfmt_misc_dirs(incusd_t)
+fs_getattr_binfmt_misc_fs(incusd_t)
+fs_mount_binfmt_misc_fs(incusd_t)
+
+# here dontaudit would also work, but consuming more resources
+fs_watch_tmpfs_dirs(incusd_t)
+
+# name="stub-resolv.conf"
+fs_read_tmpfs_files(incusd_t)
+
+iptables_domtrans(incusd_t)
+iptables_kill(incusd_t)
+
+# incus idmap support: checks whether the kernel supports VFS v3 fscaps
+container_exec_engine_tmp_files(incusd_t)
+
+# comm="incusd" path="/run/systemd/resolve/stub-resolv.conf"
+container_read_tmpfs_files(incusd_t)
+
+ifdef(`init_systemd',`
+	init_get_system_status(incusd_t)
+	init_start_system(incusd_t)
+	init_stop_generic_units(incusd_t)
+	init_stop_system(incusd_t)
+')
+
+tunable_policy(`incus_lxc_legacy_mounts',`
+	kernel_getattr_debugfs(incusd_t)
+	kernel_search_debugfs(incusd_t)
+	kernel_remount_debugfs(incusd_t)
+
+	fs_getattr_binfmt_misc_fs(incusd_t)
+	fs_getattr_efivarfs(incusd_t)
+	fs_getattr_pstorefs(incusd_t)
+	fs_remount_efivarfs(incusd_t)
+	fs_remount_pstorefs(incusd_t)
+',`
+	kernel_dontaudit_getattr_debugfs(incusd_t)
+	kernel_dontaudit_search_debugfs(incusd_t)
+	kernel_dontaudit_remount_debugfs(incusd_t)
+
+	fs_dontaudit_getattr_binfmt_misc_fs(incusd_t)
+	fs_dontaudit_getattr_efivarfs(incusd_t)
+	fs_dontaudit_getattr_pstorefs(incusd_t)
+	fs_dontaudit_remount_efivarfs(incusd_t)
+	fs_dontaudit_remount_pstorefs(incusd_t)
+')
+
+optional_policy(`
+	dnsmasq_domtrans(incusd_t)
+	dnsmasq_kill(incusd_t)
+	dnsmasq_signal(incusd_t)
+	dnsmasq_signull(incusd_t)
+')
+
+optional_policy(`
+	dpkg_dontaudit_manage_db(incusd_t)
+')
+
+optional_policy(`
+	mount_exec(incusd_t)
+')
+
+optional_policy(`
+	# these are required for incusd to check and execute qemu
+	qemu_domtrans(incusd_t)
+	qemu_exec(incusd_t)
+
+	# required so that incus will get the VM PID
+	# and make "incus info VM" work
+	# Error: stat /proc/628420: permission denied
+	qemu_read_state(incusd_t)
+
+	qemu_kill(incusd_t)
+	qemu_stream_connect(incusd_t)
+
+	# avc:  denied  { read } for  pid=20404 comm="qemu-system-x86"
+	# name="overcommit_memory" dev="proc" ino=16557
+	# scontext=system_u:system_r:incusd_t:s0
+	# tcontext=system_u:object_r:sysctl_vm_overcommit_t:s0 tclass=file permissive=0
+	kernel_read_vm_overcommit_sysctl(incusd_t)
+
+	# incusd needs support to label VM files before launching
+	# until then, VM files will unfortunately be unlabeled
+	kernel_manage_unlabeled_dirs(incusd_t)
+	kernel_manage_unlabeled_files(incusd_t)
+	kernel_manage_unlabeled_symlinks(incusd_t)
+	kernel_mounton_unlabeled_dirs(incusd_t)
+
+	# required for QEMU feature check, will not start otherwise
+	files_dontaudit_delete_generic_tmp_named_sockets(incusd_t)
+	files_rw_generic_tmp_sockets(incusd_t)
+	files_search_default(incusd_t)
+')
+
+optional_policy(`
+	rsync_exec(incusd_t)
+')
+
+########################################
+#
+# incus lxc container local policy
+
+allow incus_container_domain self:cap_userns { chown dac_read_search fowner fsetid kill net_admin net_bind_service net_raw setgid setpcap setuid sys_admin sys_boot sys_chroot sys_ptrace };
+
+container_manage_engine_tmpfs_dirs(incus_container_domain)
+container_manage_engine_tmpfs_files(incus_container_domain)
+container_manage_engine_tmpfs_symlinks(incus_container_domain)

--- a/policy/modules/services/zfs.te
+++ b/policy/modules/services/zfs.te
@@ -143,6 +143,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# required when incusd is using zfs as storage backend
+	incus_stream_connect_daemon(zfs_t)
+')
+
+optional_policy(`
 	kernel_rw_rpc_sysctls(zfs_t)
 
 	rpc_manage_nfs_state_data(zfs_t)

--- a/policy/modules/system/iptables.if
+++ b/policy/modules/system/iptables.if
@@ -255,6 +255,24 @@ interface(`iptables_dontaudit_read_runtime_files',`
 
 ########################################
 ## <summary>
+##	Send kill signals to iptables.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`iptables_kill',`
+	gen_require(`
+		type iptables_t;
+	')
+
+	allow $1 iptables_t:process sigkill;
+')
+
+########################################
+## <summary>
 ##	Allow specified domain to start and stop iptables service
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/iptables.if
+++ b/policy/modules/system/iptables.if
@@ -18,7 +18,7 @@ interface(`iptables_domtrans',`
 	corecmd_search_bin($1)
 	domtrans_pattern($1, iptables_exec_t, iptables_t)
 
-        dontaudit iptables_t $1:socket_class_set { read write };
+	dontaudit iptables_t $1:socket_class_set { read write };
 ')
 
 ########################################

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -69,6 +69,7 @@ corecmd_exec_shell(iptables_t)
 corenet_relabelto_all_packets(iptables_t)
 corenet_dontaudit_rw_tun_tap_dev(iptables_t)
 
+dev_read_urand(iptables_t)
 dev_read_sysfs(iptables_t)
 dev_dontaudit_write_mtrr(iptables_t)
 

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -132,6 +132,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	incus_stream_connect_daemon(iptables_t)
+')
+
+optional_policy(`
 	# apply firewall rules from multus
 	kubernetes_rw_container_engine_fifo_files(iptables_t)
 ')

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2333,6 +2333,24 @@ interface(`systemd_read_networkd_runtime',`
 
 #######################################
 ## <summary>
+##	Watch directories under /run/systemd/resolve
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain permitted the access
+##	</summary>
+## </param>
+#
+interface(`systemd_watch_resolved_runtime_dirs',`
+	gen_require(`
+		type systemd_resolved_runtime_t;
+	')
+
+	allow $1 systemd_resolved_runtime_t:dir watch;
+')
+
+#######################################
+## <summary>
 ##  Connect to systemd-nsresourced over
 ##  /run/systemd/io.systemd.NamespaceResource .
 ## </summary>


### PR DESCRIPTION
This PR adds a new module called `incus` for the incus container and VM manager

- add incus module
- extend container module by new container_init_t type of container
- add required interfaces to other modules