### PR TITLE
policy_capabilities: add netif_wildcard and genfs_seclabel_wildcard

### DIFF
--- a/policy/policy_capabilities
+++ b/policy/policy_capabilities
@@ -138,3 +138,17 @@ policycap nnp_nosuid_transition;
 # netlink_xfrm_socket: nlmsg_read nlmsg_write
 # netlink_audit_socket: nlmsg_read nlmsg_write nlmsg_relay nlmsg_readpriv nlmsg_tty_audit
 #policycap netlink_xperm;
+
+# Enable wildcard matching for network interface names.
+# Requires libsepol 3.9+ and kernel 6.15+.
+#
+# Added checks:
+# (none)
+#policycap netif_wildcard;
+
+# Enable wildcard matching for genfscon paths.
+# Requires libsepol 3.9+ and kernel 6.16+.
+#
+# Added checks:
+# (none)
+#policycap genfs_seclabel_wildcard;


### PR DESCRIPTION
Add definition for the policy capability netif_wildcard, which controls the support for wildcard matching of network interface names.

Add definition for the policy capability genfs_seclabel_wildcard, which controls the support for wildcard matching of genfscon paths.