### PR TITLE
Initial policy for Kanidm

### DIFF
--- a/policy/modules/admin/portage.if
+++ b/policy/modules/admin/portage.if
@@ -331,6 +331,27 @@ interface(`portage_dontaudit_use_inherited_ptys',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to read the
+##	portage configuration.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`portage_dontaudit_read_config',`
+	gen_require(`
+		type portage_conf_t;
+	')
+
+	dontaudit $1 portage_conf_t:dir search_dir_perms;
+	dontaudit $1 portage_conf_t:file read_file_perms;
+	dontaudit $1 portage_conf_t:lnk_file read_lnk_file_perms;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to search the
 ##	portage temporary directories.
 ## </summary>

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1508,6 +1508,25 @@ interface(`files_list_non_auth_dirs',`
 
 ########################################
 ## <summary>
+##	Watch all non-authentication related
+##	directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_non_auth_dirs',`
+	gen_require(`
+		attribute non_auth_file_type;
+	')
+
+	allow $1 non_auth_file_type:dir watch;
+')
+
+########################################
+## <summary>
 ##	Read all non-authentication related
 ##	files.
 ## </summary>
@@ -4190,6 +4209,24 @@ interface(`files_watch_home',`
 	')
 
 	allow $1 home_root_t:dir watch;
+')
+
+########################################
+## <summary>
+##	Manage user home root symlinks.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_manage_home_symlinks',`
+	gen_require(`
+		type home_root_t;
+	')
+
+	allow $1 home_root_t:lnk_file manage_lnk_file_perms;
 ')
 
 ########################################

--- a/policy/modules/services/kanidm.fc
+++ b/policy/modules/services/kanidm.fc
@@ -1,0 +1,23 @@
+/usr/bin/kanidmd	--	gen_context(system_u:object_r:kanidmd_exec_t,s0)
+/usr/bin/kanidm_unixd	--	gen_context(system_u:object_r:kanidm_unixd_exec_t,s0)
+/usr/bin/kanidm_unixd_tasks	--	gen_context(system_u:object_r:kanidm_unixd_tasks_exec_t,s0)
+
+/usr/sbin/kanidmd	--	gen_context(system_u:object_r:kanidmd_exec_t,s0)
+/usr/sbin/kanidm_unixd	--	gen_context(system_u:object_r:kanidm_unixd_exec_t,s0)
+/usr/sbin/kanidm_unixd_tasks	--	gen_context(system_u:object_r:kanidm_unixd_tasks_exec_t,s0)
+
+/etc/kanidm(/.*)?		gen_context(system_u:object_r:kanidm_config_t,s0)
+
+/run/kanidmd(/.*)?		gen_context(system_u:object_r:kanidmd_runtime_t,s0)
+/run/kanidm-unixd(/.*)?		gen_context(system_u:object_r:kanidm_unixd_runtime_t,s0)
+
+/var/cache/kanidm-unixd(/.*)?		gen_context(system_u:object_r:kanidm_unixd_cache_t,s0)
+
+/var/lib/kanidm(/.*)?		gen_context(system_u:object_r:kanidm_var_lib_t,s0)
+/var/lib/kanidm-unixd(/.*)?		gen_context(system_u:object_r:kanidm_unixd_var_lib_t,s0)
+
+/var/log/kanidm(/.*)?		gen_context(system_u:object_r:kanidmd_log_t,s0)
+/var/log/kanidm-unixd(/.*)?		gen_context(system_u:object_r:kanidmd_log_t,s0)
+/var/log/kanidmd\.log	--	gen_context(system_u:object_r:kanidmd_log_t,s0)
+/var/log/kanidm-unixd\.log	--	gen_context(system_u:object_r:kanidm_unixd_log_t,s0)
+/var/log/kanidm-unixd-tasks\.log	--	gen_context(system_u:object_r:kanidm_unixd_log_t,s0)

--- a/policy/modules/services/kanidm.if
+++ b/policy/modules/services/kanidm.if
@@ -1,0 +1,183 @@
+## <summary>A simple, secure and fast identity management platform</summary>
+
+########################################
+## <summary>
+##	Execute kanidmd in the kanidmd domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`kanidm_domtrans',`
+	gen_require(`
+		type kanidmd_t, kanidmd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, kanidmd_exec_t, kanidmd_t)
+')
+
+########################################
+## <summary>
+##	Execute kanidmd in the kanidmd domain, and
+##	allow the specified role the kanidmd domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`kanidm_run',`
+	gen_require(`
+		type kanidmd_t;
+	')
+
+	kanidm_domtrans($1)
+	role $2 types kanidmd_t;
+')
+
+########################################
+## <summary>
+##	Execute kanidmd-unixd in the
+##	kanidmd-unixd domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`kanidm_domtrans_unixd',`
+	gen_require(`
+		type kanidm_unixd_t, kanidm_unixd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, kanidm_unixd_exec_t, kanidm_unixd_t)
+')
+
+########################################
+## <summary>
+##	Execute kanidm-unixd in the kanidm-unixd
+##	domain, and allow the specified role the
+##	kanidm-unixd domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`kanidm_run_unixd',`
+	gen_require(`
+		type kanidm_unixd_t;
+	')
+
+	kanidm_domtrans_unixd($1)
+	role $2 types kanidm_unixd_t;
+')
+
+########################################
+## <summary>
+##	Read kanidm config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kanidm_read_config',`
+	gen_require(`
+		type kanidm_config_t;
+	')
+
+	files_search_etc($1)
+	read_files_pattern($1, kanidm_config_t, kanidm_config_t)
+')
+
+#######################################
+## <summary>
+##	Connect to kanidm-unixd with a
+##	domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kanidm_unixd_stream_connect',`
+	gen_require(`
+		type kanidm_unixd_t, kanidm_unixd_runtime_t;
+	')
+
+	files_search_runtime($1)
+	stream_connect_pattern($1, kanidm_unixd_runtime_t, kanidm_unixd_runtime_t, kanidm_unixd_t)
+')
+
+########################################
+## <summary>
+##	All of the rules required to
+##	administrate a Kanidm environment.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`kanidm_admin',`
+	gen_require(`
+		type kanidmd_t;
+		type kanidm_unixd_t;
+		type kanidm_config_t;
+		type kanidm_unixd_cache_t;
+		type kanidm_unixd_runtime_t;
+		type kanidm_var_lib_t;
+	')
+
+	kanidm_run($1, $2)
+	kanidm_run_unixd($1, $2)
+
+	allow $1 kanidmd_t:process { ptrace signal_perms };
+	ps_process_pattern($1, kanidmd_t)
+
+	allow $1 kanidm_unixd_t:process { ptrace signal_perms };
+	ps_process_pattern($1, kanidm_unixd_t)
+
+	stream_connect_pattern($1, kanidm_unixd_runtime_t, kanidm_unixd_runtime_t, kanidm_unixd_t)
+
+	files_search_etc($1)
+	admin_pattern($1, kanidm_config_t)
+
+	files_search_runtime($1)
+	admin_pattern($1, kanidm_unixd_runtime_t)
+
+	files_search_var($1)
+	admin_pattern($1, kanidm_unixd_cache_t)
+
+	files_search_var_lib($1)
+	admin_pattern($1, kanidm_var_lib_t)
+')

--- a/policy/modules/services/kanidm.te
+++ b/policy/modules/services/kanidm.te
@@ -1,0 +1,229 @@
+policy_module(kanidm)
+
+########################################
+#
+# Declarations
+#
+
+## <desc>
+##  <p>
+##  Determine whether kanidm-unixd-tasks can
+##  create home directories via pam.
+##  </p>
+## </desc>
+gen_tunable(kanidm_unixd_create_home_dirs, false)
+
+## <desc>
+##  <p>
+##	Determine whether kanidm-unixd-tasks can
+##	modify the SELinux policy. This is to create
+##	local equivalence file context rules which map
+##	usernames to their UUID, SPN, or other identifier.
+##  </p>
+## </desc>
+gen_tunable(kanidm_unixd_modify_policy, false)
+
+type kanidmd_t;
+type kanidmd_exec_t;
+init_daemon_domain(kanidmd_t, kanidmd_exec_t)
+
+type kanidm_unixd_t;
+type kanidm_unixd_exec_t;
+init_daemon_domain(kanidm_unixd_t, kanidm_unixd_exec_t)
+
+type kanidm_unixd_tasks_t;
+type kanidm_unixd_tasks_exec_t;
+init_daemon_domain(kanidm_unixd_tasks_t, kanidm_unixd_tasks_exec_t)
+
+type kanidm_config_t;
+files_config_file(kanidm_config_t)
+
+type kanidmd_runtime_t;
+files_runtime_file(kanidmd_runtime_t)
+
+type kanidm_unixd_cache_t;
+files_type(kanidm_unixd_cache_t)
+
+type kanidm_unixd_runtime_t;
+files_runtime_file(kanidm_unixd_runtime_t)
+
+type kanidm_var_lib_t;
+files_type(kanidm_var_lib_t)
+
+type kanidm_unixd_var_lib_t;
+files_type(kanidm_unixd_var_lib_t)
+
+type kanidmd_log_t;
+logging_log_file(kanidmd_log_t)
+
+type kanidm_unixd_log_t;
+logging_log_file(kanidm_unixd_log_t)
+
+########################################
+#
+# kanidmd local policy
+#
+
+allow kanidmd_t self:process getsched;
+allow kanidmd_t self:tcp_socket create_stream_socket_perms;
+allow kanidmd_t self:unix_dgram_socket create_socket_perms;
+
+read_files_pattern(kanidmd_t, kanidm_config_t, kanidm_config_t)
+
+manage_sock_files_pattern(kanidmd_t, kanidmd_runtime_t, kanidmd_runtime_t)
+files_runtime_filetrans(kanidmd_t, kanidmd_runtime_t, sock_file)
+
+manage_dirs_pattern(kanidmd_t, kanidm_var_lib_t, kanidm_var_lib_t)
+mmap_manage_files_pattern(kanidmd_t, kanidm_var_lib_t, kanidm_var_lib_t)
+
+corenet_tcp_bind_generic_node(kanidmd_t)
+corenet_tcp_bind_http_port(kanidmd_t)
+corenet_tcp_bind_servistaitsm_port(kanidmd_t)
+
+dev_read_sysfs(kanidmd_t)
+
+domain_use_interactive_fds(kanidmd_t)
+
+files_read_usr_files(kanidmd_t)
+files_read_var_lib_symlinks(kanidmd_t)
+
+fs_read_cgroup_files(kanidmd_t)
+
+kernel_read_vm_overcommit_sysctl(kanidmd_t)
+
+logging_send_syslog_msg(kanidmd_t)
+
+miscfiles_read_generic_certs(kanidmd_t)
+
+userdom_use_inherited_user_terminals(kanidmd_t)
+
+optional_policy(`
+	certbot_read_lib(kanidmd_t)
+')
+
+########################################
+#
+# kanidm-unixd local policy
+#
+
+allow kanidm_unixd_t self:process getsched;
+allow kanidm_unixd_t self:udp_socket create_socket_perms;
+allow kanidm_unixd_t self:unix_dgram_socket create_socket_perms;
+
+read_files_pattern(kanidm_unixd_t, kanidm_config_t, kanidm_config_t)
+
+mmap_manage_files_pattern(kanidm_unixd_t, kanidm_unixd_cache_t, kanidm_unixd_cache_t)
+
+manage_dirs_pattern(kanidm_unixd_t, kanidm_unixd_runtime_t, kanidm_unixd_runtime_t)
+manage_sock_files_pattern(kanidm_unixd_t, kanidm_unixd_runtime_t, kanidm_unixd_runtime_t)
+files_runtime_filetrans(kanidm_unixd_t, kanidm_unixd_runtime_t, { dir sock_file })
+
+files_search_var_lib(kanidm_unixd_t)
+manage_files_pattern(kanidm_unixd_t, kanidm_unixd_var_lib_t, kanidm_unixd_var_lib_t)
+
+append_files_pattern(kanidm_unixd_t, kanidm_unixd_log_t, kanidm_unixd_log_t)
+logging_log_filetrans(kanidm_unixd_t, kanidm_unixd_log_t, { dir file })
+
+corenet_tcp_bind_generic_node(kanidm_unixd_t)
+corenet_tcp_connect_http_port(kanidm_unixd_t)
+
+corecmd_exec_shell(kanidm_unixd_t)
+
+dev_read_sysfs(kanidm_unixd_t)
+dev_rw_tpm(kanidm_unixd_t)
+
+domain_use_interactive_fds(kanidm_unixd_t)
+
+# watch /etc/passwd
+files_watch_etc_files(kanidm_unixd_t)
+
+fs_read_cgroup_files(kanidm_unixd_t)
+
+kernel_read_system_state(kanidm_unixd_t)
+kernel_read_vm_overcommit_sysctl(kanidm_unixd_t)
+
+auth_use_nsswitch(kanidm_unixd_t)
+
+miscfiles_read_generic_certs(kanidm_unixd_t)
+miscfiles_read_localization(kanidm_unixd_t)
+
+logging_send_syslog_msg(kanidm_unixd_t)
+
+userdom_use_inherited_user_terminals(kanidm_unixd_t)
+
+########################################
+#
+# kanidm-unixd-tasks local policy
+#
+
+allow kanidm_unixd_tasks_t self:process getsched;
+# needed for running as root reading /run/kanidm-unixd
+allow kanidm_unixd_tasks_t self:capability dac_override;
+
+read_files_pattern(kanidm_unixd_tasks_t, kanidm_config_t, kanidm_config_t)
+
+stream_connect_pattern(kanidm_unixd_tasks_t, kanidm_unixd_runtime_t, kanidm_unixd_runtime_t, kanidm_unixd_t)
+
+append_files_pattern(kanidm_unixd_tasks_t, kanidm_unixd_log_t, kanidm_unixd_log_t)
+logging_log_filetrans(kanidm_unixd_tasks_t, kanidm_unixd_log_t, { dir file })
+
+corecmd_exec_bin(kanidm_unixd_tasks_t)
+
+# for creating home directories
+domain_obj_id_change_exemption(kanidm_unixd_tasks_t)
+
+files_search_home(kanidm_unixd_tasks_t)
+# recursively watch everything in /etc
+files_list_non_auth_dirs(kanidm_unixd_tasks_t)
+files_watch_non_auth_dirs(kanidm_unixd_tasks_t)
+files_dontaudit_getattr_all_files(kanidm_unixd_tasks_t)
+files_dontaudit_getattr_all_symlinks(kanidm_unixd_tasks_t)
+
+kernel_read_kernel_sysctls(kanidm_unixd_tasks_t)
+kernel_read_system_state(kanidm_unixd_tasks_t)
+
+auth_read_shadow(kanidm_unixd_tasks_t)
+auth_use_nsswitch(kanidm_unixd_tasks_t)
+
+logging_send_syslog_msg(kanidm_unixd_tasks_t)
+
+# query SELinux state at startup
+selinux_get_fs_mount(kanidm_unixd_tasks_t)
+selinux_get_enforce_mode(kanidm_unixd_tasks_t)
+
+seutil_libselinux_linked(kanidm_unixd_tasks_t)
+
+tunable_policy(`kanidm_unixd_create_home_dirs',`
+	allow kanidm_unixd_tasks_t self:process setfscreate;
+	allow kanidm_unixd_tasks_t self:capability { chown dac_read_search };
+
+	userdom_create_user_home_dirs(kanidm_unixd_tasks_t)
+	userdom_setattr_user_home_dirs(kanidm_unixd_tasks_t)
+	userdom_home_filetrans_user_home_dir(kanidm_unixd_tasks_t)
+
+	# create alias symlinks
+	files_manage_home_symlinks(kanidm_unixd_tasks_t)
+
+	# populate new home dirs from /etc/skel
+	userdom_manage_user_home_content_dirs(kanidm_unixd_tasks_t)
+	userdom_manage_user_home_content_files(kanidm_unixd_tasks_t)
+	userdom_manage_user_home_content_symlinks(kanidm_unixd_tasks_t)
+	userdom_user_home_dir_filetrans_user_home_content(kanidm_unixd_tasks_t, { dir file lnk_file sock_file fifo_file })
+
+	seutil_exec_setfiles(kanidm_unixd_tasks_t)
+')
+
+tunable_policy(`kanidm_unixd_create_home_dirs && kanidm_unixd_modify_policy',`
+	# create equivalence rules for home dirs
+	seutil_nnp_domtrans_semanage(kanidm_unixd_tasks_t)
+	seutil_read_file_contexts(kanidm_unixd_tasks_t)
+	seutil_read_default_contexts(kanidm_unixd_tasks_t)
+',`
+	seutil_dontaudit_exec_semanage(kanidm_unixd_tasks_t)
+	seutil_dontaudit_exec_setfiles(kanidm_unixd_tasks_t)
+	seutil_dontaudit_read_file_contexts(kanidm_unixd_tasks_t)
+')
+
+optional_policy(`
+	portage_dontaudit_read_config(kanidm_unixd_tasks_t)
+')

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -14,6 +14,13 @@ gen_tunable(authlogin_pam, true)
 
 ## <desc>
 ## <p>
+## Allow users to resolve user passwd entries directly from kanidm.
+## </p>
+## </desc>
+gen_tunable(authlogin_nsswitch_use_kanidm, false)
+
+## <desc>
+## <p>
 ## Allow users to resolve user passwd entries directly from ldap rather then using a sssd server
 ## </p>
 ## </desc>
@@ -482,6 +489,13 @@ ifdef(`init_systemd', `
 	systemd_stream_connect_userdb(nsswitch_domain)
 	systemd_stream_connect_homed(nsswitch_domain)
 	systemd_stream_connect_nsresourced(nsswitch_domain)
+')
+
+optional_policy(`
+	tunable_policy(`authlogin_nsswitch_use_kanidm',`
+		kanidm_read_config(nsswitch_domain)
+		kanidm_unixd_stream_connect(nsswitch_domain)
+	')
 ')
 
 tunable_policy(`authlogin_nsswitch_use_ldap',`

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -37,6 +37,13 @@ gen_tunable(init_daemons_use_tty, false)
 ## </desc>
 gen_tunable(init_mounton_non_security, false)
 
+## <desc>
+## <p>
+## Enable systemd to mount on the SELinux config directories.
+## </p>
+## </desc>
+gen_tunable(init_mounton_selinux_config, false)
+
 attribute init_domain_type;
 attribute init_mountpoint_type;
 attribute init_path_unit_loc_type;
@@ -586,6 +593,10 @@ ifdef(`init_systemd',`
 
 	tunable_policy(`init_mounton_non_security',`
 		files_mounton_non_security(init_t)
+	')
+
+	tunable_policy(`init_mounton_selinux_config',`
+		seutil_mounton_config_dirs(init_t)
 	')
 
 	optional_policy(`

--- a/policy/modules/system/selinuxutil.if
+++ b/policy/modules/system/selinuxutil.if
@@ -1036,6 +1036,26 @@ interface(`seutil_domtrans_semanage',`
 
 ########################################
 ## <summary>
+##	Transition to the semanage domain when
+##	NNP has been set.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`seutil_nnp_domtrans_semanage',`
+	gen_require(`
+		type semanage_t;
+	')
+
+	seutil_domtrans_semanage($1)
+	allow $1 semanage_t:process2 nnp_transition;
+')
+
+########################################
+## <summary>
 ##	Execute semanage in the semanage domain, and
 ##	allow the specified role the semanage domain,
 ##	and use the caller's terminal.

--- a/policy/modules/system/selinuxutil.if
+++ b/policy/modules/system/selinuxutil.if
@@ -738,6 +738,26 @@ interface(`seutil_manage_config_dirs',`
 	allow $1 selinux_config_t:dir manage_dir_perms;
 ')
 
+#######################################
+## <summary>
+##	Mount on the general selinux
+##	configuration directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`seutil_mounton_config_dirs',`
+	gen_require(`
+		type selinux_config_t;
+	')
+
+	allow $1 selinux_config_t:dir mounton;
+')
+
 ########################################
 ## <summary>
 ##	Search the policy directory with default_context files.

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2428,5 +2428,12 @@ userdom_mounton_user_runtime_dirs(systemd_user_runtime_dir_t)
 userdom_relabelto_user_runtime_dirs(systemd_user_runtime_dir_t)
 
 optional_policy(`
+	tunable_policy(`authlogin_nsswitch_use_kanidm',`
+		kanidm_read_config(systemd_user_runtime_dir_t)
+		kanidm_unixd_stream_connect(systemd_user_runtime_dir_t)
+	')
+')
+
+optional_policy(`
 	dbus_system_bus_client(systemd_user_runtime_dir_t)
 ')

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1819,6 +1819,24 @@ interface(`userdom_dontaudit_getattr_user_home_dirs',`
 
 ########################################
 ## <summary>
+##	Set the attributes of user home directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`userdom_setattr_user_home_dirs',`
+	gen_require(`
+		type user_home_dir_t;
+	')
+
+	allow $1 user_home_dir_t:dir setattr_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Search user home directories.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Add an initial policy implementation for [Kanidm](https://github.com/kanidm/kanidm).

From the README:

> Kanidm is a simple and secure identity management platform, allowing other applications and  services to offload the challenge of authenticating and storing identities to Kanidm.
>
> The goal of this project is to be a complete identity provider, covering the broadest possible set of requirements and integrations. You should not need any other components (like Keycloak) when you use Kanidm - we already have everything you need!
>
> To achieve this we rely heavily on strict defaults, simple configuration, and self-healing components. This allows Kanidm to support small home labs, families, small businesses, and all the way to the largest enterprise needs.
>
> If you want to host your own authentication service, then Kanidm is for you!

It provides the Kanidm server itself as well as the optional Kanidm-unixd client which implements support for UNIX authentication via PAM.