### PR TITLE
cloudinit: Add sys_admin to set security.sehash.

### DIFF
--- a/policy/modules/admin/cloudinit.te
+++ b/policy/modules/admin/cloudinit.te
@@ -45,8 +45,9 @@ files_tmp_file(cloud_init_tmp_t)
 # Local policy
 #
 
-allow cloud_init_t self:capability { chown dac_override dac_read_search fowner fsetid setgid setuid };
-dontaudit cloud_init_t self:capability { net_admin sys_admin sys_tty_config };
+# sys_admin: Set security.sehash
+allow cloud_init_t self:capability { chown dac_override dac_read_search fowner fsetid setgid setuid sys_admin };
+dontaudit cloud_init_t self:capability { net_admin sys_tty_config };
 allow cloud_init_t self:fifo_file rw_fifo_file_perms;
 allow cloud_init_t self:unix_dgram_socket create_socket_perms;
 allow cloud_init_t self:passwd passwd;

--- a/testing/sechecker.ini
+++ b/testing/sechecker.ini
@@ -86,6 +86,7 @@ exempt_source = acpi_t
                 cgmanager_t         # Container cgroup manager
                 cgred_t             # Move processes to cgroups based on configurable rules
                 chromium_sandbox_t
+                cloud_init_t        # Set security.sehash from restorecon() calls.
                 cockpit_session_t
                 container_engine_t
                 consoletype_t


### PR DESCRIPTION
Fixes errors like:
```
Aug 21 14:10:16 linux cloud-init[764]: setxattr failed: /var/lib/cloud: Operation not permitted
Aug 21 14:10:16 linux cloud-init[764]: setxattr failed: /var/lib/cloud/data: Operation not permitted
Aug 21 14:10:16 linux cloud-init[777]: setxattr failed: /var/lib/cloud: Operation not permitted
Aug 21 14:10:16 linux cloud-init[777]: setxattr failed: /var/lib/cloud/data: Operation not permitted
Aug 21 14:10:16 linux cloud-init[777]: setxattr failed: /var/lib/cloud/scripts: Operation not permitted
Aug 21 14:10:16 linux cloud-init[777]: setxattr failed: /var/lib/cloud/scripts: Operation not permitted
```