### PR TITLE
systemd: allow systemd-nsresourced to interact w/ bpf

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1731,16 +1731,22 @@ optional_policy(`
 #
 
 allow systemd_nsresourced_t self:capability { sys_resource };
+allow systemd_nsresourced_t self:capability2 bpf;
 allow systemd_nsresourced_t self:process { getcap signal };
 allow systemd_nsresourced_t systemd_nsresourced_exec_t:file execute_no_trans;
+allow systemd_nsresourced_t self:bpf { map_create map_read map_write prog_load prog_run };
 
 manage_dirs_pattern(systemd_nsresourced_t, systemd_nsresourced_runtime_t, systemd_nsresourced_runtime_t)
 manage_files_pattern(systemd_nsresourced_t, systemd_nsresourced_runtime_t, systemd_nsresourced_runtime_t)
 manage_sock_files_pattern(systemd_nsresourced_t, systemd_nsresourced_runtime_t, systemd_nsresourced_runtime_t)
 init_runtime_filetrans(systemd_nsresourced_t, systemd_nsresourced_runtime_t, dir)
 
+fs_getattr_bpf(systemd_nsresourced_t)
 fs_getattr_cgroup(systemd_nsresourced_t)
 fs_getattr_nsfs_files(systemd_nsresourced_t)
+
+fs_manage_bpf_dirs(systemd_nsresourced_t)
+fs_manage_bpf_files(systemd_nsresourced_t)
 
 # for /proc/1/environ
 init_read_state(systemd_nsresourced_t)


### PR DESCRIPTION
systemd-nsresourced was introduced in systemd's 8aee931e7ae1adb01eeac0e1e4c0aef6ed3969ec.
> This is implemented via a BPF-LSM module that ensures that any member of a
> userns allocated that way cannot create files unless the mount it
> operates on is owned by the userns itself, or is explicitly
> allowelisted.

From systemd-nsresourced(8):
> Allocations of UIDs/GIDs this way are transient: when a user namespace goes away,
> its UID/GID range is returned to the pool of available ranges. In order to ensure
> that clients cannot gain persistency in their transient UID/GID range a BPF-LSM based
> policy is enforced that ensures that user namespaces set up this way can only write
> to file systems they allocate themselves or that are explicitly allowlisted
> via systemd-nsresourced.

BPF therefore isn't optional for systemd-nsresourced. systemd-nsresourced is itself somewhat optional in systemd but the systemd policy is currently monolithic.

```
AVC avc:  denied  { search } for  pid=1149 comm="systemd-nsresou" name="userns-restrict" dev="bpf" ino=16642
scontext=system_u:system_r:systemd_nsresourced_t:s0
tcontext=system_u:object_r:bpf_t:s0
tclass=dir

AVC avc:  denied  { write search } for  pid=1149 comm="systemd-nsresou" name="programs" dev="bpf" ino=16644
scontext=system_u:system_r:systemd_nsresourced_t:s0
tcontext=system_u:object_r:bpf_t:s0
tclass=dir

AVC avc:  denied  { map_create } for  pid=1149 comm="systemd-nsresou"
scontext=system_u:system_r:systemd_nsresourced_t:s0
tcontext=system_u:system_r:systemd_nsresourced_t:s0
tclass=bpf

AVC avc:  denied  { map_read map_write } for  pid=1149 comm="systemd-nsresou"
scontext=system_u:system_r:systemd_nsresourced_t:s0
tcontext=system_u:system_r:systemd_nsresourced_t:s0
tclass=bpf

AVC avc:  denied  { getattr } for  pid=1149 comm="systemd-nsresou" name="/" dev="bpf" ino=1
scontext=system_u:system_r:systemd_nsresourced_t:s0
tcontext=system_u:object_r:bpf_t:s0
tclass=filesystem

AVC avc:  denied  { create } for  pid=1149 comm="systemd-nsresou" name="userns_ringbuf"
scontext=system_u:system_r:systemd_nsresourced_t:s0
tcontext=system_u:object_r:bpf_t:s0
tclass=file
```