### PR TITLE
chromium: drop the chromium_render_t domain

### DIFF
--- a/policy/modules/apps/chromium.if
+++ b/policy/modules/apps/chromium.if
@@ -29,14 +29,12 @@
 template(`chromium_role',`
 	gen_require(`
 		type chromium_t;
-		type chromium_renderer_t;
 		type chromium_sandbox_t;
 		type chromium_naclhelper_t;
 		class dbus send_msg;
 	')
 
 	role $4 types chromium_t;
-	role $4 types chromium_renderer_t;
 	role $4 types chromium_sandbox_t;
 	role $4 types chromium_naclhelper_t;
 
@@ -45,10 +43,8 @@ template(`chromium_role',`
 
 	# Allow ps to show chromium processes and allow the user to signal it
 	ps_process_pattern($3, chromium_t)
-	ps_process_pattern($3, chromium_renderer_t)
 
 	allow $3 chromium_t:process signal_perms;
-	allow $3 chromium_renderer_t:process signal_perms;
 	allow $3 chromium_sandbox_t:process signal_perms;
 	allow $3 chromium_naclhelper_t:process signal_perms;
 	allow chromium_t $3:process { signal signull };

--- a/policy/modules/apps/chromium.te
+++ b/policy/modules/apps/chromium.te
@@ -77,9 +77,6 @@ type chromium_sandbox_t;
 type chromium_sandbox_exec_t;
 application_domain(chromium_sandbox_t, chromium_sandbox_exec_t)
 
-type chromium_renderer_t;
-domain_base_type(chromium_renderer_t)
-
 type chromium_tmp_t;
 userdom_user_tmp_file(chromium_tmp_t)
 
@@ -116,14 +113,6 @@ allow chromium_t self:cap_userns { sys_admin sys_chroot sys_ptrace };
 
 allow chromium_t chromium_exec_t:file execute_no_trans;
 
-allow chromium_t chromium_renderer_t:dir list_dir_perms;
-allow chromium_t chromium_renderer_t:file rw_file_perms;
-allow chromium_t chromium_renderer_t:fd use;
-allow chromium_t chromium_renderer_t:process signal_perms;
-allow chromium_t chromium_renderer_t:shm rw_shm_perms;
-allow chromium_t chromium_renderer_t:unix_dgram_socket { read write };
-allow chromium_t chromium_renderer_t:unix_stream_socket { read write };
-
 allow chromium_t chromium_sandbox_t:unix_dgram_socket { getattr read write };
 allow chromium_t chromium_sandbox_t:unix_stream_socket { getattr read write };
 allow chromium_t chromium_sandbox_t:file read_file_perms;
@@ -145,7 +134,6 @@ userdom_user_runtime_filetrans(chromium_t, chromium_tmp_t, { file sock_file })
 manage_files_pattern(chromium_t, chromium_tmpfs_t, chromium_tmpfs_t)
 allow chromium_t chromium_tmpfs_t:file map;
 fs_tmpfs_filetrans(chromium_t, chromium_tmpfs_t, file)
-fs_tmpfs_filetrans(chromium_renderer_t, chromium_tmpfs_t, file)
 
 manage_files_pattern(chromium_t, chromium_xdg_config_t, chromium_xdg_config_t)
 allow chromium_t chromium_xdg_config_t:file map;
@@ -158,7 +146,6 @@ allow chromium_t chromium_xdg_cache_t:file map;
 manage_dirs_pattern(chromium_t, chromium_xdg_cache_t, chromium_xdg_cache_t)
 xdg_cache_filetrans(chromium_t, chromium_xdg_cache_t, dir, "chromium")
 
-dyntrans_pattern(chromium_t, chromium_renderer_t)
 domtrans_pattern(chromium_t, chromium_sandbox_exec_t, chromium_sandbox_t)
 domtrans_pattern(chromium_t, chromium_naclhelper_exec_t, chromium_naclhelper_t)
 
@@ -338,56 +325,6 @@ optional_policy(`
 
 optional_policy(`
 	wm_mmap_rw_tmpfs_files(chromium_t)
-')
-
-########################################
-#
-# chromium_renderer local policy
-#
-
-allow chromium_renderer_t self:process execmem;
-dontaudit chromium_renderer_t self:process getsched;
-allow chromium_renderer_t self:fifo_file rw_fifo_file_perms;
-allow chromium_renderer_t self:shm create_shm_perms;
-allow chromium_renderer_t self:unix_dgram_socket { create read sendto };
-allow chromium_renderer_t self:unix_stream_socket { create getattr read write };
-
-allow chromium_renderer_t chromium_t:fd use;
-allow chromium_renderer_t chromium_t:unix_stream_socket rw_stream_socket_perms;
-allow chromium_renderer_t chromium_tmpfs_t:file rw_file_perms;
-
-dontaudit chromium_renderer_t chromium_t:dir search;	# /proc/... access
-
-read_files_pattern(chromium_renderer_t, chromium_xdg_config_t, chromium_xdg_config_t)
-
-rw_fifo_files_pattern(chromium_renderer_t, chromium_tmp_t, chromium_tmp_t)
-
-dev_read_urand(chromium_renderer_t)
-
-files_dontaudit_list_tmp(chromium_renderer_t)
-files_dontaudit_read_etc_files(chromium_renderer_t)
-files_search_var(chromium_renderer_t)
-
-init_sigchld(chromium_renderer_t)
-
-miscfiles_read_localization(chromium_renderer_t)
-
-userdom_dontaudit_use_all_users_fds(chromium_renderer_t)
-userdom_use_user_terminals(chromium_renderer_t)
-
-xdg_read_config_files(chromium_renderer_t)
-
-# should we have a tunable for this?
-xdg_read_pictures(chromium_t)
-
-xserver_user_x_domain_template(chromium_renderer, chromium_renderer_t, chromium_tmpfs_t)
-
-tunable_policy(`chromium_read_system_info',`
-	kernel_read_kernel_sysctls(chromium_renderer_t)
-	kernel_read_system_state(chromium_renderer_t)
-',`
-	kernel_dontaudit_read_kernel_sysctl(chromium_renderer_t)
-	kernel_dontaudit_read_system_state(chromium_renderer_t)
 ')
 
 #########################################


### PR DESCRIPTION
Upstream no longer supports the SELinux sandbox[1], so no dyntrans is attempted, making this domain redundent. It's been long enough now that it is reasonable to drop this domain.

[1] https://github.com/chromium/chromium/blob/0f8100c82dc431809d866e5d0218cbe3c482b20c/sandbox/linux/README.md?plain=1#L31