### PR TITLE
kernel: remove some unused initial SID contexts

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -215,23 +215,12 @@ sid file gen_context(system_u:object_r:unlabeled_t,s0)
 sid unlabeled gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 neverallow * unlabeled_t:file entrypoint;
 
-# These initial sids are no longer used, and can be removed:
+# Default socket label if no kernel sock is available
 sid any_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
-sid file_labels		gen_context(system_u:object_r:unlabeled_t,s0)
-sid icmp_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
-sid igmp_packet		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
+
+# Label for userspace tasks surviving from early boot if
+# userspace_initial_context policycap is defined.
 sid init		gen_context(system_u:object_r:unlabeled_t,s0)
-sid kmod		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
-sid policy		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
-sid scmp_packet		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
-sid sysctl_modprobe 	gen_context(system_u:object_r:unlabeled_t,s0)
-sid sysctl_fs		gen_context(system_u:object_r:unlabeled_t,s0)
-sid sysctl_kernel	gen_context(system_u:object_r:unlabeled_t,s0)
-sid sysctl_net		gen_context(system_u:object_r:unlabeled_t,s0)
-sid sysctl_net_unix	gen_context(system_u:object_r:unlabeled_t,s0)
-sid sysctl_vm		gen_context(system_u:object_r:unlabeled_t,s0)
-sid sysctl_dev		gen_context(system_u:object_r:unlabeled_t,s0)
-sid tcp_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 
 ########################################
 #


### PR DESCRIPTION
Remove some unused initial SID contexts that can be safely removed without compatibility issues. This does not remove any initial SID declarations, only the corresponding initial SID context assignment.

Linux kernel commit e3e0b582c321ae ("selinux: remove unused initial SIDs and improve handling"), merged in Linux v5.7, removed unused initial SIDs from the kernel and improved the handling to support safely reclaiming and reusing of many of the initial SIDs without compatibility issues as well as enabling future addition of new initial SIDs.

SELinux userspace commit 8677ce5e8f5929 ("libsepol,checkpolicy: support omitting unused initial sid contexts"), merged in userspace release 3.1 (20200710), supported omitting unused initial SID contexts from the kernel binary policy. Previously this was treated as an error at policy compilation/linking time.

Since refpolicy already specifies a minimum SELinux userspace of 3.2, we can finally remove the unused initial SID contexts from the refpolicy kernel module. This does not depend on the kernel commit; it will work with kernels before and after that commit.

This change retains the initial SID contexts for the init SID and the any_socket SID. Kernel use of the init SID was restored by Linux kernel commit ae254858ce0745 ("selinux: introduce an initial SID for early boot processes") although this is transparently remapped to the kernel SID context unless the "userspace_initial_context" policy capability is enabled. Since this policy capability is not currently enabled by default in refpolicy, we leave the init SID with the unlabeled context for now but it should be assigned some other context if this policy capability is ever enabled. Kernel use of the any_socket SID was reintroduced by Linux kernel commit d28d1e080132f28 ("[LSM-IPSec]: Per-packet access control.") to provide a default socket label for use in checks when no socket is available.

This change also retains the initial SID contexts for the fs and sysctl initial SIDs for backward compatibility until such a time as refpolicy increases its minimum supported kernel version to one that includes the aforementioned Linux kernel commit.