### PR TITLE
Refpolicy: Addressed denials on alsa, libvirt leasesh and sysdemd-coredum

### DIFF
--- a/policy/modules/admin/alsa.te
+++ b/policy/modules/admin/alsa.te
@@ -87,6 +87,7 @@ dev_read_sound(alsa_t)
 dev_read_sysfs(alsa_t)
 dev_read_urand(alsa_t)
 dev_write_sound(alsa_t)
+dev_rw_input_dev(alsa_t)
 
 files_read_usr_files(alsa_t)
 files_search_var_lib(alsa_t)

--- a/policy/modules/services/virt.te
+++ b/policy/modules/services/virt.te
@@ -1161,6 +1161,7 @@ manage_files_pattern(virt_leaseshelper_t, virt_runtime_t, virt_runtime_t)
 files_runtime_filetrans(virt_leaseshelper_t, virt_runtime_t, file)
 
 kernel_dontaudit_read_system_state(virt_leaseshelper_t)
+kernel_read_kernel_sysctls(virt_leaseshelper_t)
 
 # Read /sys/devices/system/node/node*/meminfo
 dev_list_sysfs(virt_leaseshelper_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -563,6 +563,7 @@ fs_getattr_all_fs(systemd_coredump_t)
 fs_getattr_nsfs_files(systemd_coredump_t)
 fs_list_cgroup_dirs(systemd_coredump_t)
 fs_search_tmpfs(systemd_coredump_t)
+fs_read_nsfs_files(systemd_coredump_t)
 
 init_list_var_lib_dirs(systemd_coredump_t)
 init_read_state(systemd_coredump_t)


### PR DESCRIPTION
```
type=AVC msg=audit(1776766842.302:2875): avc:  denied  { read open } for  pid=6273 comm="systemd-coredum" path="pid:[4026531836]" dev="nsfs" ino=4026531836 scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:object_r:nsfs_t:s0 tclass=file permissive=0
type=AVC msg=audit(1776766089.433:378): avc:  denied  { use } for  pid=1192 comm="modprobe" path="/dev/null" dev="devtmpfs" ino=3 scontext=system_u:system_r:kmod_t:s0 tcontext=system_u:system_r:virtd_t:s0 tclass=fd permissive=0
type=AVC msg=audit(1776766089.633:500): avc:  denied  { search } for  pid=1240 comm="libvirt_leasesh" name="kernel" dev="proc" ino=6172 scontext=system_u:system_r:virt_leaseshelper_t:s0 tcontext=system_u:object_r:sysctl_kernel_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1776766089.681:506): avc:  denied  { open } for  pid=1090 comm="daemon-init" path="/run/credentials/libvirtd.service/secrets-encryption-key" dev="tmpfs" ino=2 scontext=system_u:system_r:virtd_t:s0 tcontext=system_u:object_r:init_tmpfs_t:s0 tclass=file permissive=0
```