### PR TITLE
gcc_config_t: allow reading cgroup files for cpu.max

### DIFF
--- a/policy/modules/admin/portage.te
+++ b/policy/modules/admin/portage.te
@@ -128,6 +128,10 @@ files_search_runtime(gcc_config_t)
 # the directory it is being run from
 files_list_all(gcc_config_t)
 
+# for sort/other coreutils:
+# https://gitweb.git.savannah.gnu.org/gitweb/?p=coreutils.git;a=commit;h=c4df55be7f78d29415abd7765f863ff38184f86e
+fs_read_cgroup_files(gcc_config_t)
+
 # seems to be ok without this
 init_dontaudit_read_script_status_files(gcc_config_t)
 


### PR DESCRIPTION
Various coreutils, such as sort, now attempt[1] to read cpu.max due to a change in gnulib[2].

[1] https://gitweb.git.savannah.gnu.org/gitweb/?p=coreutils.git;a=commit;h=c4df55be7f78d29415abd7765f863ff38184f86e
[2] https://gitweb.git.savannah.gnu.org/gitweb/?p=gnulib.git;a=commit;h=9b07115f4a344effef1dde8bd0e6e356d4b0e744