### PR TITLE
fapolicyd: support for new /usr/sbin/fapolicyd-rpm-loader

### DIFF
--- a/policy/modules/admin/fapolicyd.fc
+++ b/policy/modules/admin/fapolicyd.fc
@@ -11,5 +11,5 @@
 
 /var/log/fapolicyd-access\.log	--	gen_context(system_u:object_r:fapolicyd_log_t,s0)
 
-/var/run/fapolicyd(/.*)?			gen_context(system_u:object_r:fapolicyd_runtime_t,s0)
-/var/run/fapolicyd\.pid			--	gen_context(system_u:object_r:fapolicyd_runtime_t,s0)
+/run/fapolicyd(/.*)?				gen_context(system_u:object_r:fapolicyd_runtime_t,s0)
+/run/fapolicyd\.pid				--	gen_context(system_u:object_r:fapolicyd_runtime_t,s0)

--- a/policy/modules/admin/fapolicyd.te
+++ b/policy/modules/admin/fapolicyd.te
@@ -53,9 +53,11 @@ files_type(fapolicyd_var_lib_t)
 #
 
 allow fapolicyd_t self:capability { audit_write chown dac_override setgid setuid sys_admin sys_nice sys_ptrace };
+allow fapolicyd_t self:fifo_file rw_inherited_fifo_file_perms;
 allow fapolicyd_t self:process { setcap setsched };
 
 allow fapolicyd_t fapolicyd_log_t:file { create_file_perms write_file_perms };
+allow fapolicyd_t fapolicyd_runtime_t:dir setattr_dir_perms;
 
 manage_fifo_files_pattern(fapolicyd_t, fapolicyd_runtime_t, fapolicyd_runtime_t)
 manage_files_pattern(fapolicyd_t, fapolicyd_runtime_t, fapolicyd_runtime_t)
@@ -67,6 +69,8 @@ mmap_manage_files_pattern(fapolicyd_t, fapolicyd_var_lib_t, fapolicyd_var_lib_t)
 
 kernel_getattr_proc(fapolicyd_t)
 kernel_read_kernel_sysctls(fapolicyd_t)
+
+corecmd_exec_bin(fapolicyd_t)
 
 domain_read_all_domains_state(fapolicyd_t)
 


### PR DESCRIPTION
Updated to a newer version of fapolicyd (on RHEL).  
Policy changes to support it running /usr/sbin/fapolicyd-rpm-loader.
To support creation of runtime directory  /run/fapolicyd

avc:  denied  { setattr } for  pid=1141 comm="fapolicyd" name="fapolicyd" dev="tmpfs" ino=1306 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=dir permissive=0

avc:  denied  { execute } for  pid=5631 comm="fapolicyd" name="fapolicyd-rpm-loader" dev="dm-0" ino=174938 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1
avc:  denied { execute_no_trans } for  pid=5631 comm="fapolicyd" path="/usr/sbin/fapolicyd-rpm-loader" dev="dm-0" ino=174938 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1

avc:  denied  { read } for  pid=5630 comm="fapolicyd" path="pipe:[157491]" dev="pipefs" ino=157491 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:system_r:fapolicyd_t:s0 tclass=fifo_file permissive=1
avc:  denied { getattr } for  pid=5631 comm="fapolicyd-rpm-l" path="pipe:[157491]" dev="pipefs" ino=157491 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:system_r:fapolicyd_t:s0 tclass=fifo_file permissive=1
avc:  denied  { write } for  pid=5631 comm="fapolicyd-rpm-l" path="pipe:[157491]" dev="pipefs" ino=157491 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:system_r:fapolicyd_t:s0 tclass=fifo_file permissive=1