### PR TITLE
dbus: Remove permissions from unprivileged user

### DIFF
--- a/policy/modules/services/dbus.if
+++ b/policy/modules/services/dbus.if
@@ -112,7 +112,7 @@ template(`dbus_role_template',`
 	can_exec($1_dbusd_t, dbusd_exec_t)
 
 	ps_process_pattern($3, $1_dbusd_t)
-	allow $3 $1_dbusd_t:process { ptrace signal_perms };
+	allow $3 $1_dbusd_t:process signal_perms;
 
 	allow $1_dbusd_t $3:process sigkill;
 	allow $1_dbusd_t session_dbusd_tmp_t:sock_file manage_sock_file_perms;


### PR DESCRIPTION
Unprivileged users had process ptrace permissions of the dbus-broker process.  After removing this access I still saw the dbus-broker process running and dbus interaction functional.

Tested on RHEL9 lightdm/icewm.