### PR TITLE
ofono: introduce dedicated SELinux domain ofono_t

### DIFF
--- a/policy/modules/services/ofono.fc
+++ b/policy/modules/services/ofono.fc
@@ -1,0 +1,1 @@
+/usr/sbin/ofonod    --   gen_context(system_u:object_r:ofono_exec_t,s0)

--- a/policy/modules/services/ofono.if
+++ b/policy/modules/services/ofono.if
@@ -1,0 +1,9 @@
+## <summary>ofono</summary>
+#
+## <desc>
+## oFono is a stack for mobile telephony devices on Linux.
+## oFono supports speaking to telephony devices through specific drivers,
+## or with generic AT commands.
+##
+## https://git.kernel.org/pub/scm/network/ofono/ofono.git
+## </desc>

--- a/policy/modules/services/ofono.te
+++ b/policy/modules/services/ofono.te
@@ -1,0 +1,43 @@
+policy_module(ofono, 1.0)
+
+########################################
+#
+# Declarations
+#
+
+type ofono_t;
+type ofono_exec_t;
+
+init_daemon_domain(ofono_t, ofono_exec_t)
+
+########################################
+#
+# Local Policy
+#
+
+allow ofono_t self:capability net_admin;
+allow ofono_t self:bluetooth_socket create_stream_socket_perms;
+allow ofono_t self:netlink_kobject_uevent_socket create_socket_perms;
+allow ofono_t self:netlink_route_socket create_netlink_socket_perms;
+allow ofono_t self:unix_dgram_socket { connect create write };
+
+# Read generic sysfs entries for device enumeration (bus traversal, PCI devices)
+# and reading 'uevent' files for hardware capabilities.
+dev_read_sysfs(ofono_t)
+
+files_map_usr_files(ofono_t)
+files_read_etc_files(ofono_t)
+files_read_usr_files(ofono_t)
+
+logging_send_syslog_msg(ofono_t)
+
+init_dbus_chat(ofono_t)
+
+udev_search_runtime(ofono_t)
+udev_read_runtime_files(ofono_t)
+
+bluetooth_dbus_chat(ofono_t)
+
+dbus_system_bus_client(ofono_t)
+dbus_connect_system_bus(ofono_t)
+dbus_send_system_bus(ofono_t)


### PR DESCRIPTION
Currently, the ofono daemon runs in the generic `initrc_t` domain. While functional, this configuration lacks proper process isolation and violates the principle of least privilege.

Define a dedicated domain (`ofono_t`) to confine the service, ensuring it operates in a restricted environment isolated from other init processes.

Grant the necessary permissions to resolve AVC denials observed during the transition to enforcing mode:

*   DBus: Allow service registration on the system bus and communication
    with `org.bluez`.
*   Network: Allow `net_admin` capability and netlink socket creation
    (route and kobject_uevent) for rmnet and udev handling.
*   Filesystem: Authorize read access to configuration files in `/etc`
    and `/usr`, and traversal of `/sys` and `/run/udev`.
*   Logging: Allow write access to `/dev/log` for syslog integration.