### PR TITLE
Promote and demote some container process perms

### DIFF
--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -321,7 +321,7 @@ corenet_port(container_port_t)
 dontaudit container_domain self:capability fsetid;
 dontaudit container_domain self:capability2 block_suspend;
 allow container_domain self:cap_userns { chown dac_override dac_read_search fowner kill setgid setuid };
-allow container_domain self:process { execmem execstack getattr getcap getpgid getsched getsession setcap setpgid setrlimit setsched signal_perms };
+allow container_domain self:process { getattr getcap getpgid getsched getsession setcap setpgid setrlimit setsched signal_perms };
 allow container_domain self:dir rw_dir_perms;
 allow container_domain self:file create_file_perms;
 allow container_domain self:fifo_file manage_fifo_file_perms;
@@ -563,6 +563,8 @@ corenet_tcp_connect_all_ports(container_net_domain)
 #
 # Container local policy
 #
+
+allow container_t self:process { execmem execstack };
 
 allow container_t container_file_t:filesystem getattr;
 
@@ -990,6 +992,8 @@ filetrans_pattern(container_engine_user_domain, container_data_home_t, container
 # KVM container local policy
 #
 
+# execmem needed for mprotect
+allow container_kvm_t self:process execmem;
 allow container_kvm_t self:capability { net_admin sys_resource };
 allow container_kvm_t self:tun_socket { relabelfrom relabelto };
 
@@ -1046,7 +1050,7 @@ domtrans_pattern(container_engine_system_domain, container_file_t, spc_t)
 domtrans_pattern(container_engine_system_domain, container_ro_file_t, spc_t)
 domtrans_pattern(container_engine_system_domain, container_var_lib_t, spc_t)
 
-allow spc_t self:process setexec;
+allow spc_t self:process { execmem execstack setexec };
 # Normally triggered when rook-ceph executes lvm tools which creates noise.
 # This can be allowed if actually needed.
 dontaudit spc_t self:process setfscreate;
@@ -1295,6 +1299,8 @@ domtrans_pattern(container_engine_user_domain, container_file_t, spc_user_t)
 domtrans_pattern(container_engine_user_domain, container_ro_file_t, spc_user_t)
 domtrans_pattern(container_engine_user_domain, container_var_lib_t, spc_user_t)
 fs_fusefs_domtrans(container_engine_user_domain, spc_user_t)
+
+allow spc_user_t self:process { execmem execstack };
 
 allow container_engine_user_domain spc_user_t:process { setsched signal_perms };
 


### PR DESCRIPTION
Promote `getpgid` and `setrlimit` to all container domains, and demote `execmem` and `execstack` to downstream container types.

The demotion of `execmem` and `execstack` allows downstream container types to opt into these permissions if needed rather than having them by default, netting some hardening gains. For now we still grant these to the generic `container_t` type since many applications require these accesses and this was the old behavior.