### PR TITLE
systemd: allow users to run systemd-cgtop

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -26,7 +26,7 @@ template(`systemd_role_template',`
 		class system { disable enable reload start status stop };
 		attribute systemd_user_session_type, systemd_log_parse_env_type;
 		attribute systemd_user_activated_sock_file_type, systemd_user_unix_stream_activated_socket_type;
-		type systemd_analyze_exec_t;
+		type systemd_analyze_exec_t, systemd_cgtop_exec_t;
 		type systemd_conf_home_t, systemd_data_home_t;
 		type systemd_tmpfiles_exec_t;
 		type systemd_user_runtime_t, systemd_user_runtime_notify_t;
@@ -197,6 +197,7 @@ template(`systemd_role_template',`
 	allow $3 systemd_conf_home_t:service { reload start status stop };
 
 	can_exec($3, systemd_analyze_exec_t)
+	can_exec($3, systemd_cgtop_exec_t)
 
 	init_dbus_chat($3)
 	init_search_var_lib_dirs($3)


### PR DESCRIPTION
Allow users with systemd role access to run `systemd-cgtop`. Unprivileged users with this access can monitor resource usage of their own user slices and more privileged users can view cgroups on the system.