### PR TITLE
sepolicy: Add sepolicy rules for bluetooth Notify failures

### DIFF
--- a/policy/modules/services/bluetooth.te
+++ b/policy/modules/services/bluetooth.te
@@ -157,6 +157,12 @@ optional_policy(`
 	optional_policy(`
 		systemd_dbus_chat_hostnamed(bluetooth_t)
 	')
+
+	optional_policy(`
+	    unconfined_use_fds(bluetooth_t)
+		unconfined_rw_stream_sockets(bluetooth_t)
+	')
+
 ')
 
 optional_policy(`
@@ -177,6 +183,7 @@ allow bluetooth_helper_t self:process getsched;
 allow bluetooth_helper_t self:fifo_file rw_fifo_file_perms;
 allow bluetooth_helper_t self:shm create_shm_perms;
 allow bluetooth_helper_t self:unix_stream_socket { accept connectto listen };
+allow bluetooth_helper_t self:bluetooth_socket create_socket_perms;
 
 allow bluetooth_helper_t bluetooth_t:socket { read write };
 allow bluetooth_helper_t bluetooth_t:fd use;

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -310,6 +310,7 @@ optional_policy(`
 optional_policy(`
 	unconfined_dbus_send(system_dbusd_t)
 	unconfined_use_fds(system_dbusd_t)
+	unconfined_rw_stream_sockets(system_dbusd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -491,6 +491,24 @@ interface(`unconfined_stream_connect',`
 
 ########################################
 ## <summary>
+##	Allow a domain to read and write
+##	to unconfined unix stream sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to grant permission to.
+##	</summary>
+## </param>
+#
+interface(`unconfined_rw_stream_sockets',`
+	gen_require(`
+		type unconfined_t;
+	')
+	allow $1 unconfined_t:unix_stream_socket rw_socket_perms;
+')
+
+########################################
+## <summary>
 ##      Do not audit attempts to read and write
 ##      unconfined domain stream.
 ## </summary>


### PR DESCRIPTION
Below are the avc denials fixed:
Jan 01 00:05:12 rb3gen2-core-kit audit[642]: AVC avc:  denied  { use } for  pid=642 comm="bluetoothd" path="socket:[27887]" dev="sockfs" ino=27887 scontext=system_u:system_r:bluetooth_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=fd permissive=1 Jan 01 00:06:21 rb3gen2-core-kit audit[1555]: AVC avc:  denied  { create } for  pid=1555 comm="bluetoothctl" scontext=system_u:system_r:bluetooth_helper_t:s0 tcontext=system_u:system_r:bluetooth_helper_t:s0 tclass=bluetooth_socket permissive=0 Jan 01 00:03:43 rb3gen2-core-kit audit[696]: AVC avc:  denied  { read write } for  pid=696 comm="dbus-daemon" path="socket:[20251]" dev="sockfs" ino=20251 scontext=system_u:system_r:system_dbusd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=0

Jan 01 00:22:32 rb3gen2-core-kit audit[2021]: AVC avc:  denied  { read write } for  pid=2021 comm="bluetoothd" path="socket:[25040]" dev="sockfs" ino=25040 scontext=system_u:system_r:bluetooth_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=0

https://lore.kernel.org/selinux-refpolicy/16042657-761b-4758-bc77-e92cdb50155a@ieee.org/T/#t