### PR TITLE
snmpd: snmpd doesn't seem to need dac_override capability

### DIFF
--- a/policy/modules/services/snmp.te
+++ b/policy/modules/services/snmp.te
@@ -29,7 +29,7 @@ files_type(snmpd_var_lib_t)
 # Local policy
 #
 
-allow snmpd_t self:capability { chown dac_override ipc_lock kill net_admin setgid setuid sys_nice sys_tty_config };
+allow snmpd_t self:capability { chown ipc_lock kill net_admin setgid setuid sys_nice sys_tty_config };
 dontaudit snmpd_t self:capability { sys_module sys_tty_config };
 allow snmpd_t self:process { getsched setsched signal_perms };
 allow snmpd_t self:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
Tested on RHEL9 with net-snmp 5.9.4
I was able to query information about the system.  I didn't see any denials.  CAP_DAC_OVERRIDE is also not in the systemd unit starting snmpd.