### PR TITLE
systemd: fixes for systemd-user-runtime-dir

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2442,7 +2442,11 @@ allow systemd_user_runtime_dir_t systemd_user_runtime_notify_t:sock_file delete_
 
 allow systemd_user_runtime_dir_t systemd_userdbd_runtime_t:dir list_dir_perms;
 
+stream_connect_pattern(systemd_user_runtime_dir_t, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t, systemd_userdbd_t)
+
 files_read_etc_files(systemd_user_runtime_dir_t)
+# read /etc/machine-id
+files_read_etc_runtime_files(systemd_user_runtime_dir_t)
 
 fs_mount_tmpfs(systemd_user_runtime_dir_t)
 fs_getattr_tmpfs(systemd_user_runtime_dir_t)


### PR DESCRIPTION
Allow systemd-user-runtime-dir to connect to
/run/systemd/userdb/io.systemd.Multiplexer and read /etc/machine-id.

Fixes:
avc: denied { write } for pid=426 comm="systemd-user-ru" name="io.systemd.Multiplexer" dev="tmpfs" ino=63 scontext=system_u:system_r:systemd_user_runtime_dir_t tcontext=system_u:object_r:systemd_userdbd_runtime_t tclass=sock_file permissive=1

avc: denied { connectto } for pid=426 comm="systemd-user-ru" path="/run/systemd/userdb/io.systemd.Multiplexer" scontext=system_u:system_r:systemd_user_runtime_dir_t tcontext=system_u:system_r:systemd_userdbd_t tclass=unix_stream_socket permissive=1

avc: denied { read } for pid=426 comm="systemd-user-ru" name="machine-id" dev="vda" ino=118 scontext=system_u:system_r:systemd_user_runtime_dir_t tcontext=system_u:object_r:etc_runtime_t tclass=file permissive=1

avc: denied { open } for pid=426 comm="systemd-user-ru" path="/etc/machine-id" dev="vda" ino=118 scontext=system_u:system_r:systemd_user_runtime_dir_t tcontext=system_u:object_r:etc_runtime_t tclass=file permissive=1