### PR TITLE
ofono: allow ofonod to read localization file

### DIFF
--- a/policy/modules/services/ofono.te
+++ b/policy/modules/services/ofono.te
@@ -41,3 +41,5 @@ bluetooth_dbus_chat(ofono_t)
 dbus_system_bus_client(ofono_t)
 dbus_connect_system_bus(ofono_t)
 dbus_send_system_bus(ofono_t)
+
+miscfiles_read_localization(ofono_t)


### PR DESCRIPTION
Fixes:
avc: denied { search } for pid=345 comm="ofonod" name="zoneinfo" dev="vda" ino=63391 scontext=system_u:system_r:ofono_t tcontext=system_u:object_r locale_t tclass=dir permissive=1

avc: denied { read } for pid=345 comm="ofonod" name="Universal" dev="vda" ino=64006 scontext=system_u:system_r:ofono_t tcontext=system_u:object_r:locale_t tclass=file permissive=1

avc: denied { open } for pid=345 comm="ofonod" path="/usr/share/zoneinfo/Universal" dev="vda" ino=64006 scontext=system_u:system_r:ofono_t tcontext=system_u:object_r:locale_t tclass=file permissive=1