### PR TITLE
incus: rm explicit fcontext for /usr/libexec/incus(/.*)?

### DIFF
--- a/policy/modules/services/container.fc
+++ b/policy/modules/services/container.fc
@@ -30,7 +30,6 @@ HOME_DIR/\.docker(/.*)?		gen_context(system_u:object_r:container_conf_home_t,s0)
 
 /usr/bin/incus-.*		gen_context(system_u:object_r:container_engine_exec_t,s0)
 /usr/lib/systemd/system/incus.*	gen_context(system_u:object_r:container_engine_unit_t,s0)
-/usr/libexec/incus(/.*)?	gen_context(system_u:object_r:container_engine_exec_t,s0)
 /usr/share/lxcfs/.*		gen_context(system_u:object_r:container_engine_exec_t,s0)
 
 /usr/sbin/runc	--	gen_context(system_u:object_r:container_engine_exec_t,s0)


### PR DESCRIPTION
When creating a VM, incusd needs to read an incus-agent binary on the host to integrate it into the VM image.
If the agents delivered by incus are being stored inside /usr/libexec/incus/agents/ on the host the default file context of bin_t is sufficient whereas with container_engine_exec_t another allow rule would be required to search and read dirs and files in the agents/ sub-directory.