### PR TITLE
ping: allow execution and PTY access

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -124,6 +124,9 @@ allow ping_t self:packet_socket { bind create getopt ioctl read setopt write };
 allow ping_t self:netlink_route_socket create_netlink_socket_perms;
 allow ping_t self:icmp_socket create_socket_perms;
 
+# Allow execution of BusyBox applets installed in /bin
+corecmd_exec_bin(ping_t)
+
 corenet_all_recvfrom_netlabel(ping_t)
 corenet_sendrecv_icmp_packets(ping_t)
 corenet_tcp_sendrecv_generic_if(ping_t)
@@ -143,6 +146,8 @@ kernel_read_system_state(ping_t)
 
 auth_use_nsswitch(ping_t)
 
+# Allow ping to access /dev/pts
+init_use_script_ptys(ping_t)
 init_dontaudit_use_fds(ping_t)
 
 logging_send_syslog_msg(ping_t)


### PR DESCRIPTION
Grant ping_t permission to execute binaries labeled bin_t and allow controlled PTY access using existing refpolicy interfaces.