### PR TITLE
matrixd: gatekeep postgresql calls in an optional policy block

### DIFF
--- a/policy/modules/services/matrixd.te
+++ b/policy/modules/services/matrixd.te
@@ -123,11 +123,6 @@ tunable_policy(`matrix_allow_federation',`
 	corenet_dontaudit_udp_bind_all_ports(matrixd_t)
 ')
 
-tunable_policy(`matrix_postgresql_connect',`
-	postgresql_stream_connect(matrixd_t)
-	postgresql_tcp_connect(matrixd_t)
-')
-
 tunable_policy(`matrix_bind_all_unreserved_tcp_ports',`
 	corenet_tcp_bind_all_unreserved_ports(matrixd_t)
 ')
@@ -136,3 +131,9 @@ optional_policy(`
 	apache_search_config(matrixd_t)
 ')
 
+optional_policy(`
+	tunable_policy(`matrix_postgresql_connect',`
+		postgresql_stream_connect(matrixd_t)
+		postgresql_tcp_connect(matrixd_t)
+	')
+')


### PR DESCRIPTION
postgresql is a seperate policy module[1], and hence is not required for the matrixd policy to work; it's already behind a tunable policy block, and hence the boolean matrix_postgresql_connect.

[1] https://github.com/SELinuxProject/refpolicy/blob/main/policy/modules/services/postgresql.te

Closes: https://bugs.gentoo.org/968058