### PR TITLE
Add SELinux policy support for Userspace Resource Manager (URM)

### DIFF
--- a/policy/modules/services/urm.fc
+++ b/policy/modules/services/urm.fc
@@ -1,0 +1,4 @@
+/usr/bin/urm           --      gen_context(system_u:object_r:urm_exec_t,s0)
+/run/restune_sock      -s      gen_context(system_u:object_r:urm_runtime_t,s0)
+/etc/urm               --      gen_context(system_u:object_r:urm_etc_t,s0)
+/etc/urm(/.*)?                 gen_context(system_u:object_r:urm_config_t,s0)

--- a/policy/modules/services/urm.fc
+++ b/policy/modules/services/urm.fc
@@ -1,4 +1,3 @@
 /usr/bin/urm           --      gen_context(system_u:object_r:urm_exec_t,s0)
 /run/restune_sock      -s      gen_context(system_u:object_r:urm_runtime_t,s0)
-/etc/urm               --      gen_context(system_u:object_r:urm_etc_t,s0)
 /etc/urm(/.*)?                 gen_context(system_u:object_r:urm_config_t,s0)

--- a/policy/modules/services/urm.fc
+++ b/policy/modules/services/urm.fc
@@ -1,3 +1,3 @@
-/usr/bin/urm           --      gen_context(system_u:object_r:urm_exec_t,s0)
-/run/restune_sock      -s      gen_context(system_u:object_r:urm_runtime_t,s0)
 /etc/urm(/.*)?                 gen_context(system_u:object_r:urm_config_t,s0)
+/run/restune_sock      -s      gen_context(system_u:object_r:urm_runtime_t,s0)
+/usr/bin/urm           --      gen_context(system_u:object_r:urm_exec_t,s0)

--- a/policy/modules/services/urm.if
+++ b/policy/modules/services/urm.if
@@ -1,0 +1,67 @@
+## <summary>>Policy for the URM (Username Resource Manager) service.</summary>
+## <desc>
+##      <p>
+##              URM (Username Resource Manager) is a system service
+##              that manages CPU, IRQ, and cgroup resources per
+##              username for optimizing system performance.
+##      </p>
+## </desc>
+#
+
+########################################
+## <summary>
+##      Read the URM configuration files.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`urm_read_config',`
+        gen_require(`
+                type urm_config_t;
+        ')
+
+        files_search_etc($1)
+        allow $1 urm_config_t:dir list_dir_perms;
+        read_files_pattern($1, urm_config_t, urm_config_t)
+        read_lnk_files_pattern($1, urm_config_t, urm_config_t)
+')
+
+######################################
+## <summary>
+##      Allow the specified domain to read and write
+##      urm runtime sockets.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`urm_rw_runtime_socket',`
+    gen_require(`
+        type urm_runtime_t;
+    ')
+    allow $1 urm_runtime_t:sock_file rw_sock_file_perms;
+')
+
+########################################
+## <summary>
+##      Connect to urm with a unix socket.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`urm_unix_stream_socket_connectto',`
+        gen_require(`
+                type urm_t, urm_runtime_t;
+        ')
+        aloow $1 urm_runtime_t:sock_file write;
+        allow $1 urm_t:unix_stream_socket connectto;
+')

--- a/policy/modules/services/urm.if
+++ b/policy/modules/services/urm.if
@@ -1,4 +1,4 @@
-## <summary>>Policy for the URM (Username Resource Manager) service.</summary>
+## <summary> Policy for the URM (Username Resource Manager) service.</summary>
 ## <desc>
 ##      <p>
 ##              URM (Username Resource Manager) is a system service
@@ -17,7 +17,6 @@
 ##      Domain allowed access.
 ##      </summary>
 ## </param>
-## <rolecap/>
 #
 interface(`urm_read_config',`
         gen_require(`
@@ -62,6 +61,5 @@ interface(`urm_unix_stream_socket_connectto',`
         gen_require(`
                 type urm_t, urm_runtime_t;
         ')
-        aloow $1 urm_runtime_t:sock_file write;
         allow $1 urm_t:unix_stream_socket connectto;
 ')

--- a/policy/modules/services/urm.if
+++ b/policy/modules/services/urm.if
@@ -29,27 +29,9 @@ interface(`urm_read_config',`
         read_lnk_files_pattern($1, urm_config_t, urm_config_t)
 ')
 
-######################################
-## <summary>
-##      Allow the specified domain to read and write
-##      urm runtime sockets.
-## </summary>
-## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
-## </param>
-#
-interface(`urm_rw_runtime_socket',`
-    gen_require(`
-        type urm_runtime_t;
-    ')
-    allow $1 urm_runtime_t:sock_file rw_sock_file_perms;
-')
-
 ########################################
 ## <summary>
-##      Connect to urm with a unix socket.
+##      Connect to urm with a unix stream socket.
 ## </summary>
 ## <param name="domain">
 ##      <summary>
@@ -57,9 +39,11 @@ interface(`urm_rw_runtime_socket',`
 ##      </summary>
 ## </param>
 #
-interface(`urm_unix_stream_socket_connectto',`
+interface(`urm_stream_connectto',`
         gen_require(`
                 type urm_t, urm_runtime_t;
         ')
-        allow $1 urm_t:unix_stream_socket connectto;
+        
+        allow $1 urm_runtime_t:sock_file rw_sock_file_perms;
+        stream_connect_pattern($1, urm_runtime_t, urm_runtime_t, urm_t)
 ')

--- a/policy/modules/services/urm.if
+++ b/policy/modules/services/urm.if
@@ -39,7 +39,7 @@ interface(`urm_read_config',`
 ##      </summary>
 ## </param>
 #
-interface(`urm_stream_connectto',`
+interface(`urm_stream_connect',`
         gen_require(`
                 type urm_t, urm_runtime_t;
         ')

--- a/policy/modules/services/urm.te
+++ b/policy/modules/services/urm.te
@@ -1,0 +1,119 @@
+## <summary>
+##      Policy for the URM (Username-Resource-Manager) service.
+## </summary>
+
+policy_module(urm)
+
+########################################
+#
+# Declarations
+#
+
+type urm_t;
+type urm_exec_t;
+init_daemon_domain(urm_t, urm_exec_t)
+
+type urm_config_t;
+
+type urm_runtime_t;
+files_runtime_file(urm_runtime_t)
+
+type urm_etc_t;
+
+########################################
+#
+# urm local policy
+#
+
+# Send log messages to syslog
+logging_send_syslog_msg(urm_t)
+
+# Read per-username resource configuration files under /etc/urm
+urm_read_config(urm_t)
+
+# Read and write sysfs entries for CPU frequency
+# scaling and IRQ affinity management
+dev_rw_sysfs(urm_t)
+
+# Access /dev/cpu_dma_latency for PM QoS
+# to manage power and latency per username
+dev_rw_pmqos(urm_t)
+
+# Read kernel sysctls e.g. sched_util_clamp_min
+kernel_read_kernel_sysctls(urm_t)
+
+# Read system state from /proc for monitoring
+# per-username resource usage
+kernel_read_system_state(urm_t)
+
+# Request kernel module loading e.g. netlink connector
+kernel_request_load_module(urm_t)
+
+# Read and write IRQ sysctls /proc/irq/*/smp_affinity
+# for per-username IRQ affinity management
+kernel_rw_irq_sysctls(urm_t)
+
+# Read and write cgroup files for
+# per-username resource group management
+fs_rw_cgroup_files(urm_t)
+
+# Read all domain process state /proc/<pid>
+# for per-username process resource monitoring
+domain_read_all_domains_state(urm_t)
+
+# Create runtime socket transition under /run
+files_runtime_filetrans(urm_t, urm_runtime_t, sock_file)
+
+########################################
+#
+# Allow urm to manage its runtime socket
+# under /run for client communication
+#
+
+allow urm_t urm_runtime_t:sock_file manage_sock_file_perms;
+
+########################################
+#
+# Netlink connector socket access
+#
+
+allow urm_t self:netlink_connector_socket { create_socket_perms read };
+allow urm_t self:unix_stream_socket { create connectto };
+dontaudit urm_t self: capability net_admin;
+
+########################################
+#
+# Allow urm to read and write kernel sysctl files
+# e.g. sched_util_clamp_min, sched_util_clamp_max
+# for per-username CPU scheduling resource management
+#
+
+allow urm_t sysctl_kernel_t:file { read write open getattr };
+
+########################################
+#
+# Allow urm to read and write its own config files
+# e.g. scaling_max_freq.txt for per-username
+# CPU frequency scaling settings
+#
+
+allow urm_t urm_config_t:file { read write open getattr };
+
+########################################
+#
+# Allow urm to manage /etc/urm directory
+# for storing per-username resource configurations
+#
+
+allow urm_t urm_etc_t:dir { search write create execute };
+allow urm_t urm_etc_t:file { read write open getattr create };
+
+########################################
+#
+# Allow urm to create and manage cgroup subdirectories
+# e.g. /sys/fs/cgroup/camera-cgroup for
+# per-username resource group isolation
+#
+type cgroup_t;
+allow urm_t cgroup_t:dir { add_name create write search read open getattr };
+allow urm_t cgroup_t:file { create write read open getattr };

--- a/policy/modules/services/urm.te
+++ b/policy/modules/services/urm.te
@@ -29,13 +29,11 @@ files_runtime_file(urm_runtime_t)
 allow urm_t urm_runtime_t:sock_file manage_sock_file_perms;
 
 # Netlink connector socket access
-allow urm_t self:netlink_connector_socket { create_socket_perms read };
+allow urm_t self:netlink_connector_socket create_socket_perms;
 allow urm_t self:unix_stream_socket { create connectto };
 
 # Suppress spurious capability denials
-dontaudit urm_t self:capability net_admin;
-dontaudit urm_t self:capability dac_override;
-dontaudit urm_t self:capability dac_read_search;
+dontaudit urm_t self:capability { dac_override dac_read_search net_admin };
 
 # Read and write its own config files
 # e.g. scaling_max_freq.txt for per-username

--- a/policy/modules/services/urm.te
+++ b/policy/modules/services/urm.te
@@ -24,6 +24,24 @@ files_runtime_file(urm_runtime_t)
 # urm local policy
 #
 
+# Allow urm to manage its runtime socket
+# under /run for client communication
+allow urm_t urm_runtime_t:sock_file manage_sock_file_perms;
+
+# Netlink connector socket access
+allow urm_t self:netlink_connector_socket { create_socket_perms read };
+allow urm_t self:unix_stream_socket { create connectto };
+
+# Suppress spurious capability denials
+dontaudit urm_t self:capability net_admin;
+dontaudit urm_t self:capability dac_override;
+dontaudit urm_t self:capability dac_read_search;
+
+# Read and write its own config files
+# e.g. scaling_max_freq.txt for per-username
+# CPU frequency scaling settings
+allow urm_t urm_config_t:file rw_file_perms;
+
 # Send log messages to syslog
 logging_send_syslog_msg(urm_t)
 
@@ -60,28 +78,6 @@ fs_create_cgroup_dirs(urm_t)
 # Read all domain process state /proc/<pid>
 # for per-username process resource monitoring
 domain_read_all_domains_state(urm_t)
-
-# Allow urm to manage its runtime socket
-# under /run for client communication
-allow urm_t urm_runtime_t:sock_file manage_sock_file_perms;
-
-# Netlink connector socket access
-allow urm_t self:netlink_connector_socket { create_socket_perms read };
-allow urm_t self:unix_stream_socket { create connectto };
-
-# Suppress spurious capability denials
-dontaudit urm_t self:capability net_admin;
-dontaudit urm_t self:capability dac_override;
-dontaudit urm_t self:capability dac_read_search;
-
-# Read and write its own config files
-# e.g. scaling_max_freq.txt for per-username
-# CPU frequency scaling settings
-allow urm_t urm_config_t:file rw_file_perms;
-
-# Read and write /etc/urm directory for
-# storing per-username resource configurations
-# rw_files_pattern(urm_t, urm_etc_t, urm_etc_t)
 
 # Create and manage cgroup subdirectories
 # for per-username resource group isolation

--- a/policy/modules/services/urm.te
+++ b/policy/modules/services/urm.te
@@ -14,11 +14,10 @@ type urm_exec_t;
 init_daemon_domain(urm_t, urm_exec_t)
 
 type urm_config_t;
+files_config_file(urm_config_t)
 
 type urm_runtime_t;
 files_runtime_file(urm_runtime_t)
-
-type urm_etc_t;
 
 ########################################
 #
@@ -40,7 +39,7 @@ dev_rw_sysfs(urm_t)
 dev_rw_pmqos(urm_t)
 
 # Read kernel sysctls e.g. sched_util_clamp_min
-kernel_read_kernel_sysctls(urm_t)
+kernel_rw_kernel_sysctl(urm_t)
 
 # Read system state from /proc for monitoring
 # per-username resource usage
@@ -53,67 +52,40 @@ kernel_request_load_module(urm_t)
 # for per-username IRQ affinity management
 kernel_rw_irq_sysctls(urm_t)
 
-# Read and write cgroup files for
+# Read and write cgroup files/dirs for
 # per-username resource group management
 fs_rw_cgroup_files(urm_t)
+fs_create_cgroup_dirs(urm_t)
 
 # Read all domain process state /proc/<pid>
 # for per-username process resource monitoring
 domain_read_all_domains_state(urm_t)
 
-# Create runtime socket transition under /run
-files_runtime_filetrans(urm_t, urm_runtime_t, sock_file)
-
-########################################
-#
 # Allow urm to manage its runtime socket
 # under /run for client communication
-#
-
 allow urm_t urm_runtime_t:sock_file manage_sock_file_perms;
 
-########################################
-#
 # Netlink connector socket access
-#
-
 allow urm_t self:netlink_connector_socket { create_socket_perms read };
 allow urm_t self:unix_stream_socket { create connectto };
-dontaudit urm_t self: capability net_admin;
 
-########################################
-#
-# Allow urm to read and write kernel sysctl files
-# e.g. sched_util_clamp_min, sched_util_clamp_max
-# for per-username CPU scheduling resource management
-#
+# Suppress spurious capability denials
+dontaudit urm_t self:capability net_admin;
+dontaudit urm_t self:capability dac_override;
+dontaudit urm_t self:capability dac_read_search;
 
-allow urm_t sysctl_kernel_t:file { read write open getattr };
-
-########################################
-#
-# Allow urm to read and write its own config files
+# Read and write its own config files
 # e.g. scaling_max_freq.txt for per-username
 # CPU frequency scaling settings
-#
+allow urm_t urm_config_t:file rw_file_perms;
 
-allow urm_t urm_config_t:file { read write open getattr };
+# Read and write /etc/urm directory for
+# storing per-username resource configurations
+# rw_files_pattern(urm_t, urm_etc_t, urm_etc_t)
 
-########################################
-#
-# Allow urm to manage /etc/urm directory
-# for storing per-username resource configurations
-#
+# Create and manage cgroup subdirectories
+# for per-username resource group isolation
+fs_create_cgroup_files(urm_t)
 
-allow urm_t urm_etc_t:dir { search write create execute };
-allow urm_t urm_etc_t:file { read write open getattr create };
-
-########################################
-#
-# Allow urm to create and manage cgroup subdirectories
-# e.g. /sys/fs/cgroup/camera-cgroup for
-# per-username resource group isolation
-#
-type cgroup_t;
-allow urm_t cgroup_t:dir { add_name create write search read open getattr };
-allow urm_t cgroup_t:file { create write read open getattr };
+# Create runtime socket transition under /run
+files_runtime_filetrans(urm_t, urm_runtime_t, sock_file)

--- a/policy/modules/services/urm.te
+++ b/policy/modules/services/urm.te
@@ -1,7 +1,3 @@
-## <summary>
-##      Policy for the URM (Username-Resource-Manager) service.
-## </summary>
-
 policy_module(urm)
 
 ########################################
@@ -9,12 +5,12 @@ policy_module(urm)
 # Declarations
 #
 
-type urm_t;
-type urm_exec_t;
-init_daemon_domain(urm_t, urm_exec_t)
-
 type urm_config_t;
 files_config_file(urm_config_t)
+
+type urm_exec_t;
+type urm_t;
+init_daemon_domain(urm_t, urm_exec_t)
 
 type urm_runtime_t;
 files_runtime_file(urm_runtime_t)
@@ -24,38 +20,50 @@ files_runtime_file(urm_runtime_t)
 # urm local policy
 #
 
-# Allow urm to manage its runtime socket
-# under /run for client communication
-allow urm_t urm_runtime_t:sock_file manage_sock_file_perms;
+# Suppress spurious capability denials
+dontaudit urm_t self:capability { dac_override dac_read_search net_admin };
 
 # Netlink connector socket access
 allow urm_t self:netlink_connector_socket create_socket_perms;
-allow urm_t self:unix_stream_socket { create connectto };
 
-# Suppress spurious capability denials
-dontaudit urm_t self:capability { dac_override dac_read_search net_admin };
+# Unix stream socket for client-server communication
+allow urm_t self:unix_stream_socket { create connectto };
 
 # Read and write its own config files
 # e.g. scaling_max_freq.txt for per-username
 # CPU frequency scaling settings
 allow urm_t urm_config_t:file rw_file_perms;
 
-# Send log messages to syslog
-logging_send_syslog_msg(urm_t)
+# Allow urm to manage its runtime socket
+# under /run for client communication
+allow urm_t urm_runtime_t:sock_file manage_sock_file_perms;
 
-# Read per-username resource configuration files under /etc/urm
-urm_read_config(urm_t)
-
-# Read and write sysfs entries for CPU frequency
-# scaling and IRQ affinity management
-dev_rw_sysfs(urm_t)
+# Create runtime socket transition under /run
+files_runtime_filetrans(urm_t, urm_runtime_t, sock_file)
 
 # Access /dev/cpu_dma_latency for PM QoS
 # to manage power and latency per username
 dev_rw_pmqos(urm_t)
 
-# Read kernel sysctls e.g. sched_util_clamp_min
-kernel_rw_kernel_sysctl(urm_t)
+# Read and write sysfs entries for CPU frequency
+# scaling and IRQ affinity management
+dev_rw_sysfs(urm_t)
+
+# Read all domain process state /proc/<pid>
+# for per-username process resource monitoring
+domain_read_all_domains_state(urm_t)
+
+# Create camera and other cgroup directories
+# for per-username resource group isolation
+fs_create_cgroup_dirs(urm_t)
+
+# Create and manage cgroup files
+# for per-username resource group isolation
+fs_create_cgroup_files(urm_t)
+
+# Read and write cgroup files/dirs for
+# per-username resource group management
+fs_rw_cgroup_files(urm_t)
 
 # Read system state from /proc for monitoring
 # per-username resource usage
@@ -68,18 +76,12 @@ kernel_request_load_module(urm_t)
 # for per-username IRQ affinity management
 kernel_rw_irq_sysctls(urm_t)
 
-# Read and write cgroup files/dirs for
-# per-username resource group management
-fs_rw_cgroup_files(urm_t)
-fs_create_cgroup_dirs(urm_t)
+# Read and write kernel sysctls e.g. sched_util_clamp_min
+# for per-username CPU scheduling resource management
+kernel_rw_kernel_sysctl(urm_t)
 
-# Read all domain process state /proc/<pid>
-# for per-username process resource monitoring
-domain_read_all_domains_state(urm_t)
+# Send log messages to syslog
+logging_send_syslog_msg(urm_t)
 
-# Create and manage cgroup subdirectories
-# for per-username resource group isolation
-fs_create_cgroup_files(urm_t)
-
-# Create runtime socket transition under /run
-files_runtime_filetrans(urm_t, urm_runtime_t, sock_file)
+# Read per-username resource configuration files under /etc/urm
+urm_read_config(urm_t)


### PR DESCRIPTION
Add SELinux policy definitions for the URM (Username Resource Manager) service, which manages CPU, IRQ, and cgroup resources per username for optimizing system performance.

Changes include:
- urm.fc: File context definitions mapping:
  - /usr/bin/urm binary to urm_exec_t
  - /run/restune_sock runtime socket to urm_runtime_t
  - /etc/urm(/.*)? configuration files to urm_config_t

- urm.te: Type declarations for 3 types:
  - urm_t: URM daemon process domain
  - urm_exec_t: URM executable
  - urm_config_t: URM configuration files under /etc/urm
  - urm_runtime_t: URM runtime socket under /run

  Policy rules include:
  - Syslog access for logging
  - sysfs read/write for CPU frequency scaling and IRQ affinity
  - PM QoS access via /dev/cpu_dma_latency
  - Kernel sysctl read/write for scheduler resource clamping
  - System state read from /proc for resource monitoring
  - Kernel module request for netlink connector
  - IRQ sysctl read/write for per-username IRQ affinity management
  - Cgroup file and directory management for resource group isolation
  - Netlink connector socket for kernel-userspace communication
  - Unix stream socket for client-server communication
  - Runtime socket transition under /run for client communication

- urm.if: Three interface definitions:
  - urm_read_config(): allows domains to read URM configuration
    files under /etc/urm
  - urm_rw_runtime_socket(): allows domains to read and write
    URM runtime socket under /run
  - urm_unix_stream_socket_connectto(): allows domains to connect
    to URM via unix domain stream socket