### PR TITLE
add extra # characters to commented interfaces

### DIFF
--- a/policy/modules/services/incus.if
+++ b/policy/modules/services/incus.if
@@ -67,16 +67,16 @@ interface(`incus_run_cli',`
 	incus_domtrans_cli($1)
 ')
 
-########################################
-## <summary>
-##	Execute incus in the incus user domain.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed to transition.
-##	</summary>
-## </param>
-#
+#########################################
+### <summary>
+###	Execute incus in the incus user domain.
+### </summary>
+### <param name="domain">
+###	<summary>
+###	Domain allowed to transition.
+###	</summary>
+### </param>
+##
 #interface(`incus_domtrans_user_daemon',`
 #	gen_require(`
 #		type incusd_user_t, incusd_exec_t;
@@ -86,23 +86,23 @@ interface(`incus_run_cli',`
 #	domtrans_pattern($1, incusd_exec_t, incusd_user_t)
 #')
 
-########################################
-## <summary>
-##	Execute incus in the incus user
-##	domain, and allow the specified
-##	role the incus user domain.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed to transition.
-##	</summary>
-## </param>
-## <param name="role">
-##	<summary>
-##	The role to be allowed the incus domain.
-##	</summary>
-## </param>
-#
+#########################################
+### <summary>
+###	Execute incus in the incus user
+###	domain, and allow the specified
+###	role the incus user domain.
+### </summary>
+### <param name="domain">
+###	<summary>
+###	Domain allowed to transition.
+###	</summary>
+### </param>
+### <param name="role">
+###	<summary>
+###	The role to be allowed the incus domain.
+###	</summary>
+### </param>
+##
 #interface(`incus_run_user_daemon',`
 #	gen_require(`
 #		type incusd_user_t;
@@ -179,33 +179,33 @@ interface(`incus_stream_connect_daemon',`
 	allow $1 incusd_t:unix_stream_socket { connectto rw_socket_perms };
 ')
 
-########################################
-## <summary>
-##	Role access for rootless incus.
-## </summary>
-## <param name="role_prefix">
-##	<summary>
-##	The prefix of the user role (e.g., user
-##	is the prefix for user_r).
-##	</summary>
-## </param>
-## <param name="user_domain">
-##	<summary>
-##	User domain for the role.
-##	</summary>
-## </param>
-## <param name="user_exec_domain">
-##	<summary>
-##	User exec domain for execute and transition access.
-##	</summary>
-## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
-## <rolecap/>
-#
+#########################################
+### <summary>
+###	Role access for rootless incus.
+### </summary>
+### <param name="role_prefix">
+###	<summary>
+###	The prefix of the user role (e.g., user
+###	is the prefix for user_r).
+###	</summary>
+### </param>
+### <param name="user_domain">
+###	<summary>
+###	User domain for the role.
+###	</summary>
+### </param>
+### <param name="user_exec_domain">
+###	<summary>
+###	User exec domain for execute and transition access.
+###	</summary>
+### </param>
+### <param name="role">
+###	<summary>
+###	Role allowed access.
+###	</summary>
+### </param>
+### <rolecap/>
+##
 #template(`incus_user_role',`
 #	gen_require(`
 #		type incusd_user_t;
@@ -231,16 +231,16 @@ interface(`incus_stream_connect_daemon',`
 #	')
 #')
 
-########################################
-## <summary>
-##	Send signals to the rootless incus daemon.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed to transition.
-##	</summary>
-## </param>
-#
+#########################################
+### <summary>
+###	Send signals to the rootless incus daemon.
+### </summary>
+### <param name="domain">
+###	<summary>
+###	Domain allowed to transition.
+###	</summary>
+### </param>
+##
 #interface(`incus_signal_user_daemon',`
 #	gen_require(`
 #		type incusd_user_t;


### PR DESCRIPTION
When `make config` is called, the interfaces are passed through xmllint, which validates that the docstrings are appropriately formatted, even if the interface body has been commented out.  This causes validation errors, since these spurious docstrings are concactenated with the following docstring.

By left-padding the commented-out docstrings with another # character, the docstrings are not used, and not checked by xmllint, allowing the test to succeed.