### PR TITLE
busybox

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -173,6 +173,7 @@ ifdef(`distro_gentoo',`
 /usr/bin/tcsh			--	gen_context(system_u:object_r:shell_exec_t,s0)
 /usr/bin/yash			--	gen_context(system_u:object_r:shell_exec_t,s0)
 /usr/bin/zsh.*			--	gen_context(system_u:object_r:shell_exec_t,s0)
+/usr/bin/busybox(\.nosuid|\.suid)?	--	gen_context(system_u:object_r:shell_exec_t,s0)
 
 /usr/lib/(.*/)?bin(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/(.*/)?glib-2\.0(/.*)?		gen_context(system_u:object_r:bin_t,s0)


### PR DESCRIPTION
In minimal systems, /bin/sh is often a symlink to busybox.
SELinux expects /bin/sh to be labeled shell_exec_t, so busybox bins
can be labeled with shell_exec_t.

Reference:
https://git.yoctoproject.org/poky/tree/meta/recipes-core/busybox/busybox.inc#n251

Denials:
[   12.593748] audit: type=1400 audit(15.527:68): avc:  denied  { map } for  pid=1477 comm="klogd" path="/usr/bin/busybox.nosuid"
dev="sda2" ino=359 scontext=system_u:system_r:klogd_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1
[   12.627879] audit: type=1400 audit(15.527:68): avc:  denied  { read execute } for  pid=1477 comm="klogd" path="/usr/bin/busybox.nosuid"
 dev="sda2" ino=359 scontext=system_u:system_r:klogd_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1
[   12.627894] audit: type=1400 audit(15.539:69): avc:  denied  { map } for  pid=1480 comm="syslogd" path="/usr/bin/busybox.nosuid"
 dev="sda2" ino=359 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1
[   12.627897] audit: type=1400 audit(15.539:69): avc:  denied  { read execute } for  pid=1480 comm="syslogd"
path="/usr/bin/busybox.nosuid" dev="sda2" ino=359 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1

labelling busybox bins as shell_exec_t, ensuring compatibility with
refpolicy expectations and avoiding SELinux denials.