### PR TITLE
devices: Add label for /dev/isst_interface

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -59,6 +59,7 @@
 /dev/ipmi[0-9]+		-c	gen_context(system_u:object_r:ipmi_device_t,s0)
 /dev/ipmi/[0-9]+	-c	gen_context(system_u:object_r:ipmi_device_t,s0)
 /dev/irlpt[0-9]+	-c	gen_context(system_u:object_r:printer_device_t,s0)
+/dev/isst_interface	-c	gen_context(system_u:object_r:cpu_device_t,s0)
 /dev/jbm		-c	gen_context(system_u:object_r:mouse_device_t,s0)
 /dev/js.*		-c	gen_context(system_u:object_r:mouse_device_t,s0)
 /dev/kmem		-c	gen_context(system_u:object_r:memory_device_t,mls_systemhigh)


### PR DESCRIPTION
Device for Intel Speed Select Technology
Adding due to complaint from STIG about unlabeled device files Labeling as cpu_device_t - which matches RedHat targeted policy