### PR TITLE
support/Makefile: don't remake *.fc and *.if files

### DIFF
--- a/support/Makefile.devel
+++ b/support/Makefile.devel
@@ -187,10 +187,10 @@ tmp/all_interfaces.conf: $(m4support) $(header_interfaces) $(detected_ifs)
 
 # so users dont have to make empty .fc and .if files
 $(detected_fcs):
-	@touch $@
+	@test -f $@ || touch $@
 
 $(detected_ifs):
-	@echo "## <summary>$(basename $(@D))</summary>" > $@
+	@test -f $@ || echo "## <summary>$(basename $(@D))</summary>" > $@
 
 ########################################
 #


### PR DESCRIPTION
The Makefile.devel contains a rule that automatically creates *.if files for existing *.pp files.
This rule have no prereqs so they are normally considered up to date and therefore don't overwrite existing definitions. If however, make is invoked with -B/--always-make, all targets are remade, which will overwrite exiting *.if files.

There is a similar rule for *.fc files that only touches the file, for consistency the same check is added there.

Alternatives:
- The rules could be removed entirely. This would be a change of the intended behavior.
- The check for the *.fc rule could be dropped. The rule would only change the file timestamps. It however avoids modifications to a file that is not normally considered "generated" and will prevent similar issues should the rule be changed in the future.