### PR TITLE
fix: when using timedatectl to set system time

### DIFF
--- a/policy/modules/services/ntp.te
+++ b/policy/modules/services/ntp.te
@@ -179,6 +179,10 @@ ifdef(`init_systemd',`
 	')
 
 	optional_policy(`
+		policykit_dbus_chat(ntpd_t)
+	')
+
+	optional_policy(`
 		unconfined_dbus_send(ntpd_t)
 	')
 ')


### PR DESCRIPTION
Using timedatectl to set system time, seeing this denial

node=localhost type=USER_AVC msg=audit(1758319110.911:214791): pid=1156 uid=81 auid+4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0 msg='avc:  denied { send_msg } for scontext=system_u:system_r:ntpd_t:s0 tcontext=system_u:system_r:policykit_t:s0 tclass=dbus permissive=1 exe="/usr/bin/dbus-broker" sauid=81 hostname=? addr=?  terminal=?'UID="dbus" AUID="unset" SAUID="dbus"