### PR TITLE
build: drop obsolete setfiles option

### DIFF
--- a/Rules.modular
+++ b/Rules.modular
@@ -225,7 +225,7 @@ validate: $(base_pkg) $(mod_pkgs) $(tmpdir)/all_mods.fc $(builtappfiles)
 	$(verbose) $(SEMOD_LNK) -o $(tmpdir)/test.lnk $(base_pkg) $(mod_pkgs)
 	$(verbose) $(SEMOD_EXP) $(tmpdir)/test.lnk $(tmpdir)/policy.bin
 	@echo "Validating $(NAME) file contexts."
-	$(verbose) $(SETFILES) -q -c $(tmpdir)/policy.bin $(tmpdir)/all_mods.fc
+	$(verbose) $(SETFILES) -c $(tmpdir)/policy.bin $(tmpdir)/all_mods.fc
 	@echo "Validating $(NAME) appconfig."
 	$(verbose) $(validateappconfig) $(builtappconf) $(tmpdir)/policy.bin
 	@echo "Success."

--- a/Rules.monolithic
+++ b/Rules.monolithic
@@ -228,7 +228,7 @@ $(homedir_template): $(fc)
 #
 $(fcpath): $(fc) $(loadpath) $(userpath)/system.users
 	@echo "Validating $(NAME) file_contexts."
-	$(verbose) $(SETFILES) -q -c $(loadpath) $(fc)
+	$(verbose) $(SETFILES) -c $(loadpath) $(fc)
 	@echo "Installing file_contexts."
 	@$(INSTALL) -d -m 0755 $(@D)
 	$(verbose) $(INSTALL) -m 0644 $(fc) $(fcpath)
@@ -247,7 +247,7 @@ $(fcpath): $(fc) $(loadpath) $(userpath)/system.users
 #
 validate: $(fc) $(polver) $(builtappfiles)
 	@echo "Validating $(NAME) file_contexts."
-	$(verbose) $(SETFILES) -q -c $(polver) $(fc)
+	$(verbose) $(SETFILES) -c $(polver) $(fc)
 	@echo "Validating $(NAME) appconfig."
 	$(verbose) $(validateappconfig) $(builtappconf) $(polver)
 	@echo "Success."


### PR DESCRIPTION
The option -q has no effect anymore, see
https://github.com/SELinuxProject/selinux/blob/3.7/policycoreutils/setfiles/setfiles.c#L312-L316