### PR TITLE
git client domain fixes

### DIFF
--- a/policy/modules/apps/gpg.if
+++ b/policy/modules/apps/gpg.if
@@ -518,6 +518,26 @@ interface(`gpg_list_user_secrets',`
 
 ########################################
 ## <summary>
+##	Allow gpg to read a file type, and therefore encrypt,
+##	decrypt, sign, and validate files of that type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain gpg is allowed access to.
+##	</summary>
+## </param>
+#
+interface(`gpg_crypto_content',`
+	gen_require(`
+		type gpg_t;
+	')
+
+	allow gpg_t $1:file read_file_perms;
+	allow gpg_t $1:dir search_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempt to search gpg user secrets dirs.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/git.fc
+++ b/policy/modules/services/git.fc
@@ -7,7 +7,9 @@ HOME_DIR/\.git-credentials	--	gen_context(system_u:object_r:git_xdg_config_t,s0)
 /usr/bin/git-[^/]+	--	gen_context(system_u:object_r:git_exec_t,s0)
 /usr/bin/git2_cli	--	gen_context(system_u:object_r:git_exec_t,s0)
 
-/usr/lib/git-core/git-daemon	--	gen_context(system_u:object_r:gitd_exec_t,s0)
+/usr/lib/git-core/git	--	gen_context(system_u:object_r:git_exec_t,s0)
+/usr/lib/git-core/git-[^/]+ --	gen_context(system_u:object_r:git_exec_t,s0)
+/usr/lib/git-core/git-daemon --	gen_context(system_u:object_r:gitd_exec_t,s0)
 
 /usr/libexec/git-core/git	--	gen_context(system_u:object_r:git_exec_t,s0)
 /usr/libexec/git-core/git-[^/]+ --	gen_context(system_u:object_r:git_exec_t,s0)

--- a/policy/modules/services/git.if
+++ b/policy/modules/services/git.if
@@ -92,6 +92,7 @@ template(`git_client_role_template',`
 	gen_require(`
 		attribute git_client_domain;
 		type git_exec_t, git_home_t, git_home_hook_t;
+		type git_xdg_config_t;
 	')
 
 	########################################
@@ -117,6 +118,9 @@ template(`git_client_role_template',`
 	allow $2 git_home_hook_t:dir { manage_dir_perms relabel_dir_perms };
 	allow $2 git_home_hook_t:file { exec_file_perms manage_file_perms relabel_file_perms };
 	filetrans_pattern($2, git_home_t, git_home_hook_t, dir, "hooks")
+	xdg_config_filetrans($2, git_xdg_config_t, dir, "git")
+	userdom_user_home_dir_filetrans($2, git_xdg_config_t, file, ".gitconfig")
+	userdom_user_home_dir_filetrans($2, git_xdg_config_t, file, ".git-credentials")
 
 	allow $3 $1_git_t:process { ptrace signal_perms };
 	ps_process_pattern($3, $1_git_t)

--- a/policy/modules/services/git.if
+++ b/policy/modules/services/git.if
@@ -131,6 +131,10 @@ template(`git_client_role_template',`
 	exec_files_pattern($3, git_home_hook_t, git_home_hook_t)
 	# transition back to the user domain when executing git hooks
 	domtrans_pattern($1_git_t, git_home_t, $2)
+	# execute shell scripts
+	corecmd_exec_shell($1_git_t)
+	# execute user utilities, e.g., editor
+	corecmd_bin_domtrans($1_git_t, $2)
 
 	# transition to ssh client domain when performing ssh operations
 	optional_policy(`

--- a/policy/modules/services/git.if
+++ b/policy/modules/services/git.if
@@ -127,6 +127,17 @@ template(`git_client_role_template',`
 
 	auth_use_nsswitch($1_git_t)
 
+	type $1_git_tmp_t;
+	userdom_user_tmp_file($1_git_tmp_t)
+
+	allow $2 $1_git_tmp_t:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 $1_git_tmp_t:file { exec_file_perms manage_file_perms relabel_file_perms };
+	allow $2 $1_git_tmp_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
+	allow $1_git_t $1_git_tmp_t:dir manage_dir_perms;
+	allow $1_git_t $1_git_tmp_t:file mmap_manage_file_perms;
+	allow $1_git_t $1_git_tmp_t:lnk_file manage_lnk_file_perms;
+	files_tmp_filetrans($1_git_t, $1_git_tmp_t, {dir file})
+
 	# allow userdomains to exec git hooks
 	exec_files_pattern($3, git_home_hook_t, git_home_hook_t)
 	# transition back to the user domain when executing git hooks

--- a/policy/modules/services/git.if
+++ b/policy/modules/services/git.if
@@ -45,7 +45,7 @@ template(`git_role',`
 	#
 
 	allow $2 git_user_content_t:dir { manage_dir_perms relabel_dir_perms };
-	allow $2 git_user_content_t:file { exec_file_perms manage_file_perms relabel_file_perms };
+	allow $2 git_user_content_t:file { manage_file_perms relabel_file_perms };
 	userdom_user_home_dir_filetrans($2, git_user_content_t, dir, "public_git")
 
 	allow $3 git_session_t:process { ptrace signal_perms };

--- a/policy/modules/services/git.if
+++ b/policy/modules/services/git.if
@@ -147,6 +147,15 @@ template(`git_client_role_template',`
 	# execute user utilities, e.g., editor
 	corecmd_bin_domtrans($1_git_t, $2)
 
+	optional_policy(`
+		tunable_policy(`git_client_use_gpg', `
+			gpg_domtrans($1_git_t)
+			dev_read_urand($1_git_t)
+
+			gpg_crypto_content($1_git_tmp_t)
+		')
+	')
+
 	# transition to ssh client domain when performing ssh operations
 	optional_policy(`
 		ssh_client_domtrans($1_git_t)

--- a/policy/modules/services/git.te
+++ b/policy/modules/services/git.te
@@ -96,6 +96,14 @@ gen_tunable(git_client_manage_all_user_home_content, false)
 ## </desc>
 gen_tunable(git_client_exec_user_bin, false)
 
+## <desc>
+##	<p>
+##	Determine whether Git client domains
+##	can access gpg.
+##	</p>
+## </desc>
+gen_tunable(git_client_use_gpg, false)
+
 attribute git_daemon;
 attribute_role git_session_roles;
 

--- a/policy/modules/services/git.te
+++ b/policy/modules/services/git.te
@@ -88,6 +88,14 @@ gen_tunable(git_system_use_nfs, false)
 ## </desc>
 gen_tunable(git_client_manage_all_user_home_content, false)
 
+## <desc>
+##	<p>
+##	Determine whether Git client domains
+##	can run user binaries.
+##	</p>
+## </desc>
+gen_tunable(git_client_exec_user_bin, false)
+
 attribute git_daemon;
 attribute_role git_session_roles;
 
@@ -347,4 +355,8 @@ xdg_search_config_dirs(git_client_domain)
 tunable_policy(`git_client_manage_all_user_home_content',`
 	userdom_manage_all_user_home_content(git_client_domain)
 	userdom_map_all_user_home_content_files(git_client_domain)
+')
+
+tunable_policy(`git_client_exec_user_bin',`
+	userdom_exec_user_bin_files(git_client_domain)
 ')


### PR DESCRIPTION
Using the git client domain comes with some pain points.  This series adds some tunables and defaults that make it much more functional.

I don't fully understand the various user_git_t domains, so I'm not sure if it makes sense to have user-specific temporary directories. (Though, given the ability to run user-controlled scripts, I suspect it does make sense to restrict inter-user temporary file reads).

I also had to add an interface to gpg, and I'm not sure it's idiomatic, so I suspect it may need to be adjusted to fit in with the overall project style.