### PR TITLE
allow system_dbusd_t,systemd_logind_t unconfined:fd use

### DIFF
--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -285,6 +285,7 @@ optional_policy(`
 
 optional_policy(`
 	unconfined_dbus_send(system_dbusd_t)
+	unconfined_use_fds(system_dbusd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1265,6 +1265,7 @@ optional_policy(`
 
 optional_policy(`
 	unconfined_dbus_send(systemd_logind_t)
+	unconfined_use_fds(systemd_logind_t)
 ')
 
 #########################################


### PR DESCRIPTION
"sudo su -"

--

```
type=PROCTITLE proctitle=/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only

type=SYSCALL arch=armeb syscall=recvmsg per=PER_LINUX success=yes exit=312 a0=0x12 a1=0xbef207c8 a2=MSG_CMSG_CLOEXEC a3=0x1 items=0 ppid=1 pid=184 auid=unset uid=messagebus gid=messagebus euid=messagebus suid=messagebus fsuid=messagebus egid=messagebus sgid=messagebus fsgid=messagebus tty=(none) ses=unset comm=dbus-daemon exe=/usr/bin/dbus-daemon subj=system_u:system_r:system_dbusd_t:s0 key=(null)

type=AVC avc:  denied  { use } for  pid=184 comm=dbus-daemon path=anon_inode:[pidfd] dev="pidfs" ino=303 scontext=system_u:system_r:system_dbusd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0 tclass=fd
```

```
type=PROCTITLE proctitle=/usr/lib/systemd/systemd-logind

type=SYSCALL arch=armeb syscall=recvmsg per=PER_LINUX success=yes exit=24 a0=0xe a1=0xbee507e4 a2=MSG_DONTWAIT|MSG_CMSG_CLOEXEC a3=0x1 items=0 ppid=1 pid=186 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-logind exe=/usr/lib/systemd/systemd-logind subj=system_u:system_r:systemd_logind_t:s0 key=(null)

type=AVC avc:  denied  { use } for  pid=186 comm=systemd-logind path=anon_inode:[pidfd] dev="pidfs" ino=311 scontext=system_u:system_r:systemd_logind_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=fd
```

--

Fedora:

```
$ sesearch -A --source system_dbusd_t --target unconfined_t --class fd --perm use
allow domain domain:fd use; [ domain_fd_use ]:True
allow domain unconfined_t:fd use;
allow systemprocess initrc_transition_domain:fd use;

$ sesearch -A --source systemd_logind_t --target unconfined_t --class fd --perm use
allow daemon initrc_transition_domain:fd use;
allow domain domain:fd use; [ domain_fd_use ]:True
allow domain unconfined_t:fd use;

$ getsebool domain_fd_use
domain_fd_use --> on
```