### PR TITLE
kernel: treat /efi similarly to /boot

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -36,6 +36,11 @@ ifdef(`distro_suse',`
 /boot/System\.map(-.*)?	--	gen_context(system_u:object_r:system_map_t,s0)
 
 #
+# /efi
+#
+/efi			-d	gen_context(system_u:object_r:boot_t,s0)
+
+#
 # /emul
 #
 /emul			-d	gen_context(system_u:object_r:usr_t,s0)


### PR DESCRIPTION
systemd-boot's bootctl may probe /efi (see e.g. https://systemd.io/ROOTFS_DISCOVERY/).

We should treat /efi the same as /boot. We don't need to worry about the rest I think because it will be dosfs_t or similar. boot_t should be suitable here too as it's really split out of what /boot used to be on some systems.