### PR TITLE
selinux: allow seatd to use unallocated TTYs

### DIFF
--- a/policy/modules/services/seatd.te
+++ b/policy/modules/services/seatd.te
@@ -32,3 +32,7 @@ auth_use_nsswitch(seatd_t)
 
 dev_rw_dri(seatd_t)
 dev_rw_input_dev(seatd_t)
+
+# seatd requires access to unallocated TTYs (e.g. /dev/tty0) to manage
+# seat activation and VT handling for Wayland compositors.
+term_use_unallocated_ttys(seatd_t)


### PR DESCRIPTION
seatd requires access to unallocated TTY devices such as /dev/tty0 to manage seat activation and VT handling for Wayland compositors.