### PR TITLE
container: allow spc to use sys_admin in userns

### DIFF
--- a/policy/modules/services/container.te
+++ b/policy/modules/services/container.te
@@ -1165,8 +1165,9 @@ allow spc_t self:process { getcap setexec setrlimit };
 dontaudit spc_t self:process setfscreate;
 allow spc_t self:capability { audit_write chown dac_override dac_read_search fowner fsetid ipc_lock kill mknod net_admin net_raw setgid setpcap setuid sys_admin sys_chroot sys_nice sys_ptrace sys_rawio sys_resource };
 allow spc_t self:capability2 { bpf perfmon };
-# needed by cilium-agent
-allow spc_t self:cap_userns sys_admin;
+# sys_admin in userns needed by cilium-agent
+allow spc_t self:cap_userns { audit_write chown dac_override dac_read_search fowner fsetid ipc_lock kill mknod net_admin net_raw setgid setpcap setuid sys_admin sys_chroot sys_nice sys_ptrace sys_rawio sys_resource };
+allow spc_t self:cap2_userns { bpf perfmon };
 
 # for qemu
 domain_mmap_low(spc_t)


### PR DESCRIPTION
`cilium-agent` requires this to update MTUs in other containers' network namespaces:

```
time->Wed Jul 16 20:11:32 2025
type=PROCTITLE msg=audit(1752711092.501:1166063): proctitle=63696C69756D2D6167656E74002D2D636F6E6669672D6469723D2F746D702F63696C69756D2F636F6E6669672D6D6170 type=SYSCALL msg=audit(1752711092.501:1166063): arch=c000003e syscall=308 success=no exit=-1 a0=a1 a1=40000000 a2=0 a3=0 items=0 ppid=3533962 pid=3533964 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="cilium-agent" exe="/usr/bin/cilium-agent" subj=system_u:system_r:spc_t:s0 key=(null) type=AVC msg=audit(1752711092.501:1166063): avc:  denied  { sys_admin } for  pid=3533964 comm="cilium-agent" capability=21  scontext=system_u:system_r:spc_t:s0 tcontext=system_u:system_r:spc_t:s0 tclass=cap_userns permissive=0
```
```
cilium-agent time=2025-07-17T00:17:35Z level=error msg="error while updating MTU for endpoint" module=agent.datapath.mtu netns=2d87d85a-d417-4bb7-9aa6-c5ef9c925ce3 error="set netns: operation not permitted (terminating OS thread)"
```