### PR TITLE
shutdown_t: fix exec of /sbin/shutdown by /sbin/halt

### DIFF
--- a/policy/modules/admin/shutdown.te
+++ b/policy/modules/admin/shutdown.te
@@ -39,6 +39,9 @@ allow shutdown_t self:process { setsched signal signull };
 allow shutdown_t self:fifo_file manage_fifo_file_perms;
 allow shutdown_t self:unix_stream_socket create_stream_socket_perms;
 
+# /sbin/halt executes /sbin/shutdown
+allow shutdown_t shutdown_exec_t:file execute_no_trans;
+
 manage_files_pattern(shutdown_t, shutdown_etc_t, shutdown_etc_t)
 files_etc_filetrans(shutdown_t, shutdown_etc_t, file)
 


### PR DESCRIPTION
When rebooting using reboot provided by /sbin/init, halt is called which attempts to exec /sbin/shutdown[1].

[1] https://github.com/slicer69/sysvinit/blob/main/src/halt.c#L185