### PR TITLE
Remove redundancies

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -425,7 +425,6 @@ init_var_lib_filetrans(systemd_backlight_t, systemd_backlight_var_lib_t, dir)
 manage_files_pattern(systemd_backlight_t, systemd_backlight_var_lib_t, systemd_backlight_var_lib_t)
 
 kernel_getattr_proc(systemd_backlight_t)
-kernel_read_kernel_sysctls(systemd_backlight_t)
 
 systemd_log_parse_environment(systemd_backlight_t)
 
@@ -444,7 +443,6 @@ files_search_var_lib(systemd_backlight_t)
 
 fs_getattr_all_fs(systemd_backlight_t)
 fs_getattr_nsfs_files(systemd_backlight_t)
-fs_search_cgroup_dirs(systemd_backlight_t)
 
 fs_search_cgroup_dirs(systemd_backlight_t)
 
@@ -643,7 +641,6 @@ fs_getattr_nsfs_files(systemd_generator_t)
 
 init_create_runtime_files(systemd_generator_t)
 init_read_all_script_files(systemd_generator_t)
-init_getattr_all_unit_files(systemd_generator_t)
 init_manage_runtime_dirs(systemd_generator_t)
 init_manage_runtime_symlinks(systemd_generator_t)
 init_read_runtime_files(systemd_generator_t)
@@ -1269,9 +1266,6 @@ manage_sock_files_pattern(systemd_machined_t, systemd_userdbd_runtime_t, systemd
 allow systemd_machined_t systemd_userdb_runtime_t:dir manage_dir_perms;
 allow systemd_machined_t systemd_userdb_runtime_t:sock_file { create unlink };
 
-init_get_transient_units_status(systemd_machined_t)
-init_start_transient_units(systemd_machined_t)
-
 kernel_getattr_proc(systemd_machined_t)
 kernel_read_kernel_sysctls(systemd_machined_t)
 kernel_read_system_state(systemd_machined_t)
@@ -1622,8 +1616,6 @@ init_spec_domtrans_script(systemd_nspawn_t)
 miscfiles_read_localization(systemd_nspawn_t)
 miscfiles_manage_localization(systemd_nspawn_t)
 mount_exec(systemd_nspawn_t)
-
-udev_read_runtime_files(systemd_nspawn_t)
 
 sysnet_exec_ifconfig(systemd_nspawn_t)
 

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -82,7 +82,6 @@ manage_lnk_files_pattern(udev_t, udev_rules_t, udev_rules_t)
 allow udev_t udev_rules_t:dir watch;
 
 manage_dirs_pattern(udev_t, udev_runtime_t, udev_runtime_t)
-allow udev_t udev_runtime_t:dir watch;
 manage_files_pattern(udev_t, udev_runtime_t, udev_runtime_t)
 manage_lnk_files_pattern(udev_t, udev_runtime_t, udev_runtime_t)
 manage_sock_files_pattern(udev_t, udev_runtime_t, udev_runtime_t)


### PR DESCRIPTION
Over time, merges and rebases can introduce duplicated lines into the policy files.  This patch removes some redundancies.

All removed lines exist verbatim elsewhere in the same file.