### PR TITLE
unconfined: Promote anon_inode access to full access.

### DIFF
--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -50,8 +50,7 @@ interface(`unconfined_domain_noaudit',`
 	# Write access is for setting attributes under /proc/self/attr.
 	allow $1 self:file rw_file_perms;
 
-	# io_uring
-	allow $1 self:anon_inode { create map read write };
+	allow $1 self:anon_inode { manage_file_perms mounton quotaon relabel_file_perms watch watch_mount watch_reads watch_sb watch_with_perm }; #selint-disable:S-009
 
 	# Userland object managers
 	allow $1 self:nscd { admin getgrp gethost getpwd getserv getstat shmemgrp shmemhost shmempwd shmemserv };


### PR DESCRIPTION
This class inherits the file common.

Also see https://lore.kernel.org/selinux/48916a70-2a89-4d24-8e36-d15ccc112519@ieee.org/