### PR TITLE
systemd: allow journalctl to search log directory

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -981,6 +981,7 @@ init_read_state(systemd_journal_init_t)
 init_search_var_lib_dirs(systemd_journal_init_t)
 init_var_lib_filetrans(systemd_journal_init_t, systemd_journal_t, dir)
 
+logging_search_logs(systemd_journal_init_t)
 logging_send_syslog_msg(systemd_journal_init_t)
 logging_stream_connect_journald_varlink(systemd_journal_init_t)
 


### PR DESCRIPTION
Allow journalctl to search log directory:

avc: denied { read } for pid=483 comm="journalctl" name="log" dev="vda" ino=64466 scontext=system_u:system_r:systemd_journal_init_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=lnk_file permissive=1

avc: denied { search } for pid=483 comm="journalctl" name="log" dev="tmpfs" ino=2 scontext=system_u:system_r:systemd_journal_init_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=dir permissive=1

Fix: #1060