### PR TITLE
portage: grant compile domains getattr on chr_files in /dev

### DIFF
--- a/policy/modules/admin/portage.if
+++ b/policy/modules/admin/portage.if
@@ -149,6 +149,9 @@ interface(`portage_compile_domain',`
 	dev_read_rand($1)
 	dev_read_urand($1)
 
+	# some packages test for nodes in /dev
+	dev_getattr_all_chr_files($1)
+
 	domain_use_interactive_fds($1)
 	domain_dontaudit_read_all_domains_state($1)
 	# SELinux-aware installs doing relabels in the sandbox


### PR DESCRIPTION
Some ebuilds, such as app-emulation/qemu, attempt to check for the existence of various character devices in /dev:

avc:  denied  { getattr } for  pid=6062 comm="meson" path="/dev/kvm" dev="devtmpfs" ino=80 scontext=superuser:sysadm_r:portage_sandbox_t tcontext=system_u:object_r:kvm_device_t tclass=chr_file permissive=0