### PR TITLE
gpg: adapt to Gentoo's app-alternatives/gpg

### DIFF
--- a/policy/modules/apps/gpg.fc
+++ b/policy/modules/apps/gpg.fc
@@ -8,6 +8,10 @@ HOME_DIR/\.gnupg/S\.scdaemon		-s	gen_context(system_u:object_r:gpg_agent_tmp_t,s
 /usr/bin/gpg-agent			--	gen_context(system_u:object_r:gpg_agent_exec_t,s0)
 /usr/bin/pinentry.*			--	gen_context(system_u:object_r:gpg_pinentry_exec_t,s0)
 
+ifdef(`distro_gentoo', `
+/usr/bin/gpg-(freepg|reference)		--	gen_context(system_u:object_r:gpg_exec_t,s0)
+')
+
 /usr/lib/gnupg/.*			--	gen_context(system_u:object_r:gpg_exec_t,s0)
 /usr/lib/gnupg/gpgkeys.*		--	gen_context(system_u:object_r:gpg_helper_exec_t,s0)
 


### PR DESCRIPTION
Gentoo recently introduced app-alternatives/gpg which installs these as symlinks to a provider chosen by the user via the package manager:
* /usr/bin/gpg
* /usr/bin/gpg2

They may point to /usr/bin/gpg-reference from vanilla GnuPG or /usr/bin/gpg-freepg from FreePG [0]. We want gpg_exec_t for those.

[0] https://freepg.org/ (a fork of GnuPG)

Bug: https://bugs.gentoo.org/965532