### PR TITLE
selinux: allow ModemManager to send DBus messages to init scripts

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1327,6 +1327,11 @@ optional_policy(`
 	')
 
 	optional_policy(`
+		# Needed by wireplumber to interact with ModemManager over D-Bus
+		modemmanager_dbus_chat(initrc_t)
+	')
+
+	optional_policy(`
 		policykit_dbus_chat(initrc_t)
 	')
 ')


### PR DESCRIPTION
ModemManager sends DBus method replies to init-managed services.