### PR TITLE
sepolicy: Add sepolicy rules for hcidump, hciconfig, hcitool and l2test failures

### DIFF
--- a/policy/modules/services/bluetooth.fc
+++ b/policy/modules/services/bluetooth.fc
@@ -10,9 +10,13 @@
 /usr/bin/bluetoothctl	--	gen_context(system_u:object_r:bluetooth_helper_exec_t,s0)
 /usr/bin/dund	--	gen_context(system_u:object_r:bluetooth_exec_t,s0)
 /usr/bin/hciattach	--	gen_context(system_u:object_r:bluetooth_exec_t,s0)
+/usr/bin/hciconfig  --  gen_context(system_u:object_r:bluetooth_helper_exec_t,s0)
 /usr/bin/hcid	--	gen_context(system_u:object_r:bluetooth_exec_t,s0)
+/usr/bin/hcidump  --  gen_context(system_u:object_r:bluetooth_helper_exec_t,s0)
+/usr/bin/hcitool  --  gen_context(system_u:object_r:bluetooth_helper_exec_t,s0)
 /usr/bin/hid2hci	--	gen_context(system_u:object_r:bluetooth_exec_t,s0)
 /usr/bin/hidd	--	gen_context(system_u:object_r:bluetooth_exec_t,s0)
+/usr/bin/l2test   --  gen_context(system_u:object_r:bluetooth_helper_exec_t,s0)
 /usr/bin/rfcomm	--	gen_context(system_u:object_r:bluetooth_exec_t,s0)
 /usr/bin/sdpd	--	gen_context(system_u:object_r:bluetooth_exec_t,s0)
 

--- a/policy/modules/services/bluetooth.te
+++ b/policy/modules/services/bluetooth.te
@@ -182,6 +182,11 @@ allow bluetooth_helper_t bluetooth_t:socket { read write };
 allow bluetooth_helper_t bluetooth_t:fd use;
 allow bluetooth_helper_t bluetooth_t:unix_stream_socket rw_socket_perms;
 
+allow bluetooth_helper_t self:capability { net_admin net_raw };
+allow bluetooth_helper_t self:bluetooth_socket create_stream_socket_perms;
+domain_use_interactive_fds(bluetooth_helper_t)
+userdom_use_user_terminals(bluetooth_helper_t)
+
 manage_dirs_pattern(bluetooth_helper_t, bluetooth_helper_tmp_t, bluetooth_helper_tmp_t)
 manage_files_pattern(bluetooth_helper_t, bluetooth_helper_tmp_t, bluetooth_helper_tmp_t)
 manage_sock_files_pattern(bluetooth_helper_t, bluetooth_helper_tmp_t, bluetooth_helper_tmp_t)


### PR DESCRIPTION
Fix to resolve below avc denials -

AVC avc:  denied  { ioctl } for  pid=1884 comm="hciconfig" path="socket:[23486]" dev="sockfs" ino=23486 ioctlcmd=0x48d2 scontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tcontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tclass=bluetooth_socket permissive=0

AVC avc:  denied  { net_raw } for  pid=1917 comm="hcidump" capability=13 scontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tcontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tclass=capability permissive=0

AVC avc:  denied  { write } for  pid=1905 comm="hcitool" path="socket:[28744]" dev="sockfs" ino=28744 scontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tcontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tclass=bluetooth_socket permissive=0

AVC avc:  denied  { listen } for  pid=8149 comm="l2test" scontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tcontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tclass=bluetooth_socket permissive=0

AVC avc:  denied  { accept } for  pid=1959 comm="l2test" scontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tcontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tclass=bluetooth_socket permissive=0

AVC avc:  denied  { net_admin } for  pid=1791 comm="bluetoothctl" capability=12 scontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tcontext=root:sysadm_r:bluetooth_helper_t:s0-s0:c0.c1023 tclass=capability permissive=0