### PR TITLE
portage: domtrans udevadm out into udevadm_t

### DIFF
--- a/policy/modules/admin/portage.te
+++ b/policy/modules/admin/portage.te
@@ -245,6 +245,12 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# For systemd.eclass
+	# https://gitweb.gentoo.org/repo/gentoo.git/tree/eclass/systemd.eclass#n392
+	systemd_exec_systemctl(portage_t)
+')
+
+optional_policy(`
 	# For udev.eclass
 	# https://gitweb.gentoo.org/repo/gentoo.git/tree/eclass/udev.eclass#n127
 	udev_domtrans_udevadm(portage_t)

--- a/policy/modules/admin/portage.te
+++ b/policy/modules/admin/portage.te
@@ -245,6 +245,12 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# For udev.eclass
+	# https://gitweb.gentoo.org/repo/gentoo.git/tree/eclass/udev.eclass#n127
+	udev_domtrans_udevadm(portage_t)
+')
+
+optional_policy(`
 	usermanage_run_groupadd(portage_t, portage_roles)
 	usermanage_run_useradd(portage_t, portage_roles)
 ')


### PR DESCRIPTION
As udev.eclass executes udevadm[1], let's run udevadm in the udevadm_t domain as portage_t doesn't have any access to the udev control socket (and doesn't need it aside from running udevadm). As can be seen by the following AVC, comm="udevadm" when portage attempts access on a udev_t object:

type=AVC msg=audit(1657221248.009:859): avc:  denied  { connectto } for  pid=43001 comm="udevadm" path="/run/udev/control" scontext=unconfined_u:unconfined_r:portage_t tcontext=system_u:system_r:udev_t tclass=unix_stream_socket permissive=0

[1] https://gitweb.gentoo.org/repo/gentoo.git/tree/eclass/udev.eclass#n127

Closes: https://bugs.gentoo.org/856925