### PR TITLE
pipewire: add policy for PipeWire multimedia daemon

### DIFF
--- a/policy/modules/apps/pipewire.fc
+++ b/policy/modules/apps/pipewire.fc
@@ -1,0 +1,21 @@
+# PipeWire daemon executable.
+/usr/bin/pipewire		--	gen_context(system_u:object_r:pipewire_exec_t,s0)
+
+# pw-cat is a standalone client utility (plays/captures audio via a running
+# PipeWire daemon); it runs in pipewire_client_t, not pipewire_t.
+# pw-play, pw-record, pw-midiplay etc. are symlinks to pw-cat and
+# automatically inherit this label — no separate entries needed.
+/usr/bin/pw-cat			--	gen_context(system_u:object_r:pipewire_client_exec_t,s0)
+
+# System-service runtime directory (/run/pipewire).
+/run/pipewire(/.*)?		gen_context(system_u:object_r:pipewire_runtime_t,s0)
+
+# User-session runtime sockets live under $XDG_RUNTIME_DIR/pipewire and are
+# labelled at runtime via userdom_user_runtime_filetrans; no static entry needed.
+
+# Persistent system-service state.
+/var/lib/pipewire(/.*)?		gen_context(system_u:object_r:pipewire_var_lib_t,s0)
+
+# User home configuration and state.
+HOME_DIR/\.config/pipewire(/.*)?	gen_context(system_u:object_r:pipewire_home_t,s0)
+HOME_DIR/\.local/share/pipewire(/.*)?	gen_context(system_u:object_r:pipewire_home_t,s0)

--- a/policy/modules/apps/pipewire.fc
+++ b/policy/modules/apps/pipewire.fc
@@ -1,0 +1,10 @@
+HOME_DIR/\.config/pipewire(/.*)?	gen_context(system_u:object_r:pipewire_home_t,s0)
+HOME_DIR/\.local/share/pipewire(/.*)?	gen_context(system_u:object_r:pipewire_home_t,s0)
+
+/run/pipewire(/.*)?		gen_context(system_u:object_r:pipewire_runtime_t,s0)
+/run/user/%{USERID}/pipewire(/.*)?	gen_context(system_u:object_r:pipewire_runtime_t,s0)
+
+/usr/bin/pipewire		--	gen_context(system_u:object_r:pipewire_exec_t,s0)
+/usr/bin/pw-cat		--	gen_context(system_u:object_r:pipewire_exec_t,s0)
+
+/var/lib/pipewire(/.*)?		gen_context(system_u:object_r:pipewire_var_lib_t,s0)

--- a/policy/modules/apps/pipewire.if
+++ b/policy/modules/apps/pipewire.if
@@ -1,0 +1,225 @@
+## <summary>PipeWire multimedia daemon.</summary>
+
+########################################
+## <summary>
+##	Role access for PipeWire (user-service mode).
+##	Call this from unprivuser.te / staff.te in the same
+##	way pulseaudio_role is called.
+## </summary>
+## <param name="role_prefix">
+##	<summary>
+##	The prefix of the user role (e.g., "user" for user_r).
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	User domain for the role (e.g., user_t).
+##	</summary>
+## </param>
+## <param name="user_exec_domain">
+##	<summary>
+##	User exec domain for execute and transition access
+##	(e.g., user_application_exec_domain).
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access (e.g., user_r).
+##	</summary>
+## </param>
+#
+template(`pipewire_role',`
+	gen_require(`
+		attribute_role pipewire_roles;
+		type pipewire_t, pipewire_exec_t;
+		type pipewire_client_t, pipewire_client_exec_t;
+		type pipewire_home_t, pipewire_tmpfs_t, pipewire_runtime_t;
+	')
+
+	roleattribute $4 pipewire_roles;
+
+	domtrans_pattern($2, pipewire_exec_t, pipewire_t)
+	domtrans_pattern($3, pipewire_exec_t, pipewire_t)
+	domtrans_pattern($2, pipewire_client_exec_t, pipewire_client_t)
+	domtrans_pattern($3, pipewire_client_exec_t, pipewire_client_t)
+
+	allow $3 pipewire_t:process { ptrace signal_perms };
+	allow $3 pipewire_t:fd use;
+	ps_process_pattern($3, pipewire_t)
+
+	allow pipewire_t $3:unix_stream_socket connectto;
+	allow pipewire_t $3:process signull;
+
+	# Allow the user domain to manage and relabel pipewire home state files
+	# (e.g. restorecon after reinstall, stale file cleanup).
+	allow $2 pipewire_home_t:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 pipewire_home_t:file { mmap_manage_file_perms relabel_file_perms };
+	allow $2 pipewire_home_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
+
+	# Allow the user domain to manage and relabel runtime sock files
+	# (e.g. stale socket cleanup after daemon crash).
+	allow $2 pipewire_runtime_t:dir { manage_dir_perms relabel_dir_perms };
+	allow $2 pipewire_runtime_t:sock_file { manage_sock_file_perms relabel_sock_file_perms };
+
+	# Allow the user domain to manage shared memory files created by the daemon.
+	pipewire_mmap_rw_tmpfs_files($2)
+	allow $2 pipewire_tmpfs_t:file relabel_file_perms;
+
+	optional_policy(`
+		systemd_user_app_status($1, pipewire_t)
+		systemd_user_app_socket_create($1, pipewire_t, pipewire_runtime_t)
+	')
+')
+
+########################################
+## <summary>
+##	Execute a domain transition to run the PipeWire daemon.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`pipewire_domtrans',`
+	gen_require(`
+		type pipewire_t, pipewire_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, pipewire_exec_t, pipewire_t)
+')
+
+########################################
+## <summary>
+##	Execute a domain transition to run a PipeWire client utility
+##	(e.g. pw-cat).
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`pipewire_domtrans_client',`
+	gen_require(`
+		type pipewire_client_t, pipewire_client_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, pipewire_client_exec_t, pipewire_client_t)
+')
+
+########################################
+## <summary>
+##	Connect to the PipeWire daemon over a Unix stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pipewire_stream_connect',`
+	gen_require(`
+		type pipewire_t, pipewire_runtime_t;
+	')
+
+	files_search_runtime($1)
+	stream_connect_pattern($1, pipewire_runtime_t, pipewire_runtime_t, pipewire_t)
+')
+
+########################################
+## <summary>
+##	Read and write connected PipeWire daemon stream sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pipewire_rw_stream_sockets',`
+	gen_require(`
+		type pipewire_t;
+	')
+
+	allow $1 pipewire_t:unix_stream_socket rw_socket_perms;
+')
+
+########################################
+## <summary>
+##	Allow a domain to use file descriptors passed from PipeWire.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pipewire_use_fds',`
+	gen_require(`
+		type pipewire_t;
+	')
+
+	allow $1 pipewire_t:fd use;
+')
+
+########################################
+## <summary>
+##	Use file descriptors inherited from PipeWire clients.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pipewire_use_client_fds',`
+	gen_require(`
+		type pipewire_client_t;
+	')
+
+	allow $1 pipewire_client_t:fd use;
+')
+
+########################################
+## <summary>
+##	Allow a domain to read, write, and map PipeWire shared memory (tmpfs) files.
+##	These are memfd files passed between the daemon and its clients for
+##	zero-copy audio buffer sharing.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pipewire_mmap_rw_tmpfs_files',`
+	gen_require(`
+		type pipewire_tmpfs_t;
+	')
+
+	fs_search_tmpfs($1)
+	mmap_rw_files_pattern($1, pipewire_tmpfs_t, pipewire_tmpfs_t)
+')
+
+########################################
+## <summary>
+##	Allow a domain to read PipeWire home directory content.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pipewire_read_home_files',`
+	gen_require(`
+		type pipewire_home_t;
+	')
+
+	userdom_search_user_home_dirs($1)
+	read_files_pattern($1, pipewire_home_t, pipewire_home_t)
+	read_lnk_files_pattern($1, pipewire_home_t, pipewire_home_t)
+')

--- a/policy/modules/apps/pipewire.if
+++ b/policy/modules/apps/pipewire.if
@@ -1,0 +1,83 @@
+## <summary>PipeWire multimedia daemon.</summary>
+
+########################################
+## <summary>
+##	Role access for PipeWire in user-service mode.
+## </summary>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <param name="domain">
+##	<summary>
+##	User domain for the role.
+##	</summary>
+## </param>
+#
+interface(`pipewire_role',`
+	gen_require(`
+		type pipewire_t, pipewire_exec_t;
+	')
+
+	role $1 types pipewire_t;
+	domtrans_pattern($2, pipewire_exec_t, pipewire_t)
+')
+
+########################################
+## <summary>
+##	Allow a domain to use file descriptors
+##	passed from PipeWire.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pipewire_use_fds',`
+	gen_require(`
+		type pipewire_t;
+	')
+
+	allow $1 pipewire_t:fd use;
+')
+
+########################################
+## <summary>
+##	Connect to PipeWire over a unix stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pipewire_stream_connect',`
+	gen_require(`
+		type pipewire_t, pipewire_runtime_t;
+	')
+
+	files_search_runtime($1)
+	stream_connect_pattern($1, pipewire_runtime_t, pipewire_runtime_t, pipewire_t)
+')
+
+########################################
+## <summary>
+##	Allow a domain to read and write
+##	PipeWire tmpfs shared memory files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pipewire_rw_tmpfs_files',`
+	gen_require(`
+		type pipewire_tmpfs_t;
+	')
+
+	fs_search_tmpfs($1)
+	rw_files_pattern($1, pipewire_tmpfs_t, pipewire_tmpfs_t)
+')

--- a/policy/modules/apps/pipewire.te
+++ b/policy/modules/apps/pipewire.te
@@ -1,0 +1,229 @@
+policy_module(pipewire, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+
+type pipewire_t;
+type pipewire_exec_t;
+ifdef(`pipewire_system_service',`
+	init_daemon_domain(pipewire_t, pipewire_exec_t)
+',`
+	userdom_user_application_domain(pipewire_t, pipewire_exec_t)
+')
+
+type pipewire_home_t;
+userdom_user_home_content(pipewire_home_t)
+
+type pipewire_var_lib_t;
+files_type(pipewire_var_lib_t)
+
+type pipewire_runtime_t;
+files_type(pipewire_runtime_t)
+
+type pipewire_tmpfs_t;
+userdom_user_tmp_file(pipewire_tmpfs_t)
+
+########################################
+#
+# Local policy
+#
+
+allow pipewire_t self:capability sys_nice;
+allow pipewire_t self:process { getsched setsched signal sigchld };
+allow pipewire_t self:fifo_file rw_fifo_file_perms;
+allow pipewire_t self:unix_stream_socket { create_stream_socket_perms connectto };
+
+manage_dirs_pattern(pipewire_t, pipewire_runtime_t, pipewire_runtime_t)
+manage_files_pattern(pipewire_t, pipewire_runtime_t, pipewire_runtime_t)
+manage_sock_files_pattern(pipewire_t, pipewire_runtime_t, pipewire_runtime_t)
+
+manage_files_pattern(pipewire_t, pipewire_tmpfs_t, pipewire_tmpfs_t)
+allow pipewire_t pipewire_tmpfs_t:file map;
+fs_tmpfs_filetrans(pipewire_t, pipewire_tmpfs_t, file)
+
+dev_read_sound(pipewire_t)
+dev_read_sysfs(pipewire_t)
+dev_write_sound(pipewire_t)
+
+kernel_read_system_state(pipewire_t)
+
+domain_dontaudit_read_all_domains_state(pipewire_t)
+
+files_read_etc_files(pipewire_t)
+files_read_usr_files(pipewire_t)
+ifdef(`files_map_usr_files',`
+	files_map_usr_files(pipewire_t)
+')
+
+logging_send_syslog_msg(pipewire_t)
+
+# Allow pw-play to read files from /tmp
+files_search_tmp(pipewire_t)
+files_read_all_tmp_files(pipewire_t)
+
+miscfiles_read_localization(pipewire_t)
+
+ifdef(`pipewire_system_service',`
+	allow pipewire_t self:capability dac_override;
+
+	manage_dirs_pattern(pipewire_t, pipewire_var_lib_t, pipewire_var_lib_t)
+	manage_files_pattern(pipewire_t, pipewire_var_lib_t, pipewire_var_lib_t)
+	files_var_lib_filetrans(pipewire_t, pipewire_var_lib_t, { dir file })
+
+	gen_require(`
+		type var_run_t;
+	')
+	allow pipewire_t var_run_t:dir { search add_name write remove_name };
+	filetrans_pattern(pipewire_t, var_run_t, pipewire_runtime_t, dir, "pipewire")
+
+	# Needed only when launched from init/system scripts.
+	init_rw_script_stream_sockets(pipewire_t)
+	dev_rw_dma_dev(pipewire_t)
+
+	# Allow pw-record to create/write output files in /tmp (e.g. pw-record /tmp/test.wav).
+	ifdef(`files_write_tmp_files',`
+		files_write_tmp_files(pipewire_t)
+	',`
+		gen_require(`
+			type tmp_t;
+		')
+		allow pipewire_t tmp_t:dir { search add_name write };
+		allow pipewire_t tmp_t:file { create open read write getattr setattr };
+	')
+
+	ifdef(`dbus_system_domain',`
+		optional_policy(`
+			dbus_system_domain(pipewire_t, pipewire_exec_t)
+		')
+	')
+',`
+	manage_dirs_pattern(pipewire_t, pipewire_home_t, pipewire_home_t)
+	manage_files_pattern(pipewire_t, pipewire_home_t, pipewire_home_t)
+
+	ifdef(`userdom_user_runtime_filetrans',`
+		userdom_user_runtime_filetrans(pipewire_t, pipewire_runtime_t, dir)
+	',`
+		gen_require(`
+			type user_tmp_t;
+		')
+		filetrans_pattern(pipewire_t, user_tmp_t, pipewire_runtime_t, dir, "pipewire")
+	')
+
+	ifdef(`userdom_user_home_dir_filetrans',`
+		userdom_user_home_dir_filetrans(pipewire_t, pipewire_home_t, dir)
+	',`
+		# Older trees fallback: keep compile compatibility; rely on FC/restorecon for home paths.
+	')
+
+	# Session/system D-Bus socket access for PipeWire helpers.
+	optional_policy(`
+		gen_require(`
+			type session_dbusd_tmp_t;
+			type staff_dbusd_t;
+		')
+		allow pipewire_t session_dbusd_tmp_t:sock_file write;
+		allow pipewire_t staff_dbusd_t:unix_stream_socket connectto;
+	')
+
+	optional_policy(`
+		gen_require(`
+			type system_dbusd_var_run_t;
+			type system_dbusd_t;
+		')
+		allow pipewire_t system_dbusd_var_run_t:sock_file write;
+		allow pipewire_t system_dbusd_t:unix_stream_socket connectto;
+	')
+
+	# Name-service and ALSA config reads observed in enforcing logs.
+	optional_policy(`
+		gen_require(`
+			type passwd_file_t;
+		')
+		allow pipewire_t passwd_file_t:file { getattr open read };
+	')
+
+	optional_policy(`
+		gen_require(`
+			type alsa_etc_rw_t;
+		')
+		allow pipewire_t alsa_etc_rw_t:file { getattr open read map };
+	')
+
+	ifdef(`dbus_all_session_bus_client',`
+		optional_policy(`
+			dbus_all_session_bus_client(pipewire_t)
+		')
+	')
+	ifdef(`dbus_connect_all_session_bus',`
+		optional_policy(`
+			dbus_connect_all_session_bus(pipewire_t)
+		')
+	')
+')
+
+ifdef(`pulseaudio_stream_connect',`
+	optional_policy(`
+		pulseaudio_stream_connect(pipewire_t)
+	')
+')
+
+ifdef(`rtkit_scheduled',`
+	optional_policy(`
+		rtkit_scheduled(pipewire_t)
+	')
+')
+
+ifdef(`systemd_read_journal_files',`
+	optional_policy(`
+		systemd_read_journal_files(pipewire_t)
+	')
+')
+
+########################################
+#
+# Unconfined access rules
+#
+
+ifdef(`pipewire_system_service',`',`
+    gen_require(`
+        type staff_t;
+        type user_t;
+        role staff_r;
+        role user_r;
+    ')
+    role staff_r types pipewire_t;
+    role user_r types pipewire_t;
+    domtrans_pattern(staff_t, pipewire_exec_t, pipewire_t)
+    domtrans_pattern(user_t, pipewire_exec_t, pipewire_t)
+    allow staff_t pipewire_t:unix_stream_socket { create setopt bind listen connectto getopt };
+    allow user_t pipewire_t:unix_stream_socket { create setopt bind listen connectto getopt };
+    allow staff_t pipewire_t:process { signal sigkill signull };
+    allow user_t pipewire_t:process { signal sigkill signull };
+    allow staff_t pipewire_t:process2 nnp_transition;
+    allow user_t pipewire_t:process2 nnp_transition;
+
+    # PipeWire stores lock/pid/socket files directly under /run/user/<uid>.
+    gen_require(`
+        type user_tmp_t;
+    ')
+    manage_files_pattern(pipewire_t, user_tmp_t, user_tmp_t)
+    manage_sock_files_pattern(pipewire_t, user_tmp_t, user_tmp_t)
+
+    # WirePlumber (left in staff_t/user_t) maps PipeWire memfd files.
+    allow staff_t pipewire_tmpfs_t:file { read write map getattr open };
+    allow user_t pipewire_tmpfs_t:file { read write map getattr open };
+
+    optional_policy(`
+        gen_require(`
+            type systemd_user_t;
+        ')
+        domtrans_pattern(systemd_user_t, pipewire_exec_t, pipewire_t)
+        allow systemd_user_t pipewire_t:unix_stream_socket { create setopt bind listen connectto getopt };
+        allow systemd_user_t pipewire_t:process { signal sigkill signull };
+        allow systemd_user_t pipewire_t:process2 nnp_transition;
+        allow systemd_user_t pipewire_tmpfs_t:file { read write map getattr open };
+    ')
+')

--- a/policy/modules/apps/pipewire.te
+++ b/policy/modules/apps/pipewire.te
@@ -1,0 +1,214 @@
+policy_module(pipewire)
+
+########################################
+#
+# Declarations
+#
+
+## <desc>
+##	<p>
+##	Run PipeWire as a system-wide daemon launched by the systemd system
+##	instance.  When false (default), PipeWire runs as a per-user session
+##	service launched by systemd --user.
+##	Define pipewire_system_service at build time to enable system-service mode.
+##	</p>
+## </desc>
+
+attribute_role pipewire_roles;
+
+#
+# pipewire_t — the PipeWire multimedia daemon.
+#
+type pipewire_t;
+type pipewire_exec_t;
+ifdef(`pipewire_system_service',`
+	init_daemon_domain(pipewire_t, pipewire_exec_t)
+',`
+	userdom_user_application_domain(pipewire_t, pipewire_exec_t)
+	role pipewire_roles types pipewire_t;
+')
+
+#
+# pipewire_client_t — domain for pw-cat and other PipeWire client utilities.
+# pw-cat, pw-play, pw-record, etc. are standalone clients that connect to a
+# running PipeWire daemon; they are separate programs and must not run in
+# pipewire_t.
+#
+type pipewire_client_t;
+type pipewire_client_exec_t;
+userdom_user_application_domain(pipewire_client_t, pipewire_client_exec_t)
+role pipewire_roles types pipewire_client_t;
+
+type pipewire_home_t alias pipewire_var_lib_t;
+userdom_user_home_content(pipewire_home_t)
+
+type pipewire_runtime_t;
+files_runtime_file(pipewire_runtime_t)
+
+type pipewire_tmpfs_t;
+userdom_user_tmpfs_file(pipewire_tmpfs_t)
+
+########################################
+#
+# pipewire_t — common policy (both system and user instances)
+#
+
+allow pipewire_t self:capability sys_nice;
+allow pipewire_t self:process { getsched setsched signal sigchld };
+allow pipewire_t self:fifo_file rw_fifo_file_perms;
+allow pipewire_t self:unix_stream_socket { create_stream_socket_perms connectto };
+
+# Manage the daemon's own runtime socket/pid directory.
+manage_dirs_pattern(pipewire_t, pipewire_runtime_t, pipewire_runtime_t)
+manage_files_pattern(pipewire_t, pipewire_runtime_t, pipewire_runtime_t)
+manage_sock_files_pattern(pipewire_t, pipewire_runtime_t, pipewire_runtime_t)
+
+# Shared memory (memfd) files passed to clients via file-descriptor passing
+# for zero-copy audio buffer sharing.
+mmap_manage_files_pattern(pipewire_t, pipewire_tmpfs_t, pipewire_tmpfs_t)
+fs_tmpfs_filetrans(pipewire_t, pipewire_tmpfs_t, file)
+
+# Audio hardware access.
+dev_read_sound(pipewire_t)
+dev_write_sound(pipewire_t)
+
+# Device enumeration via sysfs (discovering ALSA/USB audio devices at startup).
+dev_read_sysfs(pipewire_t)
+
+# Suppress noisy denials when PipeWire probes /proc/<pid>/status of other
+# processes during client enumeration; these are harmless stat-only calls.
+domain_dontaudit_read_all_domains_state(pipewire_t)
+
+# Read /proc state for scheduling and memory info.
+kernel_read_system_state(pipewire_t)
+
+files_read_etc_files(pipewire_t)
+files_read_usr_files(pipewire_t)
+files_map_usr_files(pipewire_t)
+
+logging_send_syslog_msg(pipewire_t)
+
+miscfiles_read_localization(pipewire_t)
+
+# NSS/name-service lookups to resolve user names for session ownership checks.
+auth_use_nsswitch(pipewire_t)
+
+# ALSA configuration files (/etc/alsa/*, ~/.asoundrc).
+optional_policy(`
+	alsa_read_config(pipewire_t)
+')
+
+# PulseAudio compatibility layer (pipewire-pulse connects to PulseAudio clients).
+optional_policy(`
+	pulseaudio_stream_connect(pipewire_t)
+')
+
+# Real-time scheduling priority via rtkit-daemon.
+optional_policy(`
+	rtkit_scheduled(pipewire_t)
+')
+
+# Read systemd journal for log correlation.
+optional_policy(`
+	systemd_read_journal_files(pipewire_t)
+')
+
+########################################
+#
+# pipewire_t — system-service-only policy
+#
+
+ifdef(`pipewire_system_service',`
+	# CAP_DAC_OVERRIDE is required to open /dev/snd/* devices that are owned
+	# by root:audio when PipeWire runs as a system-wide daemon (not as the
+	# session user).
+	allow pipewire_t self:capability dac_override;
+
+	# Persistent state directory under /var/lib/pipewire.
+	manage_dirs_pattern(pipewire_t, pipewire_var_lib_t, pipewire_var_lib_t)
+	manage_files_pattern(pipewire_t, pipewire_var_lib_t, pipewire_var_lib_t)
+	files_var_lib_filetrans(pipewire_t, pipewire_var_lib_t, { dir file })
+
+	# Runtime socket/pid directory transition under /run/pipewire.
+	files_runtime_filetrans(pipewire_t, pipewire_runtime_t, dir, "pipewire")
+
+	# DMA buffer access for zero-copy audio with hardware that supports it
+	# (e.g. /dev/dma_heap on newer kernels).
+	dev_rw_dma_dev(pipewire_t)
+
+	# System D-Bus registration (org.PipeWire.* service name on the system bus).
+	optional_policy(`
+		dbus_system_domain(pipewire_t, pipewire_exec_t)
+	')
+')
+
+########################################
+#
+# pipewire_t — user-service-only policy
+#
+
+ifndef(`pipewire_system_service',`
+	# Home directory state (~/.local/share/pipewire).
+	# mmap_manage_file_perms includes map permission needed for config file mmap.
+	manage_dirs_pattern(pipewire_t, pipewire_home_t, pipewire_home_t)
+	allow pipewire_t pipewire_home_t:file mmap_manage_file_perms;
+	manage_lnk_files_pattern(pipewire_t, pipewire_home_t, pipewire_home_t)
+
+	# Runtime socket directory transition under $XDG_RUNTIME_DIR/pipewire.
+	userdom_user_runtime_filetrans(pipewire_t, pipewire_runtime_t, dir, "pipewire")
+
+	# Session D-Bus (register org.PipeWire.* on the per-user session bus).
+	optional_policy(`
+		dbus_all_session_bus_client(pipewire_t)
+		dbus_connect_all_session_bus(pipewire_t)
+	')
+
+	# Allow systemd --user to start the user-service instance.
+	optional_policy(`
+		systemd_user_daemon_domain(user, pipewire_exec_t, pipewire_t)
+		systemd_user_daemon_domain(staff, pipewire_exec_t, pipewire_t)
+	')
+')
+
+########################################
+#
+# pipewire_client_t — pw-cat and other client utilities
+#
+# pw-cat is a standalone client that connects to a running PipeWire daemon
+# to play back or capture audio; it does not implement the daemon itself.
+#
+
+allow pipewire_client_t self:process { getsched signal };
+allow pipewire_client_t self:fifo_file rw_fifo_file_perms;
+allow pipewire_client_t self:unix_stream_socket { create_stream_socket_perms connectto };
+
+auth_use_nsswitch(pipewire_client_t)
+
+files_read_usr_files(pipewire_client_t)
+files_map_usr_files(pipewire_client_t)
+
+kernel_read_system_state(pipewire_client_t)
+
+miscfiles_read_localization(pipewire_client_t)
+
+# Connect to the PipeWire daemon socket and map its shared memory buffers.
+pipewire_stream_connect(pipewire_client_t)
+pipewire_rw_stream_sockets(pipewire_client_t)
+pipewire_mmap_rw_tmpfs_files(pipewire_client_t)
+pipewire_use_fds(pipewire_client_t)
+pipewire_use_client_fds(pipewire_t)
+
+# Read media files from the user's home, and allow capture tools such as
+# pw-record to manage user-selected output files in /tmp.
+userdom_read_user_home_content_files(pipewire_client_t)
+userdom_manage_user_tmp_files(pipewire_client_t)
+userdom_tmp_filetrans_user_tmp(pipewire_client_t, file)
+
+optional_policy(`
+	alsa_read_config(pipewire_client_t)
+')
+
+optional_policy(`
+	dbus_all_session_bus_client(pipewire_client_t)
+	dbus_connect_all_session_bus(pipewire_client_t)
+')

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -167,6 +167,10 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
+		pipewire_role(staff, staff_t, staff_application_exec_domain, staff_r)
+	')
+
+	optional_policy(`
 		pyzor_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -135,6 +135,10 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
+		pipewire_role(user, user_t, user_application_exec_domain, user_r)
+	')
+
+	optional_policy(`
 		pyzor_role(user, user_t, user_application_exec_domain, user_r)
 	')
 


### PR DESCRIPTION
Add a new SELinux policy module for the PipeWire multimedia daemon. PipeWire is a low-latency audio and video server that replaces PulseAudio and JACK on modern Linux systems.

The policy confines the pipewire_t domain with:
- Process control: fork, signal handling and scheduling (sys_nice) for low-latency audio operation
- Runtime socket and directory management under /run/pipewire
- ALSA sound device access via dev_read_sound/dev_write_sound
- Shared memory (tmpfs/memfd) for zero-copy audio buffer handling
- sysfs and procfs read access for hardware discovery
- System logging via syslog and systemd journal
- PulseAudio runtime compatibility via optional_policy
- Suppressed audit noise for expected /proc scan denials

pipewire-pulse is a symlink to the pipewire binary and transitions into the same pipewire_t domain, so no separate domain is needed.