### PR TITLE
tee_supplicant: Add necessary SELinux policy for tee_supplicant domain

### DIFF
--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -549,6 +549,36 @@ interface(`storage_read_scsi_generic',`
 
 ########################################
 ## <summary>
+##      Allow the caller to directly read, in a
+##      generic fashion, from any SCSI device
+##      if a tunable is set.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <param name="tunable">
+##      <summary>
+##      Tunable to depend on
+##      </summary>
+## </param>
+#
+interface(`storage_read_scsi_generic_cond',`
+        gen_require(`
+                attribute scsi_generic_read;
+                type scsi_generic_device_t;
+        ')
+
+        typeattribute $1 scsi_generic_read;
+        tunable_policy(`$2',`
+                dev_list_all_dev_nodes($1)
+                allow $1 scsi_generic_device_t:chr_file read_chr_file_perms;
+        ')
+')
+
+########################################
+## <summary>
 ##	Allow the caller to directly write, in a
 ##	generic fashion, from any SCSI device.
 ##	This is extremely dangerous as it can bypass the
@@ -570,6 +600,36 @@ interface(`storage_write_scsi_generic',`
 	dev_list_all_dev_nodes($1)
 	allow $1 scsi_generic_device_t:chr_file write_chr_file_perms;
 	typeattribute $1 scsi_generic_write;
+')
+
+########################################
+## <summary>
+##      Allow the caller to directly write, in a
+##      generic fashion, from any SCSI device
+##      if a tunable is set.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <param name="tunable">
+##      <summary>
+##      Tunable to depend on
+##      </summary>
+## </param>
+#
+interface(`storage_write_scsi_generic_cond',`
+        gen_require(`
+                attribute scsi_generic_write;
+                type scsi_generic_device_t;
+        ')
+
+        typeattribute $1 scsi_generic_write;
+        tunable_policy(`$2',`
+                dev_list_all_dev_nodes($1)
+                allow $1 scsi_generic_device_t:chr_file write_chr_file_perms;
+        ')
 ')
 
 ########################################

--- a/policy/modules/services/tee_supplicant.fc
+++ b/policy/modules/services/tee_supplicant.fc
@@ -1,2 +1,4 @@
 /usr/bin/qtee_supplicant      --      gen_context(system_u:object_r:tee_supplicant_exec_t,s0)
 /usr/sbin/tee-supplicant      --      gen_context(system_u:object_r:tee_supplicant_exec_t,s0)
+
+/var/lib/tee(/.*)?                    gen_context(system_u:object_r:tee_supplicant_var_lib_t,s0)

--- a/policy/modules/services/tee_supplicant.if
+++ b/policy/modules/services/tee_supplicant.if
@@ -1,5 +1,5 @@
 ## <summary>tee_supplicant</summary>
-#
+##
 ## <desc>
 ## qtee_supplicant is a userspace supplicant daemon that
 ## services callback requests from QTEE via the Linux TEE subsystem.
@@ -8,3 +8,23 @@
 ##
 ## https://github.com/qualcomm/minkipc/tree/main/qtee_supplicant
 ## </desc>
+
+#####################
+## <summary>
+##  Allow the specified domain to create
+##  objects in /var/lib with an automatic
+##  transition to the tee_supplicant var lib type.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`tee_supplicant_var_lib_filetrans',`
+       gen_require(`
+               type tee_supplicant_var_lib_t;
+       ')
+
+       files_var_lib_filetrans($1, tee_supplicant_var_lib_t, dir, "qtee_supplicant")
+')

--- a/policy/modules/services/tee_supplicant.te
+++ b/policy/modules/services/tee_supplicant.te
@@ -5,12 +5,20 @@ policy_module(tee_supplicant)
 # Declarations
 #
 
+## <desc>
+##  <p>
+##  Enable rules specific to qtee_supplicant.
+##  </p>
+## </desc>
+gen_tunable(tee_supplicant_qtee, false)
+
 type tee_supplicant_t;
 type tee_supplicant_exec_t;
 init_daemon_domain(tee_supplicant_t, tee_supplicant_exec_t)
 
 type tee_supplicant_var_lib_t;
 files_type(tee_supplicant_var_lib_t)
+files_mountpoint(tee_supplicant_var_lib_t)
 
 #########################################
 #
@@ -25,3 +33,34 @@ dev_rw_tee(tee_supplicant_t)
 dev_rw_tee_priv(tee_supplicant_t)
 
 kernel_read_vm_overcommit_sysctl(tee_supplicant_t)
+
+# Access qtee_supplicant to access UFS BSG device
+storage_read_scsi_generic_cond(tee_supplicant_t,tee_supplicant_qtee)
+storage_write_scsi_generic_cond(tee_supplicant_t,tee_supplicant_qtee)
+
+tunable_policy(`tee_supplicant_qtee',`
+
+        # Access qtee_supplicant to request sys_rawio capability
+        allow tee_supplicant_t self:capability sys_rawio;
+
+        # Allow qtee_supplicant to block system suspend by wake_lock
+        allow tee_supplicant_t self:capability2 block_suspend;
+
+        # Access qtee_supplicant to open/read /sys/firmware/devicetree/base/compatible
+        dev_read_sysfs(tee_supplicant_t)
+
+        # Access qtee_supplicant to write /sys/power/wake_lock
+        dev_write_sysfs(tee_supplicant_t)
+
+        # Access tee_supplicant to read /var
+        files_list_var(tee_supplicant_t)
+
+        # Access qtee_supplicant to visit /var/lib
+        files_list_var_lib(tee_supplicant_t)
+
+        # Access qtee_supplicant to access /proc/cmdline
+        kernel_read_system_state(tee_supplicant_t)
+
+        # Access qtee_supplicant to send logs to systemd journal
+        logging_send_syslog_msg(tee_supplicant_t)
+')

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1524,6 +1524,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	tee_supplicant_var_lib_filetrans(initrc_t)
+')
+
+optional_policy(`
 	udev_manage_runtime_files(initrc_t)
 	udev_manage_runtime_dirs(initrc_t)
 	udev_manage_rules_files(initrc_t)

--- a/testing/sechecker.ini
+++ b/testing/sechecker.ini
@@ -221,6 +221,7 @@ exempt_source = abrt_t              # Conditional access (allow_raw_memory_acces
                 sosreport_t         # Conditional access (allow_raw_memory_access)
                 spc_t
                 sysadm_t            # System admin role
+                tee_supplicant_t    # Access qtee_supplicant to request sys_rawio capability
                 udev_t
                 vbetool_t           # Conditional access (allow_raw_memory_access)
                 vmware_t


### PR DESCRIPTION
Define some new interfaces to access /var/lib/tee, /var/lib/qtee_supplicant
and /var/lib/tee/qtee_supplicant.

Grant the nescessary permission to tee_supplicant for resolving
AVC denials in enforcing mode.

Upstream-Status: Inappropriate [embedded specific]

In the commit write the Upstream-status just because yocto project request it, the status isn't the truly status, just to maintain a uniform format.