### PR TITLE
incus: remove commented (future use) interfaces

### DIFF
--- a/policy/modules/services/incus.if
+++ b/policy/modules/services/incus.if
@@ -69,52 +69,6 @@ interface(`incus_run_cli',`
 
 ########################################
 ## <summary>
-##	Execute incus in the incus user domain.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed to transition.
-##	</summary>
-## </param>
-#
-#interface(`incus_domtrans_user_daemon',`
-#	gen_require(`
-#		type incusd_user_t, incusd_exec_t;
-#	')
-#
-#	corecmd_search_bin($1)
-#	domtrans_pattern($1, incusd_exec_t, incusd_user_t)
-#')
-
-########################################
-## <summary>
-##	Execute incus in the incus user
-##	domain, and allow the specified
-##	role the incus user domain.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed to transition.
-##	</summary>
-## </param>
-## <param name="role">
-##	<summary>
-##	The role to be allowed the incus domain.
-##	</summary>
-## </param>
-#
-#interface(`incus_run_user_daemon',`
-#	gen_require(`
-#		type incusd_user_t;
-#	')
-#
-#	role $2 types incusd_user_t;
-#
-#	incus_domtrans_user_daemon($1)
-#')
-
-########################################
-## <summary>
 ##	Execute incus CLI in the incus CLI
 ##	user domain.
 ## </summary>
@@ -178,76 +132,6 @@ interface(`incus_stream_connect_daemon',`
 
 	allow $1 incusd_t:unix_stream_socket { connectto rw_socket_perms };
 ')
-
-########################################
-## <summary>
-##	Role access for rootless incus.
-## </summary>
-## <param name="role_prefix">
-##	<summary>
-##	The prefix of the user role (e.g., user
-##	is the prefix for user_r).
-##	</summary>
-## </param>
-## <param name="user_domain">
-##	<summary>
-##	User domain for the role.
-##	</summary>
-## </param>
-## <param name="user_exec_domain">
-##	<summary>
-##	User exec domain for execute and transition access.
-##	</summary>
-## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
-## <rolecap/>
-#
-#template(`incus_user_role',`
-#	gen_require(`
-#		type incusd_user_t;
-#		type incusd_exec_t;
-#	')
-#
-#	role $4 types incusd_user_t;
-#
-#	incus_run_user_daemon($3, $4)
-#	incus_run_user_cli($3, $4)
-#
-#	ifdef(`init_systemd',`
-#		systemd_user_daemon_domain($1, incusd_exec_t, incusd_user_t)
-#		systemd_user_send_systemd_notify($1, incusd_user_t)
-#	')
-#
-#	optional_policy(`
-#		dbus_spec_session_bus_client($1, incusd_user_t)
-#	')
-#
-#	optional_policy(`
-#		rootlesskit_role($1, $2, $3, $4)
-#	')
-#')
-
-########################################
-## <summary>
-##	Send signals to the rootless incus daemon.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed to transition.
-##	</summary>
-## </param>
-#
-#interface(`incus_signal_user_daemon',`
-#	gen_require(`
-#		type incusd_user_t;
-#	')
-#
-#	allow $1 incusd_user_t:process signal;
-#')
 
 ########################################
 ## <summary>


### PR DESCRIPTION
This removes commented interfaces from the incus module that were there for future updates that may come to enable root-less containers with incus. May be re-added in the future when required.