### PR TITLE
systemd: allow user systemd-tmpfiles to setfscreate

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -155,6 +155,7 @@ template(`systemd_role_template',`
 	userdom_exec_user_bin_files($1_systemd_t)
 
 	# user systemd-tmpfiles rules
+	allow $1_systemd_tmpfiles_t self:process setfscreate;
 	allow $1_systemd_tmpfiles_t $1_systemd_t:unix_stream_socket rw_socket_perms;
 	domtrans_pattern($1_systemd_t, systemd_tmpfiles_exec_t, $1_systemd_tmpfiles_t)
 	read_files_pattern($1_systemd_t, $1_systemd_tmpfiles_t, $1_systemd_tmpfiles_t)


### PR DESCRIPTION
systemd-tmpfiles needs to be able to setfscreate when run as a user too:
```
AVC avc:  denied  { setfscreate } for  pid=1656 comm="systemd-tmpfile"
scontext=staff_u:staff_r:staff_systemd_tmpfiles_t:s0-s0:c0.c1023
tcontext=staff_u:staff_r:staff_systemd_tmpfiles_t:s0-s0:c0.c1023
tclass=process
permissive=1
```