### PR TITLE
Revert "kernel: remove some unused initial SID contexts"

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -215,12 +215,23 @@ sid file gen_context(system_u:object_r:unlabeled_t,s0)
 sid unlabeled gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 neverallow * unlabeled_t:file entrypoint;
 
-# Default socket label if no kernel sock is available
+# These initial sids are no longer used, and can be removed:
 sid any_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
-
-# Label for userspace tasks surviving from early boot if
-# userspace_initial_context policycap is defined.
+sid file_labels		gen_context(system_u:object_r:unlabeled_t,s0)
+sid icmp_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
+sid igmp_packet		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 sid init		gen_context(system_u:object_r:unlabeled_t,s0)
+sid kmod		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
+sid policy		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
+sid scmp_packet		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
+sid sysctl_modprobe 	gen_context(system_u:object_r:unlabeled_t,s0)
+sid sysctl_fs		gen_context(system_u:object_r:unlabeled_t,s0)
+sid sysctl_kernel	gen_context(system_u:object_r:unlabeled_t,s0)
+sid sysctl_net		gen_context(system_u:object_r:unlabeled_t,s0)
+sid sysctl_net_unix	gen_context(system_u:object_r:unlabeled_t,s0)
+sid sysctl_vm		gen_context(system_u:object_r:unlabeled_t,s0)
+sid sysctl_dev		gen_context(system_u:object_r:unlabeled_t,s0)
+sid tcp_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 
 ########################################
 #


### PR DESCRIPTION
Reverts SELinuxProject/refpolicy#1035

Fixes #1036