### PR TITLE
WIP: systemd dbus to varlink transition (logind)

### DIFF
--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -92,6 +92,7 @@ interface(`auth_use_pam_systemd',`
 	systemd_dbus_chat_logind($1)
 	systemd_read_logind_state($1)
 	systemd_use_logind_fds($1)
+	systemd_connectto_logind_sockets($1)
 
 	# to read /etc/machine-id
 	files_read_etc_runtime_files($1)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1472,6 +1472,25 @@ interface(`systemd_use_logind_fds',`
 
 ######################################
 ## <summary>
+##   Connect to systemd logind
+##   sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_connectto_logind_sockets',`
+	gen_require(`
+		type systemd_logind_t;
+	')
+
+	allow $1 systemd_logind_t:unix_stream_socket connectto;
+')
+
+######################################
+## <summary>
 ##      Watch logind sessions dirs.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
It looks like systemd is now using `/run/systemd/io.systemd.Login` (as part of varlink?)

I'm running into this issue:

```
type=AVC msg=audit(1767029869.633:25522): avc:  denied  { connectto } for  pid=33412 comm="sshd-session" path="/run/systemd/io.systemd.Login" scontext=system_u:system_r:sshd_t:s0 tcontext=system_u:system_r:systemd_logind_t:s0 tclass=unix_stream_socket permissive=0
```

I suspect this problem may affect much more than just my particular ssh issue, and the fix here addresses it pretty well by giving access to logind through the unix domain socket wherever .  How should we handle this?  Rename the interface? Create a new one and just make sure that both the old and the new are used together?

My proximate issue is solved by just adding the permission into `auth_use_pam_systemd`, so maybe only add it there; i.e., make a new interface `systemd_connectto_logind_socket` and put it in `auth_use_pam_systemd`.  I can modify this PR to do that.