### PR TITLE
Include read permission in rw_dirs_pattern

### DIFF
--- a/policy/support/file_patterns.spt
+++ b/policy/support/file_patterns.spt
@@ -38,7 +38,7 @@ define(`del_entry_dirs_pattern',`
 
 define(`rw_dirs_pattern',`
 	allow $1 $2:dir search_dir_perms;
-	allow $1 $3:dir { add_entry_dir_perms del_entry_dir_perms };
+	allow $1 $3:dir { rw_dir_perms };
 ')
 
 define(`create_dirs_pattern',`


### PR DESCRIPTION
The previous set of permissions only included write related accesses, despite the pattern name.