### PR TITLE
refpolicy: label busybox.suid and restrict setuid BusyBox execution

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -22,10 +22,13 @@ files_tmp_file(netutils_tmp_t)
 type ping_t;
 type ping_exec_t;
 init_system_domain(ping_t, ping_exec_t)
+domain_execute_busybox_suid(ping_t)
+init_use_script_ptys(ping_t)
 
 type traceroute_t;
 type traceroute_exec_t;
 init_system_domain(traceroute_t, traceroute_exec_t)
+domain_execute_busybox_suid(traceroute_t)
 
 ########################################
 #

--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -384,6 +384,7 @@ userdom_read_user_tmp_files(passwd_t)
 # user generally runs this from their home directory, so do not audit a search
 # on user home dir
 userdom_dontaudit_search_user_home_content(passwd_t)
+domain_execute_busybox_suid(passwd_t)
 
 optional_policy(`
 	nscd_run(passwd_t, passwd_roles)

--- a/policy/modules/apps/vlock.te
+++ b/policy/modules/apps/vlock.te
@@ -41,3 +41,5 @@ miscfiles_read_localization(vlock_t)
 
 userdom_dontaudit_search_user_home_dirs(vlock_t)
 userdom_use_user_terminals(vlock_t)
+
+domain_execute_busybox_suid(vlock_t)

--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -173,6 +173,7 @@ ifdef(`distro_gentoo',`
 /usr/bin/tcsh			--	gen_context(system_u:object_r:shell_exec_t,s0)
 /usr/bin/yash			--	gen_context(system_u:object_r:shell_exec_t,s0)
 /usr/bin/zsh.*			--	gen_context(system_u:object_r:shell_exec_t,s0)
+/usr/bin/busybox\.suid          --      gen_context(system_u:object_r:busybox_suid_exec_t,s0)
 
 /usr/lib/(.*/)?bin(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/(.*/)?glib-2\.0(/.*)?		gen_context(system_u:object_r:bin_t,s0)

--- a/policy/modules/kernel/corecommands.if
+++ b/policy/modules/kernel/corecommands.if
@@ -842,3 +842,24 @@ interface(`corecmd_mmap_all_executables',`
 	corecmd_search_bin($1)
 	mmap_exec_files_pattern($1, bin_t, exec_type)
 ')
+
+######################################
+## <summary>
+## Allow a domain to execute the setuid BusyBox binary.
+## </summary>
+##
+## <param name="domain">
+## <summary>
+## Domain to be permitted execution of busybox.suid, which provides
+## privileged applets such as ping that require elevated capabilities
+## (e.g. raw socket access).
+## </summary>
+## </param>
+#
+interface(`domain_execute_busybox_suid',`
+    gen_require(`
+        type busybox_suid_exec_t;
+    ')
+
+    allow $1 busybox_suid_exec_t:file mmap_exec_file_perms;
+')

--- a/policy/modules/kernel/corecommands.te
+++ b/policy/modules/kernel/corecommands.te
@@ -26,3 +26,10 @@ corecmd_executable_file(shell_exec_t)
 
 type chroot_exec_t;
 corecmd_executable_file(chroot_exec_t)
+
+#
+# busybox setuid executable
+#
+
+type busybox_suid_exec_t;
+corecmd_executable_file(busybox_suid_exec_t)

--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -146,6 +146,7 @@ userdom_search_user_home_content(local_login_t)
 userdom_use_unpriv_users_fds(local_login_t)
 userdom_sigchld_all_users(local_login_t)
 userdom_create_all_users_keys(local_login_t)
+domain_execute_busybox_suid(local_login_t)
 
 ifdef(`init_systemd',`
 	auth_manage_faillog(local_login_t)

--- a/policy/modules/system/mount.te
+++ b/policy/modules/system/mount.te
@@ -153,6 +153,7 @@ seutil_read_config(mount_t)
 selinux_getattr_fs(mount_t)
 
 userdom_use_all_users_fds(mount_t)
+domain_execute_busybox_suid(mount_t)
 
 ifdef(`distro_redhat',`
 	optional_policy(`


### PR DESCRIPTION
This change improves SELinux confinement by introducing a dedicated label for the setuid BusyBox binary, /usr/bin/busybox.suid.

Previously, both setuid and non-setuid BusyBox binaries were labeled with the generic bin_t type, making the setuid BusyBox executable broadly accessible. Treating privileged and non-privileged executables identically undermines SELinux confinement, as busybox.suid provides elevated privileges that should be tightly controlled.

To address this, a new executable type, busybox_suid_exec_t, and a reusable interface, domain_execute_busybox_suid(), are introduced to allow explicit execution of the setuid BusyBox binary only by domains with a legitimate functional requirement (e.g. ping, traceroute, passwd, vlock, mount, and local login helpers). To preserve existing functionality, the interface is applied selectively to domains that require execution of BusyBox applets with the setuid bit set.

This keeps access explicit and auditable while avoiding broad permissions and preserving least-privilege principles.

Additionally, ping is granted controlled PTY access via the existing init_use_script_ptys() interface to allow normal interactive operation (stdout/stderr and signal handling) without unnecessary device access.