### PR TITLE
firewalld: Allow firewall-cmd to be called from systemd

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1316,6 +1316,10 @@ optional_policy(`
 	init_dbus_chat(initrc_t)
 
 	optional_policy(`
+		firewalld_dbus_chat(initrc_t)
+	')
+
+	optional_policy(`
 		networkmanager_dbus_chat(initrc_t)
 	')
 


### PR DESCRIPTION
RedHat has added 'ExecStartPost=/usr/bin/firewall-cmd --state' in the firewalld.service file. As firewall-cmd was just labeled bin_t this ran in initrc_t.
This change sets the type for firewall-cmd so running from systemd will work.  Also added runas in the admin interface to allow admin users to still be able to run firewall-cmd.

node=localhost type=USER_AVC msg=audit(1763093230.354:10021): pid=1156 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:initrc_t:s0 tcontext=system_u:system_r:firewalld_t:s0 tclass=dbus permissive=1 exe="/usr/bin/dbus-broker" sauid=81 hostname=? addr=? terminal=?' UID="dbus" AUID="unset" SAUID="dbus"