### PR TITLE
various: make dbus optional

### DIFF
--- a/policy/modules/admin/blueman.te
+++ b/policy/modules/admin/blueman.te
@@ -7,7 +7,9 @@ policy_module(blueman)
 
 type blueman_t;
 type blueman_exec_t;
-dbus_system_domain(blueman_t, blueman_exec_t)
+domain_type(blueman_t)
+domain_entry_file(blueman_t, blueman_exec_t)
+role system_r types blueman_t;
 
 type blueman_runtime_t alias blueman_var_run_t;
 files_runtime_file(blueman_runtime_t)
@@ -58,6 +60,10 @@ sysnet_domtrans_ifconfig(blueman_t)
 
 optional_policy(`
 	avahi_domtrans(blueman_t)
+')
+
+optional_policy(`
+	dbus_system_domain(blueman_t, blueman_exec_t)
 ')
 
 optional_policy(`

--- a/policy/modules/admin/cloudinit.te
+++ b/policy/modules/admin/cloudinit.te
@@ -83,8 +83,6 @@ corenet_tcp_bind_all_unreserved_ports(cloud_init_t)
 corenet_udp_bind_generic_node(cloud_init_t)
 corenet_udp_bind_all_unreserved_ports(cloud_init_t)
 
-dbus_system_bus_client(cloud_init_t)
-
 dev_getattr_all_blk_files(cloud_init_t)
 # /sys/devices/pci0000:00/0000:00:03.0/net/eth0/address
 dev_read_sysfs(cloud_init_t)
@@ -356,6 +354,10 @@ optional_policy(`
 
 optional_policy(`
 	dante_admin(cloud_init_t, system_r)
+')
+
+optional_policy(`
+	dbus_system_bus_client(cloud_init_t)
 ')
 
 optional_policy(`

--- a/policy/modules/apps/vmware.te
+++ b/policy/modules/apps/vmware.te
@@ -321,8 +321,6 @@ kernel_read_network_state(vmware_tools_t)
 kernel_read_system_state(vmware_tools_t)
 kernel_request_load_module(vmware_tools_t)
 
-dbus_system_bus_client(vmware_tools_t)
-
 init_read_state(vmware_tools_t)
 
 logging_send_syslog_msg(vmware_tools_t)
@@ -332,6 +330,10 @@ miscfiles_read_localization(vmware_tools_t)
 systemd_dbus_chat_logind(vmware_tools_t)
 
 udev_read_runtime_files(vmware_tools_t)
+
+optional_policy(`
+	dbus_system_bus_client(vmware_tools_t)
+')
 
 ########################################
 #

--- a/policy/modules/services/accountsd.te
+++ b/policy/modules/services/accountsd.te
@@ -11,7 +11,9 @@ gen_require(`
 
 type accountsd_t;
 type accountsd_exec_t;
-dbus_system_domain(accountsd_t, accountsd_exec_t)
+domain_type(accountsd_t)
+domain_entry_file(accountsd_t, accountsd_exec_t)
+role system_r types accountsd_t;
 
 type accountsd_var_lib_t;
 files_type(accountsd_var_lib_t)
@@ -61,6 +63,10 @@ userdom_read_user_home_content_files(accountsd_t)
 
 usermanage_domtrans_useradd(accountsd_t)
 usermanage_domtrans_passwd(accountsd_t)
+
+optional_policy(`
+	dbus_system_domain(accountsd_t, accountsd_exec_t)
+')
 
 optional_policy(`
 	policykit_dbus_chat(accountsd_t)

--- a/policy/modules/services/cockpit.te
+++ b/policy/modules/services/cockpit.te
@@ -119,13 +119,15 @@ fs_read_efivarfs_files(cockpit_ws_t)
 init_read_state(cockpit_ws_t)
 init_stream_connect(cockpit_ws_t)
 
-dbus_system_bus_client(cockpit_ws_t)
-
 logging_send_syslog_msg(cockpit_ws_t)
 
 miscfiles_read_localization(cockpit_ws_t)
 
 sysnet_exec_ifconfig(cockpit_ws_t)
+
+optional_policy(`
+	dbus_system_bus_client(cockpit_ws_t)
+')
 
 optional_policy(`
 	hostname_exec(cockpit_ws_t)
@@ -185,8 +187,6 @@ kernel_read_network_state(cockpit_session_t)
 
 selinux_use_status_page(cockpit_session_t)
 
-dbus_system_bus_client(cockpit_session_t)
-
 # cockpit-session runs a full pam stack, including pam_selinux.so
 auth_login_pgm_domain(cockpit_session_t)
 # cockpit-session resseting expired passwords
@@ -201,6 +201,10 @@ miscfiles_read_localization(cockpit_session_t)
 
 # cockpit-session can execute cockpit-agent as the user
 userdom_spec_domtrans_all_users(cockpit_session_t)
+
+optional_policy(`
+	dbus_system_bus_client(cockpit_session_t)
+')
 
 optional_policy(`
 	systemd_dbus_chat_logind(cockpit_session_t)

--- a/policy/modules/services/colord.te
+++ b/policy/modules/services/colord.te
@@ -7,7 +7,9 @@ policy_module(colord)
 
 type colord_t;
 type colord_exec_t;
-dbus_system_domain(colord_t, colord_exec_t)
+domain_type(colord_t)
+domain_entry_file(colord_t, colord_exec_t)
+role system_r types colord_t;
 
 type colord_tmp_t;
 files_tmp_file(colord_tmp_t)
@@ -119,6 +121,10 @@ optional_policy(`
 	cups_read_state(colord_t)
 	cups_stream_connect(colord_t)
 	cups_dbus_chat(colord_t)
+')
+
+optional_policy(`
+	dbus_system_domain(colord_t, colord_exec_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/devicekit.te
+++ b/policy/modules/services/devicekit.te
@@ -7,15 +7,21 @@ policy_module(devicekit)
 
 type devicekit_t;
 type devicekit_exec_t;
-dbus_system_domain(devicekit_t, devicekit_exec_t)
+domain_type(devicekit_t)
+domain_entry_file(devicekit_t, devicekit_exec_t)
+role system_r types devicekit_t;
 
 type devicekit_power_t;
 type devicekit_power_exec_t;
-dbus_system_domain(devicekit_power_t, devicekit_power_exec_t)
+domain_type(devicekit_power_t)
+domain_entry_file(devicekit_power_t, devicekit_power_exec_t)
+role system_r types devicekit_power_t;
 
 type devicekit_disk_t;
 type devicekit_disk_exec_t;
-dbus_system_domain(devicekit_disk_t, devicekit_disk_exec_t)
+domain_type(devicekit_disk_t)
+domain_entry_file(devicekit_disk_t, devicekit_disk_exec_t)
+role system_r types devicekit_disk_t;
 
 type devicekit_runtime_t alias devicekit_var_run_t;
 files_runtime_file(devicekit_runtime_t)
@@ -51,6 +57,7 @@ files_read_etc_files(devicekit_t)
 miscfiles_read_localization(devicekit_t)
 
 optional_policy(`
+	dbus_system_domain(devicekit_t, devicekit_exec_t)
 	dbus_system_bus_client(devicekit_t)
 
 	devicekit_dbus_chat_disk(devicekit_t)
@@ -154,6 +161,7 @@ userdom_read_all_users_state(devicekit_disk_t)
 userdom_search_user_home_dirs(devicekit_disk_t)
 
 optional_policy(`
+	dbus_system_domain(devicekit_disk_t, devicekit_disk_exec_t)
 	dbus_system_bus_client(devicekit_disk_t)
 
 	optional_policy(`
@@ -291,6 +299,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	dbus_system_domain(devicekit_power_t, devicekit_power_exec_t)
 	dbus_system_bus_client(devicekit_power_t)
 	init_dbus_chat(devicekit_power_t)
 

--- a/policy/modules/services/eg25manager.te
+++ b/policy/modules/services/eg25manager.te
@@ -49,8 +49,6 @@ dev_rw_gpiochip(eg25manager_t)
 
 corenet_tcp_connect_http_port(eg25manager_t)
 
-dbus_system_bus_client(eg25manager_t)
-
 files_read_etc_files(eg25manager_t)
 files_read_etc_symlinks(eg25manager_t)
 files_read_usr_files(eg25manager_t)
@@ -71,6 +69,10 @@ systemd_use_logind_fds(eg25manager_t)
 systemd_write_inherited_logind_inhibit_pipes(eg25manager_t)
 
 term_use_unallocated_ttys(eg25manager_t)
+
+optional_policy(`
+	dbus_system_bus_client(eg25manager_t)
+')
 
 optional_policy(`
 	modemmanager_dbus_chat(eg25manager_t)

--- a/policy/modules/services/geoclue.te
+++ b/policy/modules/services/geoclue.te
@@ -7,7 +7,9 @@ policy_module(geoclue)
 
 type geoclue_t;
 type geoclue_exec_t;
-dbus_system_domain(geoclue_t, geoclue_exec_t)
+domain_type(geoclue_t)
+domain_entry_file(geoclue_t, geoclue_exec_t)
+role system_r types geoclue_t;
 
 type geoclue_etc_t;
 files_config_file(geoclue_etc_t)
@@ -48,6 +50,10 @@ miscfiles_read_localization(geoclue_t)
 
 optional_policy(`
 	avahi_dbus_chat(geoclue_t)
+')
+
+optional_policy(`
+	dbus_system_domain(geoclue_t, geoclue_exec_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/iiosensorproxy.te
+++ b/policy/modules/services/iiosensorproxy.te
@@ -52,14 +52,16 @@ dev_read_sysfs(iiosensorproxy_t)
 # /sys/devices/pci0000:00/0000:00:13.0/{33AECD58-B679-4E54-9BD9-A04D34F0C226}/001F:8087:0AC2.0005/HID-SENSOR-200083.21.auto/iio:device8/buffer/enable
 dev_write_sysfs(iiosensorproxy_t)
 
-dbus_system_bus_client(iiosensorproxy_t)
-dbus_connect_system_bus(iiosensorproxy_t)
-
 logging_send_syslog_msg(iiosensorproxy_t)
 
 miscfiles_read_localization(iiosensorproxy_t)
 
 udev_read_runtime_files(iiosensorproxy_t)
+
+optional_policy(`
+	dbus_system_bus_client(iiosensorproxy_t)
+	dbus_connect_system_bus(iiosensorproxy_t)
+')
 
 optional_policy(`
 	policykit_dbus_chat(iiosensorproxy_t)

--- a/policy/modules/services/kubernetes.te
+++ b/policy/modules/services/kubernetes.te
@@ -362,9 +362,6 @@ seutil_read_default_contexts(kubelet_t)
 userdom_dontaudit_search_user_runtime_root(kubelet_t)
 userdom_use_user_terminals(kubelet_t)
 
-dbus_list_system_bus_runtime(kubelet_t)
-dbus_system_bus_client(kubelet_t)
-
 container_read_config(kubelet_t)
 container_getattr_device_blk_files(kubelet_t)
 container_getattr_fs(kubelet_t)
@@ -468,6 +465,11 @@ optional_policy(`
 
 optional_policy(`
 	crio_read_conmon_state(kubelet_t)
+')
+
+optional_policy(`
+	dbus_list_system_bus_runtime(kubelet_t)
+	dbus_system_bus_client(kubelet_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/lowmemorymonitor.te
+++ b/policy/modules/services/lowmemorymonitor.te
@@ -25,11 +25,13 @@ kernel_read_system_state(low_mem_mon_t)
 # /etc/localtime
 files_read_etc_symlinks(low_mem_mon_t)
 
-dbus_list_system_bus_runtime(low_mem_mon_t)
-dbus_system_bus_client(low_mem_mon_t)
-dbus_connect_system_bus(low_mem_mon_t)
-
 miscfiles_read_localization(low_mem_mon_t)
+
+optional_policy(`
+	dbus_list_system_bus_runtime(low_mem_mon_t)
+	dbus_system_bus_client(low_mem_mon_t)
+	dbus_connect_system_bus(low_mem_mon_t)
+')
 
 optional_policy(`
 	unconfined_dbus_send(low_mem_mon_t)

--- a/policy/modules/services/powerprofiles.te
+++ b/policy/modules/services/powerprofiles.te
@@ -27,10 +27,6 @@ dev_create_sysfs_files(power_profilesd_t)
 dev_read_sysfs(power_profilesd_t)
 dev_write_sysfs(power_profilesd_t)
 
-dbus_list_system_bus_runtime(power_profilesd_t)
-dbus_system_bus_client(power_profilesd_t)
-dbus_connect_system_bus(power_profilesd_t)
-
 files_read_etc_files(power_profilesd_t)
 files_search_var_lib(power_profilesd_t)
 
@@ -45,6 +41,12 @@ udev_search_runtime(power_profilesd_t)
 
 ifdef(`init_systemd',`
 	init_stream_connect(power_profilesd_t)
+')
+
+optional_policy(`
+	dbus_list_system_bus_runtime(power_profilesd_t)
+	dbus_system_bus_client(power_profilesd_t)
+	dbus_connect_system_bus(power_profilesd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/switcheroo.te
+++ b/policy/modules/services/switcheroo.te
@@ -22,13 +22,15 @@ kernel_read_system_state(switcheroo_t)
 
 dev_read_sysfs(switcheroo_t)
 
-dbus_list_system_bus_runtime(switcheroo_t)
-dbus_system_bus_client(switcheroo_t)
-dbus_connect_system_bus(switcheroo_t)
-
 miscfiles_read_localization(switcheroo_t)
 
 udev_search_runtime(switcheroo_t)
+
+optional_policy(`
+	dbus_list_system_bus_runtime(switcheroo_t)
+	dbus_system_bus_client(switcheroo_t)
+	dbus_connect_system_bus(switcheroo_t)
+')
 
 optional_policy(`
 	unconfined_dbus_send(switcheroo_t)


### PR DESCRIPTION
There's a few modules where `dbus_()` interfaces are used outside of an optional which causes policy build failures on systems without it. `kubernetes` and `cloud-init` are two such modules that don't actually strictly require it.

Let's go ahead and just blanket make `dbus` optional everywhere.