### PR TITLE
logging: update rules for audit

### DIFF
--- a/policy/modules/system/logging.fc
+++ b/policy/modules/system/logging.fc
@@ -72,6 +72,7 @@ ifdef(`distro_gentoo',`
 /var/empty/dev/log	-s	gen_context(system_u:object_r:devlog_t,s0)
 ')
 
+/run/audit(/.*)?		gen_context(system_u:object_r:auditd_runtime_t,mls_systemhigh)
 /run/audit_events	-s	gen_context(system_u:object_r:auditd_runtime_t,mls_systemhigh)
 /run/audispd_events	-s	gen_context(system_u:object_r:audisp_runtime_t,mls_systemhigh)
 /run/auditd\.pid	--	gen_context(system_u:object_r:auditd_runtime_t,mls_systemhigh)

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -115,6 +115,9 @@ allow auditctl_t self:capability { dac_override dac_read_search fsetid };
 allow auditctl_t self:process getcap;
 allow auditctl_t self:netlink_audit_socket nlmsg_readpriv;
 
+allow auditctl_t auditd_log_t:dir list_dir_perms;
+allow auditctl_t auditd_log_t:file read_file_perms;
+
 read_files_pattern(auditctl_t, auditd_etc_t, auditd_etc_t)
 allow auditctl_t auditd_etc_t:dir list_dir_perms;
 dontaudit auditctl_t auditd_etc_t:file map;
@@ -179,9 +182,10 @@ allow auditd_t auditd_log_t:file { append_file_perms create_file_perms link read
 manage_lnk_files_pattern(auditd_t, auditd_log_t, auditd_log_t)
 allow auditd_t var_log_t:dir search_dir_perms;
 
+manage_dirs_pattern(auditd_t, auditd_runtime_t, auditd_runtime_t)
 manage_files_pattern(auditd_t, auditd_runtime_t, auditd_runtime_t)
 manage_sock_files_pattern(auditd_t, auditd_runtime_t, auditd_runtime_t)
-files_runtime_filetrans(auditd_t, auditd_runtime_t, { file sock_file })
+files_runtime_filetrans(auditd_t, auditd_runtime_t, { dir file sock_file })
 
 # Needs to be able to getattr on the audisp-remote binary to verify
 # the plugin configuration.


### PR DESCRIPTION
Update rules for audit 4.1.2:
Allow auditd to create /run/audit/ directory
Allow auditctl to read /var/log/audit/audit.log

Fix:
avc:  denied  { create } for  pid=497 comm="auditd" name="audit" scontext=system_u:system_r:auditd_t:s15:c0.c1023
tcontext=system_u:object_r:var_run_t:s15:c0.c1023 tclass=dir permissive=0

avc:  denied  { read } for  pid=314 comm="auditctl" name="audit.log" dev="tmpfs" ino=9 scontext=system_u:system_r:auditctl_t:s0-s15:c0.c1023 tcontext=system_u:object_r:auditd_log_t:s15:c0.c1023 tclass=file permissive=0

avc:  denied  { open } for  pid=314 comm="auditctl" path="/var/log/audit/audit.log" dev="tmpfs" ino=9
scontext=system_u:system_r:auditctl_t:s0-s15:c0.c1023 tcontext=system_u:object_r:auditd_log_t:s15:c0.c1023 tclass=file permissive=0