### PR TITLE
obexctl: Add sepolicy for obexctl to work in ssh

### DIFF
--- a/policy/modules/services/obex.fc
+++ b/policy/modules/services/obex.fc
@@ -1,1 +1,2 @@
 /usr/bin/obex-data-server	--	gen_context(system_u:object_r:obex_exec_t,s0)
+/usr/libexec/bluetooth/obexd   --      gen_context(system_u:object_r:obex_exec_t,s0)

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -175,6 +175,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	obex_dbus_chat(unconfined_t)
+')
+
+optional_policy(`
 	oddjob_run_mkhomedir(unconfined_t, unconfined_r)
 ')
 


### PR DESCRIPTION
This fix is required to resolve below AVC denial -

audit[635]: USER_AVC pid=635 uid=999 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0 msg='avc:  denied  { send_msg } for msgtype=method_return dest=:1.47 spid=763 tpid=1862 scontext=system_u:system_r:initrc_t:s0
tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=dbus permissive=0 exe="/usr/bin/dbus-daemon" sauid=999 hostname=? addr=? terminal=?'