### PR TITLE
Add a policy for installkernel and dracut

### DIFF
--- a/policy/modules/admin/dracut.fc
+++ b/policy/modules/admin/dracut.fc
@@ -1,0 +1,5 @@
+#
+# /usr
+#
+/usr/sbin/dracut	--	gen_context(system_u:object_r:dracut_exec_t,s0)
+/usr/bin/dracut	--	gen_context(system_u:object_r:dracut_exec_t,s0)

--- a/policy/modules/admin/dracut.fc
+++ b/policy/modules/admin/dracut.fc
@@ -1,5 +1,2 @@
-#
-# /usr
-#
 /usr/sbin/dracut	--	gen_context(system_u:object_r:dracut_exec_t,s0)
 /usr/bin/dracut	--	gen_context(system_u:object_r:dracut_exec_t,s0)

--- a/policy/modules/admin/dracut.if
+++ b/policy/modules/admin/dracut.if
@@ -1,0 +1,67 @@
+## <summary>Dracut initramfs creation tool</summary>
+
+########################################
+## <summary>
+##	Execute the dracut program in the dracut domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`dracut_domtrans',`
+	gen_require(`
+		type dracut_t, dracut_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, dracut_exec_t, dracut_t)
+')
+
+########################################
+## <summary>
+##	Execute dracut in the dracut domain, and
+##	allow the specified role the dracut domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+#
+interface(`dracut_run',`
+	gen_require(`
+		type dracut_t;
+	')
+
+	dracut_domtrans($1)
+	role $2 types dracut_t;
+')
+
+########################################
+## <summary>
+## 	Read/write dracut temporary files
+## </summary>
+## <param name="domain">
+##	<summary>
+##		Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dracut_rw_tmp_files',`
+	gen_require(`
+		type dracut_tmp_t;
+	')
+
+	files_search_var($1)
+	files_search_tmp($1)
+
+	rw_files_pattern($1, dracut_tmp_t, dracut_tmp_t)
+')
+

--- a/policy/modules/admin/dracut.if
+++ b/policy/modules/admin/dracut.if
@@ -64,4 +64,3 @@ interface(`dracut_rw_tmp_files',`
 
 	rw_files_pattern($1, dracut_tmp_t, dracut_tmp_t)
 ')
-

--- a/policy/modules/admin/dracut.te
+++ b/policy/modules/admin/dracut.te
@@ -1,11 +1,19 @@
 policy_module(dracut)
 
+########################################
+#
+# Declarations
+#
+
 type dracut_t;
 type dracut_exec_t;
 application_domain(dracut_t, dracut_exec_t)
 
 type dracut_var_log_t;
 logging_log_file(dracut_var_log_t)
+
+type dracut_runtime_t;
+files_runtime_file(dracut_runtime_t)
 
 type dracut_tmp_t;
 files_tmp_file(dracut_tmp_t)
@@ -15,13 +23,21 @@ files_tmp_file(dracut_tmp_t)
 # Local policy
 #
 
-allow dracut_t self:process setfscreate;
-allow dracut_t self:capability dac_override;
+allow dracut_t self:process { getsched setfscreate };
+# sys_admin needed for fsfreeze use
+# sys_chroot needed for ldconfig
+allow dracut_t self:capability { dac_override dac_read_search setfcap sys_admin sys_chroot };
+dontaudit dracut_t self:capability sys_resource;
 allow dracut_t self:fifo_file rw_fifo_file_perms;
 allow dracut_t self:unix_stream_socket create_stream_socket_perms;
+allow dracut_t self:alg_socket create_stream_socket_perms;
 
-manage_files_pattern(dracut_t, dracut_tmp_t, dracut_tmp_t)
-manage_dirs_pattern(dracut_t, dracut_tmp_t, dracut_tmp_t)
+allow dracut_t dracut_runtime_t:dir manage_dir_perms;
+allow dracut_t dracut_runtime_t:file manage_file_perms;
+files_runtime_filetrans(dracut_t, dracut_runtime_t, { dir file })
+
+allow dracut_t dracut_tmp_t:dir { manage_dir_perms relabelfrom };
+allow dracut_t dracut_tmp_t:file { manage_file_perms relabel_file_perms };
 manage_lnk_files_pattern(dracut_t, dracut_tmp_t, dracut_tmp_t)
 manage_chr_files_pattern(dracut_t, dracut_tmp_t, dracut_tmp_t)
 files_tmp_filetrans(dracut_t, dracut_tmp_t, dir)
@@ -32,35 +48,160 @@ logging_log_filetrans(dracut_t, dracut_var_log_t, file)
 corecmd_exec_bin(dracut_t)
 corecmd_exec_shell(dracut_t)
 corecmd_mmap_all_executables(dracut_t)
+corecmd_delete_all_executables(dracut_t)
+corecmd_setattr_all_executables(dracut_t)
+corecmd_relabelto_all_executables(dracut_t)
 
 dev_read_kmsg(dracut_t)
+dev_read_rand(dracut_t)
 dev_read_sysfs(dracut_t)
+dev_rw_lvm_control(dracut_t)
+# for ssh-keygen
+dev_write_urand(dracut_t)
+# findmnt generates these
+dev_dontaudit_getattr_all_blk_files(dracut_t)
+dev_dontaudit_getattr_all_chr_files(dracut_t)
 
 domain_use_interactive_fds(dracut_t)
+domain_obj_id_change_exemption(dracut_t)
 
 files_create_kernel_img(dracut_t)
-files_read_etc_files(dracut_t)
-files_read_kernel_modules(dracut_t)
-files_read_usr_files(dracut_t)
 files_search_runtime(dracut_t)
+
+files_rw_etc_files(dracut_t)
+files_create_etc_files(dracut_t)
+files_delete_etc_files(dracut_t)
+files_rename_etc_files(dracut_t)
+files_setattr_etc_files(dracut_t)
+files_relabelto_etc_files(dracut_t)
+files_mmap_read_kernel_modules(dracut_t)
+files_delete_kernel_modules(dracut_t)
+files_setattr_kernel_modules(dracut_t)
+files_relabelto_kernel_modules_files(dracut_t)
+files_read_usr_files(dracut_t)
+files_delete_usr_files(dracut_t)
+files_setattr_usr_files(dracut_t)
+files_relabelto_usr_files(dracut_t)
+files_read_usr_src_files(dracut_t)
+files_read_etc_runtime_files(dracut_t)
+files_delete_etc_runtime_files(dracut_t)
+files_setattr_etc_runtime_files(dracut_t)
+files_relabelto_etc_runtime_files(dracut_t)
+files_relabelfrom_etc_runtime_files(dracut_t)
+
+files_dontaudit_search_mnt(dracut_t)
+
+# cgroup for virt-detect
+fs_getattr_cgroup(dracut_t)
+fs_read_cgroup_files(dracut_t)
+# tmpfs on /run/modprobe.d
+fs_list_tmpfs(dracut_t)
+fs_getattr_nsfs_files(dracut_t)
+fs_getattr_xattr_fs(dracut_t)
+fs_dontaudit_getattr_hugetlbfs_dirs(dracut_t)
+
+kernel_read_messages(dracut_t)
+kernel_read_system_state(dracut_t)
+# for virt-detect
+kernel_read_kernel_sysctls(dracut_t)
+kernel_read_network_state(dracut_t)
+kernel_read_vm_overcommit_sysctl(dracut_t)
+kernel_dontaudit_getattr_proc(dracut_t)
+
+storage_dontaudit_read_fixed_disk(dracut_t)
+
+# create a stripped down shadow file in initrd
+auth_manage_shadow(dracut_t)
+auth_use_nsswitch(dracut_t)
+
+# for virt-detect
+init_read_state(dracut_t)
+
+fstools_domtrans(dracut_t)
 
 libs_exec_ldconfig(dracut_t)
 libs_exec_ld_so(dracut_t)
 libs_exec_lib_files(dracut_t)
+libs_delete_ld_so(dracut_t)
+libs_setattr_ld_so(dracut_t)
+libs_relabel_ld_so(dracut_t)
+libs_delete_lib_files(dracut_t)
+libs_setattr_lib_files(dracut_t)
+libs_relabelto_lib_files(dracut_t)
 
-kernel_read_messages(dracut_t)
-kernel_read_system_state(dracut_t)
+logging_read_syslog_config(dracut_t)
+logging_delete_syslog_config_files(dracut_t)
+logging_setattr_syslog_config_files(dracut_t)
+logging_relabelto_syslog_config_files(dracut_t)
+logging_dontaudit_search_runtime_dirs(dracut_t)
 
+miscfiles_read_generic_certs(dracut_t)
 miscfiles_read_localization(dracut_t)
 
+modutils_exec(dracut_t)
 modutils_read_module_config(dracut_t)
+modutils_delete_module_config(dracut_t)
+modutils_setattr_module_config(dracut_t)
+modutils_relabel_module_config(dracut_t)
 modutils_read_module_deps(dracut_t)
 
-udev_read_rules_files(dracut_t)
+seutil_domtrans_setfiles(dracut_t)
+
+udev_list_rules(dracut_t)
+udev_rw_rules_files(dracut_t)
+udev_delete_rules_files(dracut_t)
+udev_setattr_rules_files(dracut_t)
+udev_relabelto_rules_files(dracut_t)
 
 userdom_search_user_home_dirs(dracut_t)
 userdom_use_user_terminals(dracut_t)
 
+ifdef(`init_systemd',`
+	sysnet_read_config(dracut_t)
+	sysnet_delete_config(dracut_t)
+	sysnet_setattr_config(dracut_t)
+	sysnet_relabelto_config(dracut_t)
+
+	init_manage_all_unit_files(dracut_t)
+	init_relabel_all_unit_files(dracut_t)
+
+	systemd_exec_sysusers(dracut_t)
+	systemd_read_user_units_files(dracut_t)
+')
+
 optional_policy(`
+	installkernel_list_tmp(dracut_t)
+	installkernel_create_tmp_files(dracut_t)
+	installkernel_rw_tmp_files(dracut_t)
+')
+
+optional_policy(`
+	lvm_exec(dracut_t)
 	lvm_read_config(dracut_t)
+')
+
+optional_policy(`
+	portage_exec_gcc_config(dracut_t)
+	portage_list_config(dracut_t)
+	portage_read_config(dracut_t)
+	portage_list_ebuild(dracut_t)
+	portage_read_ebuild_files(dracut_t)
+')
+
+optional_policy(`
+	ssh_exec_keygen(dracut_t)
+	ssh_read_server_keys(dracut_t)
+	ssh_dontaudit_getattr_home_dirs(dracut_t)
+')
+
+optional_policy(`
+	xdg_dontaudit_search_data_dirs(dracut_t)
+')
+
+optional_policy(`
+	zfs_read_config(dracut_t)
+	zfs_read_zpool_cache(dracut_t)
+	zfs_delete_zpool_cache(dracut_t)
+	zfs_setattr_zpool_cache_files(dracut_t)
+	zfs_relabelto_zpool_cache_files(dracut_t)
 ')

--- a/policy/modules/admin/dracut.te
+++ b/policy/modules/admin/dracut.te
@@ -1,4 +1,4 @@
-policy_module(dracut, 1.0)
+policy_module(dracut)
 
 type dracut_t;
 type dracut_exec_t;
@@ -14,6 +14,7 @@ files_tmp_file(dracut_tmp_t)
 #
 # Local policy
 #
+
 allow dracut_t self:process setfscreate;
 allow dracut_t self:capability dac_override;
 allow dracut_t self:fifo_file rw_fifo_file_perms;
@@ -27,9 +28,6 @@ files_tmp_filetrans(dracut_t, dracut_tmp_t, dir)
 
 manage_files_pattern(dracut_t, dracut_var_log_t, dracut_var_log_t)
 logging_log_filetrans(dracut_t, dracut_var_log_t, file)
-
-kernel_read_messages(dracut_t)
-kernel_read_system_state(dracut_t)
 
 corecmd_exec_bin(dracut_t)
 corecmd_exec_shell(dracut_t)
@@ -50,6 +48,9 @@ libs_exec_ldconfig(dracut_t)
 libs_exec_ld_so(dracut_t)
 libs_exec_lib_files(dracut_t)
 
+kernel_read_messages(dracut_t)
+kernel_read_system_state(dracut_t)
+
 miscfiles_read_localization(dracut_t)
 
 modutils_read_module_config(dracut_t)
@@ -63,4 +64,3 @@ userdom_use_user_terminals(dracut_t)
 optional_policy(`
 	lvm_read_config(dracut_t)
 ')
-

--- a/policy/modules/admin/dracut.te
+++ b/policy/modules/admin/dracut.te
@@ -1,0 +1,66 @@
+policy_module(dracut, 1.0)
+
+type dracut_t;
+type dracut_exec_t;
+application_domain(dracut_t, dracut_exec_t)
+
+type dracut_var_log_t;
+logging_log_file(dracut_var_log_t)
+
+type dracut_tmp_t;
+files_tmp_file(dracut_tmp_t)
+
+########################################
+#
+# Local policy
+#
+allow dracut_t self:process setfscreate;
+allow dracut_t self:capability dac_override;
+allow dracut_t self:fifo_file rw_fifo_file_perms;
+allow dracut_t self:unix_stream_socket create_stream_socket_perms;
+
+manage_files_pattern(dracut_t, dracut_tmp_t, dracut_tmp_t)
+manage_dirs_pattern(dracut_t, dracut_tmp_t, dracut_tmp_t)
+manage_lnk_files_pattern(dracut_t, dracut_tmp_t, dracut_tmp_t)
+manage_chr_files_pattern(dracut_t, dracut_tmp_t, dracut_tmp_t)
+files_tmp_filetrans(dracut_t, dracut_tmp_t, dir)
+
+manage_files_pattern(dracut_t, dracut_var_log_t, dracut_var_log_t)
+logging_log_filetrans(dracut_t, dracut_var_log_t, file)
+
+kernel_read_messages(dracut_t)
+kernel_read_system_state(dracut_t)
+
+corecmd_exec_bin(dracut_t)
+corecmd_exec_shell(dracut_t)
+corecmd_mmap_all_executables(dracut_t)
+
+dev_read_kmsg(dracut_t)
+dev_read_sysfs(dracut_t)
+
+domain_use_interactive_fds(dracut_t)
+
+files_create_kernel_img(dracut_t)
+files_read_etc_files(dracut_t)
+files_read_kernel_modules(dracut_t)
+files_read_usr_files(dracut_t)
+files_search_runtime(dracut_t)
+
+libs_exec_ldconfig(dracut_t)
+libs_exec_ld_so(dracut_t)
+libs_exec_lib_files(dracut_t)
+
+miscfiles_read_localization(dracut_t)
+
+modutils_read_module_config(dracut_t)
+modutils_read_module_deps(dracut_t)
+
+udev_read_rules_files(dracut_t)
+
+userdom_search_user_home_dirs(dracut_t)
+userdom_use_user_terminals(dracut_t)
+
+optional_policy(`
+	lvm_read_config(dracut_t)
+')
+

--- a/policy/modules/admin/installkernel.fc
+++ b/policy/modules/admin/installkernel.fc
@@ -1,0 +1,4 @@
+/usr/bin/kernel-install	--	gen_context(system_u:object_r:installkernel_exec_t,s0)
+/usr/bin/installkernel	--	gen_context(system_u:object_r:installkernel_exec_t,s0)
+/var/lib/misc/installkernel	--	gen_context(system_u:object_r:installkernel_var_lib_t,s0)
+/var/log/installkernel\.log	--	gen_context(system_u:object_r:installkernel_log_t,s0)

--- a/policy/modules/admin/installkernel.if
+++ b/policy/modules/admin/installkernel.if
@@ -45,3 +45,57 @@ interface(`installkernel_run',`
 	installkernel_domtrans($1)
 	role $2 types installkernel_t;
 ')
+
+########################################
+## <summary>
+##	List the contents of installkernel tmp directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`installkernel_list_tmp',`
+	gen_require(`
+		type installkernel_tmp_t;
+	')
+
+	allow $1 installkernel_tmp_t:dir list_dir_perms;
+')
+
+########################################
+## <summary>
+##	Create installkernel tmp files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`installkernel_create_tmp_files',`
+	gen_require(`
+		type installkernel_tmp_t;
+	')
+
+	create_files_pattern($1, installkernel_tmp_t, installkernel_tmp_t)
+')
+
+########################################
+## <summary>
+##	Read and write installkernel tmp files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`installkernel_rw_tmp_files',`
+	gen_require(`
+		type installkernel_tmp_t;
+	')
+
+	rw_files_pattern($1, installkernel_tmp_t, installkernel_tmp_t)
+')

--- a/policy/modules/admin/installkernel.if
+++ b/policy/modules/admin/installkernel.if
@@ -1,0 +1,47 @@
+## <summary>Install kernels and update the bootloader configuration.</summary>
+
+########################################
+## <summary>
+##	Execute installkernel in the installkernel domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`installkernel_domtrans',`
+	gen_require(`
+		type installkernel_t, installkernel_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, installkernel_exec_t, installkernel_t)
+')
+
+########################################
+## <summary>
+##	Execute installkernel in the installkernel
+##	domain, and allow the specified
+##	role the installkernel domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`installkernel_run',`
+	gen_require(`
+		type installkernel_t;
+	')
+
+	installkernel_domtrans($1)
+	role $2 types installkernel_t;
+')

--- a/policy/modules/admin/installkernel.te
+++ b/policy/modules/admin/installkernel.te
@@ -1,0 +1,102 @@
+policy_module(installkernel)
+
+########################################
+#
+# Declarations
+#
+
+type installkernel_t;
+type installkernel_exec_t;
+application_domain(installkernel_t, installkernel_exec_t)
+
+type installkernel_var_lib_t;
+files_type(installkernel_var_lib_t)
+
+type installkernel_log_t;
+logging_log_file(installkernel_log_t)
+
+type installkernel_tmp_t;
+files_tmp_file(installkernel_tmp_t)
+
+########################################
+#
+# Local policy
+#
+
+allow installkernel_t self:process { getcap getsched };
+allow installkernel_t self:capability sys_resource;
+allow installkernel_t self:fifo_file rw_inherited_fifo_file_perms;
+
+can_exec(installkernel_t, installkernel_exec_t)
+
+corecmd_exec_bin(installkernel_t)
+corecmd_exec_shell(installkernel_t)
+
+# create staging area
+allow installkernel_t installkernel_tmp_t:dir manage_dir_perms;
+allow installkernel_t installkernel_tmp_t:file { mmap_manage_file_perms relabel_file_perms };
+files_tmp_filetrans(installkernel_t, installkernel_tmp_t, { dir file })
+
+# update /var/lib/misc/installkernel
+files_search_var_lib(installkernel_t)
+allow installkernel_t installkernel_var_lib_t:file manage_file_perms;
+
+allow installkernel_t installkernel_log_t:file { create_file_perms append_file_perms };
+logging_log_filetrans(installkernel_t, installkernel_log_t, file)
+
+dev_getattr_sysfs(installkernel_t)
+dev_read_sysfs(installkernel_t)
+
+# boot_t is constrained
+domain_obj_id_change_exemption(installkernel_t)
+
+domain_use_interactive_fds(installkernel_t)
+
+files_list_boot(installkernel_t)
+files_manage_boot_files(installkernel_t)
+files_relabelto_boot_files(installkernel_t)
+files_getattr_boot_fs(installkernel_t)
+# read /etc/kernel
+files_read_etc_files(installkernel_t)
+# read /etc/machine-id
+files_read_etc_runtime_files(installkernel_t)
+files_mmap_read_usr_src_files(installkernel_t)
+# execute depmod
+files_manage_kernel_modules(installkernel_t)
+
+fs_getattr_xattr_fs(installkernel_t)
+fs_getattr_nsfs_files(installkernel_t)
+
+kernel_read_system_state(installkernel_t)
+# read /proc/sys/kernel/osrelease
+kernel_read_kernel_sysctls(installkernel_t)
+kernel_dontaudit_getattr_proc(installkernel_t)
+
+storage_raw_read_fixed_disk(installkernel_t)
+
+auth_use_nsswitch(installkernel_t)
+
+miscfiles_read_generic_certs(installkernel_t)
+miscfiles_read_localization(installkernel_t)
+
+# read /etc/systemd/network
+sysnet_read_config(installkernel_t)
+
+libs_exec_lib_files(installkernel_t)
+
+userdom_use_user_terminals(installkernel_t)
+userdom_dontaudit_search_user_home_dirs(installkernel_t)
+
+xdg_dontaudit_search_data_dirs(installkernel_t)
+
+ifdef(`init_systemd',`
+	# detect if running in a container
+	init_search_runtime(installkernel_t)
+	fs_getattr_cgroup(installkernel_t)
+	fs_search_cgroup_dirs(installkernel_t)
+	init_read_state(installkernel_t)
+')
+
+optional_policy(`
+	dracut_domtrans(installkernel_t)
+')

--- a/policy/modules/admin/portage.if
+++ b/policy/modules/admin/portage.if
@@ -251,6 +251,25 @@ interface(`portage_run_fetch',`
 
 ########################################
 ## <summary>
+##	Execute gcc-config in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`portage_exec_gcc_config',`
+	gen_require(`
+		type gcc_config_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, gcc_config_exec_t)
+')
+
+########################################
+## <summary>
 ##	Execute gcc-config in the gcc config domain.
 ## </summary>
 ## <param name="domain">
@@ -351,6 +370,103 @@ interface(`portage_dontaudit_read_config',`
 	dontaudit $1 portage_conf_t:dir search_dir_perms;
 	dontaudit $1 portage_conf_t:file read_file_perms;
 	dontaudit $1 portage_conf_t:lnk_file read_lnk_file_perms;
+')
+
+########################################
+## <summary>
+##	List the contents of portage config directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`portage_list_config',`
+	gen_require(`
+		type portage_conf_t;
+	')
+
+	files_search_etc($1)
+	list_dirs_pattern($1, portage_conf_t, portage_conf_t)
+')
+
+########################################
+## <summary>
+##	Read portage config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`portage_read_config',`
+	gen_require(`
+		type portage_conf_t;
+	')
+
+	files_search_etc($1)
+	list_dirs_pattern($1, portage_conf_t, portage_conf_t)
+	read_files_pattern($1, portage_conf_t, portage_conf_t)
+	read_lnk_files_pattern($1, portage_conf_t, portage_conf_t)
+')
+
+########################################
+## <summary>
+##	Memory map and read portage config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`portage_mmap_read_config',`
+	gen_require(`
+		type portage_conf_t;
+	')
+
+	files_search_etc($1)
+	list_dirs_pattern($1, portage_conf_t, portage_conf_t)
+	mmap_read_files_pattern($1, portage_conf_t, portage_conf_t)
+	read_lnk_files_pattern($1, portage_conf_t, portage_conf_t)
+')
+
+########################################
+## <summary>
+##	List the contents of portage ebuild directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`portage_list_ebuild',`
+	gen_require(`
+		type portage_ebuild_t;
+	')
+
+	list_dirs_pattern($1, portage_ebuild_t, portage_ebuild_t)
+')
+
+########################################
+## <summary>
+##	Read portage ebuild files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`portage_read_ebuild_files',`
+	gen_require(`
+		type portage_ebuild_t;
+	')
+
+	read_files_pattern($1, portage_ebuild_t, portage_ebuild_t)
 ')
 
 ########################################

--- a/policy/modules/kernel/corecommands.if
+++ b/policy/modules/kernel/corecommands.if
@@ -702,6 +702,27 @@ interface(`corecmd_getattr_all_executables',`
 
 ########################################
 ## <summary>
+##	Set the attributes of all executable files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`corecmd_setattr_all_executables',`
+	gen_require(`
+		attribute exec_type;
+		type bin_t;
+	')
+
+	corecmd_list_bin($1)
+	setattr_files_pattern($1, bin_t, exec_type)
+')
+
+########################################
+## <summary>
 ##	Read all executable files.
 ## </summary>
 ## <param name="domain">
@@ -782,6 +803,27 @@ interface(`corecmd_dontaudit_exec_all_executables',`
 
 ########################################
 ## <summary>
+##	Delete all executable files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`corecmd_delete_all_executables',`
+	gen_require(`
+		attribute exec_type;
+		type bin_t;
+	')
+
+	corecmd_list_bin($1)
+	delete_files_pattern($1, bin_t, exec_type)
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and all executable files.
 ## </summary>
 ## <param name="domain">
@@ -821,6 +863,25 @@ interface(`corecmd_relabel_all_executables',`
 
 	corecmd_search_bin($1)
 	relabel_files_pattern($1, bin_t, exec_type)
+')
+
+########################################
+## <summary>
+##	Relabelto all executable file types.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`corecmd_relabelto_all_executables',`
+	gen_require(`
+		attribute exec_type;
+	')
+
+	allow $1 exec_type:file relabelto;
 ')
 
 ########################################

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -2724,6 +2724,24 @@ interface(`files_relabelfrom_boot_files',`
 	relabelfrom_files_pattern($1, boot_t, boot_t)
 ')
 
+########################################
+## <summary>
+##	Relabel to files in the /boot directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_relabelto_boot_files',`
+	gen_require(`
+		type boot_t;
+	')
+
+	relabelto_files_pattern($1, boot_t, boot_t)
+')
+
 ######################################
 ## <summary>
 ##	Read symbolic links in the /boot directory.
@@ -5857,6 +5875,27 @@ interface(`files_read_usr_src_files',`
 
 	allow $1 usr_t:dir search_dir_perms;
 	read_files_pattern($1, { usr_t src_t }, src_t)
+	read_lnk_files_pattern($1, { usr_t src_t }, src_t)
+	allow $1 src_t:dir list_dir_perms;
+')
+
+########################################
+## <summary>
+##	Memory map and read files in /usr/src.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_mmap_read_usr_src_files',`
+	gen_require(`
+		type usr_t, src_t;
+	')
+
+	allow $1 usr_t:dir search_dir_perms;
+	mmap_read_files_pattern($1, { usr_t src_t }, src_t)
 	read_lnk_files_pattern($1, { usr_t src_t }, src_t)
 	allow $1 src_t:dir list_dir_perms;
 ')

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -3483,6 +3483,24 @@ interface(`files_dontaudit_manage_etc_files',`
 
 ########################################
 ## <summary>
+##	Create system configuration files in /etc.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_create_etc_files',`
+	gen_require(`
+		type etc_t;
+	')
+
+	create_files_pattern($1, etc_t, etc_t)
+')
+
+########################################
+## <summary>
 ##	Delete system configuration files in /etc.
 ## </summary>
 ## <param name="domain">
@@ -3497,6 +3515,41 @@ interface(`files_delete_etc_files',`
 	')
 
 	delete_files_pattern($1, etc_t, etc_t)
+')
+########################################
+## <summary>
+##	Rename system configuration files in /etc.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_rename_etc_files',`
+	gen_require(`
+		type etc_t;
+	')
+
+	rename_files_pattern($1, etc_t, etc_t)
+')
+
+########################################
+## <summary>
+##	Set the attributes of etc_t files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_setattr_etc_files',`
+	gen_require(`
+		type etc_t;
+	')
+
+	allow $1 etc_t:file setattr;
 ')
 
 ########################################
@@ -3535,6 +3588,24 @@ interface(`files_watch_etc_files', `
 	')
 
 	allow $1 etc_t:file watch;
+')
+
+########################################
+## <summary>
+##	Relabel files to etc_t.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_relabelto_etc_files',`
+	gen_require(`
+		type etc_t;
+	')
+
+	allow $1 etc_t:file relabelto;
 ')
 
 ########################################
@@ -3886,8 +3957,8 @@ interface(`files_read_etc_runtime_files',`
 	')
 
 	allow $1 etc_t:dir list_dir_perms;
-	read_files_pattern($1, etc_t, etc_runtime_t)
-	read_lnk_files_pattern($1, etc_t, etc_runtime_t)
+	read_files_pattern($1, etc_runtime_t, etc_runtime_t)
+	read_lnk_files_pattern($1, etc_runtime_t, etc_runtime_t)
 ')
 
 ########################################
@@ -4008,6 +4079,24 @@ interface(`files_rw_etc_runtime_files',`
 
 ########################################
 ## <summary>
+##	Delete etc_runtime_t files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_delete_etc_runtime_files',`
+	gen_require(`
+		type etc_runtime_t;
+	')
+
+	allow $1 etc_runtime_t:file delete_file_perms;
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete files in
 ##	/etc that are dynamically created on boot,
 ##	such as mtab.
@@ -4029,6 +4118,24 @@ interface(`files_manage_etc_runtime_files',`
 
 ########################################
 ## <summary>
+##	Set the attributes on etc_runtime_t files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_setattr_etc_runtime_files',`
+	gen_require(`
+		type etc_runtime_t;
+	')
+
+	allow $1 etc_runtime_t:file setattr;
+')
+
+########################################
+## <summary>
 ##	Relabel to etc_runtime_t files.
 ## </summary>
 ## <param name="domain">
@@ -4043,6 +4150,24 @@ interface(`files_relabelto_etc_runtime_files',`
 	')
 
 	allow $1 etc_runtime_t:file relabelto;
+')
+
+########################################
+## <summary>
+##	Relabel from etc_runtime_t files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_relabelfrom_etc_runtime_files',`
+	gen_require(`
+		type etc_runtime_t;
+	')
+
+	allow $1 etc_runtime_t:file relabelfrom;
 ')
 
 ########################################
@@ -4693,6 +4818,24 @@ interface(`files_delete_kernel_modules',`
 
 ########################################
 ## <summary>
+##	Set the attributes on kernel module files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_setattr_kernel_modules',`
+	gen_require(`
+		type modules_object_t;
+	')
+
+	allow $1 modules_object_t:file setattr;
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete
 ##	kernel module files.
 ## </summary>
@@ -4782,6 +4925,24 @@ interface(`files_kernel_modules_filetrans',`
 	')
 
 	filetrans_pattern($1, modules_object_t, $2, $3, $4)
+')
+
+########################################
+## <summary>
+##	Relabel files to the kernel module type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_relabelto_kernel_modules_files',`
+	gen_require(`
+		type modules_object_t;
+	')
+
+	allow $1 modules_object_t:file relabelto;
 ')
 
 ########################################
@@ -5599,6 +5760,24 @@ interface(`files_getattr_usr_files',`
 	')
 
 	getattr_files_pattern($1, usr_t, usr_t)
+')
+
+########################################
+## <summary>
+##	Set the attributes of files in the /usr directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_setattr_usr_files',`
+	gen_require(`
+		type usr_t;
+	')
+
+	allow $1 usr_t:file setattr;
 ')
 
 ########################################

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -3643,6 +3643,25 @@ interface(`fs_getattr_hugetlbfs',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to get the
+##	attributes of directories on a hugetlbfs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_getattr_hugetlbfs_dirs',`
+	gen_require(`
+		type hugetlbfs_t;
+	')
+
+	dontaudit $1 hugetlbfs_t:dir getattr_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Remount a hugetlbfs filesystem.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -556,6 +556,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	installkernel_run(sysadm_t, sysadm_r)
+')
+
+optional_policy(`
 	iptables_admin(sysadm_t, sysadm_r)
 	iptables_run(sysadm_t, sysadm_r)
 ')

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -423,6 +423,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	dracut_run(sysadm_t, sysadm_r)
+')
+
+optional_policy(`
 	drbd_admin(sysadm_t, sysadm_r)
 ')
 

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -459,7 +459,7 @@ template(`ssh_role_template',`
 		cockpit_rw_session_pipes($1_ssh_agent_t)
 		cockpit_send_signal($1_ssh_agent_t)
 	')
-	
+
 	optional_policy(`
 		nis_use_ypbind($1_ssh_agent_t)
 	')
@@ -760,6 +760,25 @@ interface(`ssh_agent_exec',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to get the attributes
+##	of ssh home directory (~/.ssh).
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`ssh_dontaudit_getattr_home_dirs',`
+	gen_require(`
+		type ssh_home_t;
+	')
+
+	dontaudit $1 ssh_home_t:dir getattr_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Set the attributes of ssh home directory (~/.ssh)
 ## </summary>
 ## <param name="domain">
@@ -814,6 +833,24 @@ interface(`ssh_read_user_home_files',`
 	read_files_pattern($1, ssh_home_t, ssh_home_t)
 	read_lnk_files_pattern($1, ssh_home_t, ssh_home_t)
 	userdom_search_user_home_dirs($1)
+')
+
+########################################
+## <summary>
+##	Execute the ssh key generator in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ssh_exec_keygen',`
+	gen_require(`
+		type ssh_keygen_exec_t;
+	')
+
+	can_exec($1, ssh_keygen_exec_t)
 ')
 
 ########################################

--- a/policy/modules/services/zfs.if
+++ b/policy/modules/services/zfs.if
@@ -106,6 +106,80 @@ interface(`zfs_read_config',`
 
 ########################################
 ## <summary>
+##	Read the zpool cache.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`zfs_read_zpool_cache',`
+	gen_require(`
+		type zfs_zpool_cache_t;
+	')
+
+	files_search_etc($1)
+	zfs_search_config($1)
+	read_files_pattern($1, zfs_zpool_cache_t, zfs_zpool_cache_t)
+')
+
+########################################
+## <summary>
+##	Delete the zpool cache file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`zfs_delete_zpool_cache',`
+	gen_require(`
+		type zfs_zpool_cache_t;
+	')
+
+	delete_files_pattern($1, zfs_zpool_cache_t, zfs_zpool_cache_t)
+')
+
+########################################
+## <summary>
+##	Set the attributes on the zpool cache file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`zfs_setattr_zpool_cache_files',`
+	gen_require(`
+		type zfs_zpool_cache_t;
+	')
+
+	allow $1 zfs_zpool_cache_t:file setattr;
+')
+
+########################################
+## <summary>
+##	Relabel files to the zpool cache type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`zfs_relabelto_zpool_cache_files',`
+	gen_require(`
+		type zfs_zpool_cache_t;
+	')
+
+	allow $1 zfs_zpool_cache_t:file relabelto;
+')
+
+########################################
+## <summary>
 ##	Create the zpool cache with an
 ##	automatic transition to the zpool
 ##	cache type.

--- a/policy/modules/system/libraries.if
+++ b/policy/modules/system/libraries.if
@@ -151,6 +151,42 @@ interface(`libs_exec_ld_so',`
 
 ########################################
 ## <summary>
+##	Delete the dynamic link/loader.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`libs_delete_ld_so',`
+	gen_require(`
+		type ld_so_t;
+	')
+
+	delete_files_pattern($1, ld_so_t, ld_so_t)
+')
+
+########################################
+## <summary>
+##	Set the attributes on the dynamic link/loader.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`libs_setattr_ld_so',`
+	gen_require(`
+		type ld_so_t;
+	')
+
+	allow $1 ld_so_t:file setattr;
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete the
 ##	dynamic link/loader.
 ## </summary>
@@ -311,6 +347,42 @@ interface(`libs_watch_lib_dirs',`
 	')
 
 	allow $1 lib_t:dir watch;
+')
+
+########################################
+## <summary>
+##	Delete library files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`libs_delete_lib_files',`
+	gen_require(`
+		type lib_t;
+	')
+
+	allow $1 lib_t:file delete_file_perms;
+')
+
+########################################
+## <summary>
+##	Set the attributes on library files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`libs_setattr_lib_files',`
+	gen_require(`
+		type lib_t;
+	')
+
+	allow $1 lib_t:file setattr;
 ')
 
 ########################################

--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -829,6 +829,82 @@ interface(`logging_read_syslog_config',`
 
 ########################################
 ## <summary>
+##	Delete syslog configuration files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`logging_delete_syslog_config_files',`
+	gen_require(`
+		type syslog_conf_t;
+	')
+
+	delete_files_pattern($1, syslog_conf_t, syslog_conf_t)
+')
+
+########################################
+## <summary>
+##	Set the attributes on syslog configuration files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`logging_setattr_syslog_config_files',`
+	gen_require(`
+		type syslog_conf_t;
+	')
+
+	allow $1 syslog_conf_t:file setattr;
+')
+
+########################################
+## <summary>
+##	Relabelto syslog configuration files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`logging_relabelto_syslog_config_files',`
+	gen_require(`
+		type syslog_conf_t;
+	')
+
+	allow $1 syslog_conf_t:file relabelto;
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to search syslog
+##	runtime directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`logging_dontaudit_search_runtime_dirs',`
+	gen_require(`
+		type syslogd_runtime_t;
+	')
+
+	dontaudit $1 syslogd_runtime_t:dir search_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Watch syslog runtime dirs.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/modutils.if
+++ b/policy/modules/system/modutils.if
@@ -105,6 +105,25 @@ interface(`modutils_delete_module_config',`
 
 ########################################
 ## <summary>
+##	Set the attributes on a file with the configuration
+##	options used when loading modules.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`modutils_setattr_module_config',`
+	gen_require(`
+		type modules_conf_t;
+	')
+
+	allow $1 modules_conf_t:file setattr;
+')
+
+########################################
+## <summary>
 ##	Manage files with the configuration options used when
 ##	loading modules.
 ## </summary>
@@ -120,6 +139,25 @@ interface(`modutils_manage_module_config',`
 	')
 
 	manage_files_pattern($1, modules_conf_t, modules_conf_t)
+')
+
+########################################
+## <summary>
+##	Relabel to and from a file with the configuration
+##	options used when loading modules.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`modutils_relabel_module_config',`
+	gen_require(`
+		type modules_conf_t;
+	')
+
+	relabel_files_pattern($1, modules_conf_t, modules_conf_t)
 ')
 
 ########################################

--- a/policy/modules/system/modutils.te
+++ b/policy/modules/system/modutils.te
@@ -147,6 +147,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	dracut_rw_tmp_files(kmod_t)
+')
+
+optional_policy(`
 	firstboot_dontaudit_rw_pipes(kmod_t)
 	firstboot_dontaudit_rw_stream_sockets(kmod_t)
 ')

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -495,6 +495,25 @@ interface(`sysnet_create_config',`
 
 #######################################
 ## <summary>
+##	Delete network config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_delete_config',`
+	gen_require(`
+		type net_conf_t;
+	')
+
+	files_search_etc($1)
+	delete_files_pattern($1, net_conf_t, net_conf_t)
+')
+
+#######################################
+## <summary>
 ##	Relabel network config files.
 ## </summary>
 ## <param name="domain">
@@ -510,6 +529,25 @@ interface(`sysnet_relabel_config',`
 
 	files_search_etc($1)
 	allow $1 net_conf_t:file relabel_file_perms;
+')
+
+#######################################
+## <summary>
+##	Relabelto network config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_relabelto_config',`
+	gen_require(`
+		type net_conf_t;
+	')
+
+	files_search_etc($1)
+	allow $1 net_conf_t:file relabelto;
 ')
 
 #######################################

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -3080,6 +3080,26 @@ interface(`systemd_status_all_user_sessions',`
 ########################################
 ## <summary>
 ##  Execute systemd-sysusers in the
+##  caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_exec_sysusers', `
+	gen_require(`
+		type systemd_sysusers_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, systemd_sysusers_exec_t)
+')
+
+########################################
+## <summary>
+##  Execute systemd-sysusers in the
 ##  systemd sysusers domain.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/udev.if
+++ b/policy/modules/system/udev.if
@@ -213,6 +213,8 @@ interface(`udev_read_rules_files',`
 		type udev_rules_t;
 	')
 
+	files_search_etc($1) # /etc/udev/rules.d
+	udev_search_runtime($1) # /run/udev/rules.d
 	read_files_pattern($1, udev_rules_t, udev_rules_t)
 ')
 

--- a/policy/modules/system/udev.if
+++ b/policy/modules/system/udev.if
@@ -182,6 +182,132 @@ interface(`udev_dontaudit_rw_dgram_sockets',`
 
 ########################################
 ## <summary>
+##	List the contents of udev rules directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`udev_list_rules',`
+	gen_require(`
+		type udev_rules_t;
+	')
+
+	allow $1 udev_rules_t:dir list_dir_perms;
+')
+
+########################################
+## <summary>
+##	Read udev rules files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`udev_read_rules_files',`
+	gen_require(`
+		type udev_rules_t;
+	')
+
+	read_files_pattern($1, udev_rules_t, udev_rules_t)
+')
+
+########################################
+## <summary>
+##	Read and write udev rules files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`udev_rw_rules_files',`
+	gen_require(`
+		type udev_rules_t;
+	')
+
+	rw_files_pattern($1, udev_rules_t, udev_rules_t)
+')
+
+########################################
+## <summary>
+##	Create udev rules files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`udev_create_rules_files',`
+	gen_require(`
+		type udev_rules_t;
+	')
+
+	create_files_pattern($1, udev_rules_t, udev_rules_t)
+')
+
+########################################
+## <summary>
+##	Delete udev rules files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`udev_delete_rules_files',`
+	gen_require(`
+		type udev_rules_t;
+	')
+
+	allow $1 udev_rules_t:file delete_file_perms;
+')
+
+########################################
+## <summary>
+##	Rename udev rules files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`udev_rename_rules_files',`
+	gen_require(`
+		type udev_rules_t;
+	')
+
+	allow $1 udev_rules_t:file rename_file_perms;
+')
+
+########################################
+## <summary>
+##	Set the attributes on udev rules files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`udev_setattr_rules_files',`
+	gen_require(`
+		type udev_rules_t;
+	')
+
+	allow $1 udev_rules_t:file setattr;
+')
+
+########################################
+## <summary>
 ##	Manage udev rules files
 ## </summary>
 ## <param name="domain">
@@ -240,6 +366,24 @@ interface(`udev_relabel_rules_files',`
 	relabel_files_pattern($1, udev_rules_t, udev_rules_t)
 
 	files_search_etc($1)
+')
+
+########################################
+## <summary>
+##	Relabelto udev rules files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`udev_relabelto_rules_files',`
+	gen_require(`
+		type udev_rules_t;
+	')
+
+	allow $1 udev_rules_t:file relabelto;
 ')
 
 ########################################

--- a/testing/sechecker.ini
+++ b/testing/sechecker.ini
@@ -103,6 +103,7 @@ exempt_source = acpi_t
                 dockerd_t           # Container engine (namespacing)
                 dockerd_user_t      # Container engine (namespacing)
                 dphysswapfile_t     # Configure swap files
+                dracut_t            # Needed to use fsfreeze when building an initrd
                 entropyd_t          # Add entropy to the system
                 fapolicyd_t
                 fsadm_t


### PR DESCRIPTION
Pull in the `dracut` policy module from Gentoo and get it working with modern systems. For this, we:
1. Add the `dracut` policy module as-is from Gentoo.
2. Also add a policy module for `installkernel`. This tool is used on several distros (including Gentoo) as a helper for calling the necessary utilities for installing a kernel. In our case, this tool can be used to call into `dracut`.
3. Apply a bunch of a fixes to the `dracut` module to get it working as needed.

The workflow I tested is installing a hostonly kernel via the kernel's `make install`, which calls `installkernel` and then `dracut`. Happy to share the `dracut` config if needed.

Normally `dracut` has helper scripts that get installed by other system tools (e.g. ZFS) that allow it to handle installing those components as needed. I only tested the tools that I am using personally, so there may be others that need looking into as well.