### PR TITLE
systemd: systemd-pcrphase read /etc/crypto-policies

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1840,6 +1840,8 @@ dev_read_sysfs(systemd_pcrphase_t)
 dev_rw_tpm(systemd_pcrphase_t)
 dev_write_kmsg(systemd_pcrphase_t)
 
+# read /etc/crypto-policies
+files_read_etc_files(systemd_pcrphase_t)
 # read /etc/machine-id
 files_read_etc_runtime_files(systemd_pcrphase_t)
 files_search_var_lib(systemd_pcrphase_t)


### PR DESCRIPTION
node=localhost type=AVC msg=audit(1769136380,332:83): avc: denied { getattr } for pid=857 comm="systemd-pcrphas" path="/etc/crypto-policies/back-ends/opensslcnf.config" dev="dm-0" ino=262166 scontext=system_u:system_r:systemd_pcrphase_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=0
node=localhost type AVC msg=audit(1769136380.333:84): avc: denied { read } for pid=857 comm="systemd-pcrphas" name="openssl_fips.config" dev="dm-0" ino=262162 scontext=system_u:system_r:systemd_pcrphase_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=0
node=localhost type=AVC msg=audit(1769136383.934:355): avc: denied { getattr } for pid=1152 comm="systemd-pcrphas" path="/etc/crypto-policies/back-ends/opensslcnf.config" dev="dm-0" ino=262166 scontext=system_u:system_r:systemd_pcrphase_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=0
node=localhost type=AVC msg-audit(1769136383.934:356): avc: denied { read } for pid=1152 comm="systemd-pcrphas" name="openssl_fips.config" dev="dm-0" ino=262162 scontext=system_u:system_r:systemd_pcrphase_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=0
node=localhost type=AVC msg=audit(1769136384.742:466): avc: denied { getattr } for pid=1180 comm="systemd-pcrphas" path="/etc/crypto-policies/back-ends/opensslcnf.config" dev="dm-0" ino=262166 scontext=system_u:system_r:systemd_pcrphase_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=0
node=localhost type=AVC msg=audit(1769136384.742:467): avc: denied { read } for pid=1180 comm="systemd-pcrphas" name="openssl_fips.config" dev="dm-0" ino=262162 scontext=system_u:system_r:systemd_pcrphase_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=0