### PR TITLE
Sepolicy changes for brctl to access devpts

### DIFF
--- a/policy/modules/admin/brctl.te
+++ b/policy/modules/admin/brctl.te
@@ -23,6 +23,8 @@ allow brctl_t self:unix_stream_socket create_stream_socket_perms;
 allow brctl_t self:unix_dgram_socket create_socket_perms;
 allow brctl_t self:tcp_socket create_socket_perms;
 
+init_use_script_ptys(brctl_t)
+
 kernel_request_load_module(brctl_t)
 kernel_read_network_state(brctl_t)
 kernel_read_sysctl(brctl_t)


### PR DESCRIPTION
Resolve selinux permission for brctl tool failed to launch in adb mode with enforcing mode enabled.

Below avc denials that are fixed with this patch -

avc:  denied  { read write } for  pid=1407 comm="brctl" path="/dev/pts/0" dev="devpts" ino=3
scontext=system_u:system_r:brctl_t:s0
tcontext=system_u:object_r:initrc_devpts_t:s0 tclass=chr_file permissive=0