### PR TITLE
incus: update and extend module to work with recent incus versions

### DIFF
--- a/policy/modules/apps/qemu.if
+++ b/policy/modules/apps/qemu.if
@@ -208,6 +208,24 @@ interface(`qemu_read_state',`
 
 ########################################
 ## <summary>
+##	Get qemu process stats.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`qemu_getattr',`
+	gen_require(`
+		type qemu_t;
+	')
+
+	allow $1 qemu_t:process getattr;
+')
+
+########################################
+## <summary>
 ##	Set qemu scheduler.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/apps/qemu.if
+++ b/policy/modules/apps/qemu.if
@@ -360,6 +360,26 @@ interface(`qemu_domtrans_unconfined',`
 ########################################
 ## <summary>
 ##	Create, read, write, and delete
+##	qemu image symlinks.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`qemu_manage_image_symlinks',`
+	gen_require(`
+		type qemu_image_t;
+	')
+
+	manage_lnk_files_pattern($1, qemu_image_t, qemu_image_t)
+
+')
+
+########################################
+## <summary>
+##	Create, read, write, and delete
 ##	qemu temporary directories.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/apps/qemu.if
+++ b/policy/modules/apps/qemu.if
@@ -208,6 +208,27 @@ interface(`qemu_read_state',`
 
 ########################################
 ## <summary>
+##	Write qemu process state files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to allow access.
+##	</summary>
+## </param>
+#
+interface(`qemu_write_state',`
+	gen_require(`
+		type qemu_t;
+	')
+
+	kernel_search_proc($1)
+	allow $1 qemu_t:dir list_dir_perms;
+	allow $1 qemu_t:file write_file_perms;
+	allow $1 qemu_t:lnk_file read_lnk_file_perms;
+')
+
+########################################
+## <summary>
 ##	Get qemu process stats.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/apps/qemu.te
+++ b/policy/modules/apps/qemu.te
@@ -57,12 +57,19 @@ tunable_policy(`qemu_full_network',`
 
 optional_policy(`
 	tunable_policy(`qemu_incus_managed',`
+		allow qemu_t self:process setrlimit;
+
 		incus_stream_connect_daemon(qemu_t)
 
 		files_create_generic_tmp_named_sockets(qemu_t)
+		# read /etc/machine-id
+		files_read_etc_runtime_files(qemu_t)
+
+		fs_read_cgroup_files(qemu_t)
 
 		kernel_read_kernel_sysctls(qemu_t)
 		kernel_read_vm_overcommit_sysctl(qemu_t)
+		kernel_rw_psi(qemu_t)
 
 		# incus VMs do not start otherwise
 		allow qemu_t self:capability { dac_override dac_read_search setuid setgid };

--- a/policy/modules/kernel/selinux.if
+++ b/policy/modules/kernel/selinux.if
@@ -295,6 +295,25 @@ interface(`selinux_dontaudit_search_fs',`
 
 ########################################
 ## <summary>
+##	Read selinuxfs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`selinux_read_fs',`
+	gen_require(`
+		type security_t;
+	')
+
+	allow $1 security_t:dir search_dir_perms;
+	allow $1 security_t:file read_file_perms;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to read
 ##	generic selinuxfs entries
 ## </summary>

--- a/policy/modules/services/container.if
+++ b/policy/modules/services/container.if
@@ -704,6 +704,25 @@ interface(`container_read_all_container_state',`
 
 ########################################
 ## <summary>
+##	Write the process state (/proc/pid)
+##	of all containers.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_write_all_container_state',`
+	gen_require(`
+		attribute container_domain;
+	')
+
+	allow $1 container_domain:file write_file_perms;
+')
+
+########################################
+## <summary>
 ##	Run all system container BPF programs.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/incus.if
+++ b/policy/modules/services/incus.if
@@ -158,3 +158,22 @@ interface(`incus_admin',`
 		rootlesskit_run($1, $2)
 	')
 ')
+
+######################################
+## <summary>
+##	Make incusd executable files an
+##	entrypoint for the specified domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	The domain for which incusd_exec_t is an entrypoint.
+##	</summary>
+## </param>
+#
+interface(`incus_entry_type',`
+	gen_require(`
+		type incusd_exec_t;
+	')
+
+	domain_entry_file($1, incusd_exec_t)
+')

--- a/policy/modules/services/incus.te
+++ b/policy/modules/services/incus.te
@@ -98,6 +98,9 @@ fs_watch_tmpfs_dirs(incusd_t)
 # name="stub-resolv.conf"
 fs_read_tmpfs_files(incusd_t)
 
+# required for incusd to start virtual networking
+init_signull_script(incusd_t)
+
 iptables_domtrans(incusd_t)
 iptables_kill(incusd_t)
 

--- a/policy/modules/services/incus.te
+++ b/policy/modules/services/incus.te
@@ -110,6 +110,9 @@ container_exec_engine_tmp_files(incusd_t)
 # comm="incusd" path="/run/systemd/resolve/stub-resolv.conf"
 container_read_tmpfs_files(incusd_t)
 
+# to write oom_score_adj
+container_write_all_container_state(incusd_t)
+
 ifdef(`init_systemd',`
 	init_get_system_status(incusd_t)
 	init_start_system(incusd_t)
@@ -166,6 +169,8 @@ optional_policy(`
 
 	qemu_kill(incusd_t)
 	qemu_stream_connect(incusd_t)
+	# to write oom_score_adj
+	qemu_write_state(incusd_t)
 
 	# avc:  denied  { read } for  pid=20404 comm="qemu-system-x86"
 	# name="overcommit_memory" dev="proc" ino=16557

--- a/policy/modules/services/incus.te
+++ b/policy/modules/services/incus.te
@@ -53,13 +53,24 @@ allow incusd_t self:vsock_socket create_stream_socket_perms;
 allow incusd_t self:rawip_socket create_socket_perms;
 allow incusd_t self:tun_socket { create relabelfrom relabelto };
 
+kernel_associate_proc(incusd_t)
+
 # mounton access to /proc/sys/kernel/random/boot_id
 kernel_mounton_kernel_sysctl_files(incusd_t)
+
+kernel_relabelfrom_unlabeled_dirs(incusd_t)
+kernel_relabelfrom_unlabeled_files(incusd_t)
+kernel_relabelfrom_unlabeled_symlinks(incusd_t)
+kernel_relabelfrom_unlabeled_blk_devs(incusd_t)
+kernel_relabelfrom_unlabeled_chr_devs(incusd_t)
 
 # incusd wants to load netdev-phys*
 kernel_request_load_module(incusd_t)
 
 kernel_setsched(incusd_t)
+
+selinux_getattr_dirs(incusd_t)
+selinux_read_fs(incusd_t)
 
 # for bridge management
 dev_create_sysfs_files(incusd_t)
@@ -79,6 +90,7 @@ dev_watch_dev_fs(incusd_t)
 
 # read /etc/machine-id
 files_read_etc_runtime_files(incusd_t)
+files_mounton_non_security(incusd_t)
 
 # incus apparmor support wants to handle /sys/kernel/tracing
 fs_dontaudit_getattr_configfs(incusd_t)
@@ -161,6 +173,8 @@ optional_policy(`
 	# these are required for incusd to check and execute qemu
 	qemu_domtrans(incusd_t)
 	qemu_exec(incusd_t)
+	qemu_getattr(incusd_t)
+	qemu_manage_image_symlinks(incusd_t)
 
 	# required so that incus will get the VM PID
 	# and make "incus info VM" work
@@ -171,6 +185,9 @@ optional_policy(`
 	qemu_stream_connect(incusd_t)
 	# to write oom_score_adj
 	qemu_write_state(incusd_t)
+
+	virt_manage_images(incusd_t)
+	virt_relabel_images(incusd_t)
 
 	# avc:  denied  { read } for  pid=20404 comm="qemu-system-x86"
 	# name="overcommit_memory" dev="proc" ino=16557

--- a/policy/modules/services/virt.if
+++ b/policy/modules/services/virt.if
@@ -1046,6 +1046,29 @@ interface(`virt_manage_images',`
 
 ########################################
 ## <summary>
+##	Relabel virt image.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_relabel_images',`
+	gen_require(`
+		attribute virt_image_type;
+	')
+
+	allow $1 virt_image_type:dir relabel_dir_perms;
+	allow $1 virt_image_type:file relabel_file_perms;
+	allow $1 virt_image_type:fifo_file relabel_fifo_file_perms;
+	allow $1 virt_image_type:lnk_file relabel_lnk_file_perms;
+	allow $1 virt_image_type:sock_file relabel_sock_file_perms;
+	allow $1 virt_image_type:blk_file relabel_blk_file_perms;
+')
+
+########################################
+## <summary>
 ##	Inherit and use virtd lxc
 ##	file descriptors.
 ## </summary>


### PR DESCRIPTION
In this PR
- incus: Fix starting of virtual networking in Incus version >=6.15
- incus: Add rule that lets Incus detect SELinux on a system
- incus: Add new rules required for improved SELinux support in Incus 7
- virt: Add new interface required by Incus
- container: Add new interface required by Incus
- qemu:  Add new interfaces required by Incus
- qemu: Update Incus support for new Incus versions

Edit: Rewrote description