### PR TITLE
userdomain: Remove permissions from unprivileged user

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -991,10 +991,9 @@ template(`userdom_login_user_template', `
 	# User domain Local policy
 	#
 
-	allow $1_t self:capability { chown fowner setgid };
 	dontaudit $1_t self:capability { fsetid sys_nice };
 
-	allow $1_t self:process { dyntransition getattr getcap getpgid getrlimit getsched getsession noatsecure ptrace rlimitinh setcap setfscreate setkeycreate setpgid setsched setsockcreate share siginh signal_perms transition };
+	allow $1_t self:process { dyntransition getattr getcap getpgid getrlimit getsched getsession noatsecure rlimitinh setcap setfscreate setkeycreate setpgid setsched setsockcreate share siginh signal_perms transition };
 	dontaudit $1_t self:process setrlimit;
 	dontaudit $1_t self:netlink_route_socket { append bind connect create getattr getopt ioctl nlmsg_read nlmsg_write read setattr setopt shutdown write };
 
@@ -1370,7 +1369,7 @@ template(`userdom_admin_user_template',`
 
 	allow $1_t self:capability { chown dac_override dac_read_search fowner fsetid ipc_lock ipc_owner kill lease linux_immutable mknod net_admin net_bind_service net_broadcast net_raw setfcap setgid setpcap setuid sys_admin sys_boot sys_chroot sys_nice sys_pacct sys_ptrace sys_rawio sys_resource sys_time sys_tty_config };
 	allow $1_t self:cap_userns sys_ptrace;
-	allow $1_t self:process { setexec setfscreate };
+	allow $1_t self:process { ptrace setexec setfscreate };
 	allow $1_t self:netlink_audit_socket nlmsg_readpriv;
 	allow $1_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
 	allow $1_t self:tun_socket create;


### PR DESCRIPTION
I am using userdom_unpriv_user_template() to create an unprivileged user.  That user was getting capabilities for chown, fowner and setgid.  Unrpivileged users were also allowed process ptrace, which I moved into
userdom_admin_user_template().

After dropping these permissions, those users were still able to login to the console and GUI (lightdm/icewm - on RHEL9)

Note that this does not affect admin users - which get the capabilities in userdom_admin_user_template()