### PR TITLE
files: add a default file context spec for /proc

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -142,12 +142,6 @@ HOME_ROOT/lost\+found/.*	<<none>>
 /opt/(.*/)?var/lib(64)?(/.*)?	gen_context(system_u:object_r:var_lib_t,s0)
 
 #
-# /proc
-#
-/proc			-d	<<none>>
-/proc/.*			<<none>>
-
-#
 # /run
 #
 /run			-d	gen_context(system_u:object_r:var_run_t,s0-mls_systemhigh)

--- a/policy/modules/kernel/kernel.fc
+++ b/policy/modules/kernel/kernel.fc
@@ -1,2 +1,5 @@
+/proc			-d	gen_context(system_u:object_r:proc_t,s0)
+/proc/.*			<<none>>
+
 /sys/kernel/debug	-d	gen_context(system_u:object_r:debugfs_t,s0)
 /sys/kernel/debug/.*		<<none>>


### PR DESCRIPTION
There are many situations where having a default label for /proc is helpful in early boot, generally before /proc is mounted in cases such as plymouth. Having a /proc label also doesn't really hurt here, and makes labelling more robust before the system is fully initalised.

Another example of this being useful is for mounting namespaces, such as used by systemd for auditd:

[   19.902620] audit: type=1400 audit(1663630933.439:3): avc:  denied  { mounton } for  pid=1062 comm="(auditd)" path="/run/systemd/unit-root/proc" dev="dm-3" ino=67581 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1

Closes: https://bugs.gentoo.org/871966