### PR TITLE
snmpd doesn't seem to need sys_ptrace capability

### DIFF
--- a/policy/modules/services/snmp.te
+++ b/policy/modules/services/snmp.te
@@ -29,9 +29,8 @@ files_type(snmpd_var_lib_t)
 # Local policy
 #
 
-allow snmpd_t self:capability { chown dac_override ipc_lock kill net_admin setgid setuid sys_nice sys_ptrace sys_tty_config };
+allow snmpd_t self:capability { chown dac_override ipc_lock kill net_admin setgid setuid sys_nice sys_tty_config };
 dontaudit snmpd_t self:capability { sys_module sys_tty_config };
-allow snmpd_t self:cap_userns sys_ptrace;
 allow snmpd_t self:process { getsched setsched signal_perms };
 allow snmpd_t self:fifo_file rw_fifo_file_perms;
 allow snmpd_t self:unix_stream_socket { accept connectto listen };


### PR DESCRIPTION
Tested on RHEL9 with net-snmp 5.9.4.
I was able to query information about running processes.  I'm not sure what else sys_ptrace might be needed for by snmpd