### PR TITLE
check_fc_files.py: Add additional optional pattern reduction.

### DIFF
--- a/testing/check_fc_files.py
+++ b/testing/check_fc_files.py
@@ -265,6 +265,7 @@ def analyze_fc_file(fc_path):
             reduced_path = re.sub(r'\[[-0-9A-Za-z_.^]+\][?*]', '', reduced_path)
             reduced_path = re.sub(r'\[[-0-9A-Za-z_.^]+\](\+)?', '∞', reduced_path)
             reduced_path = reduced_path.replace('/[^/]+/', '/∞/')
+            reduced_path = re.sub(r'\([·∞†δ]{2,4}\)\?', '', reduced_path)
 
             if '.' in reduced_path:
                 print(f"{prefix}unescaped dot still present {path} after being reduced to {reduced_path} (suggestion: use \\. to match a dot, or a charset like [^/])")  # noqa


### PR DESCRIPTION
Fixes patterns such as:

```
/home/runner/work/refpolicy/refpolicy/policy/modules/services/dnsmasq.fc:16: unexpected symbols ( ) ? in /var/lib/misc/dnsmasq\.([a-z0-9]+\.)?leases after being reduced to /var/lib/misc/dnsmasq·(∞·)?leases. This could be due to an error in the pattern or a missing reduction rule in the checker
```