### PR TITLE
authlogin: allow pam_domain to read /usr/share/pam

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -355,6 +355,7 @@ ifdef(`distro_debian',`
 /usr/share/Modules/init(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/share/org\.gnome\.Weather/org\.gnome\.Weather\.Application	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/org\.gnome\.Weather/org\.gnome\.Weather\.BackgroundService	--	gen_context(system_u:object_r:bin_t,s0)
+/usr/share/pam/security/namespace\.init	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/printconf/util/print\.py --	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/PackageKit/pk-upgrade-distro\.sh -- 	gen_context(system_u:object_r:bin_t,s0)
 /usr/share/PackageKit/helpers(/.*)?	gen_context(system_u:object_r:bin_t,s0)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -259,6 +259,7 @@ auth_setattr_faillog_files(pam_domain)
 auth_exec_pam(pam_domain)
 
 files_read_etc_files(pam_domain)
+files_read_usr_files(pam_domain)
 
 logging_send_audit_msgs(pam_domain)
 logging_send_syslog_msg(pam_domain)


### PR DESCRIPTION
.. by allowing /usr overall. pam installs these configuration files there as its `vendordir`. It also does this since aea30822e2fa6f87faf2541da140f69dfdfee728.

(I think that commit message isn't quite right: it seems to do this regardless of libeconf support.)

This comes from auth_use_pam which sudo and su use:
```
AVC avc:  denied  { getattr } for  pid=239941 comm="su" path="/usr/share/pam/security/faillock.conf" dev="dm-0" ino=3227904748
scontext=staff_u:sysadm_r:sysadm_su_t:s0-s0:c0.c1023
tcontext=system_u:object_r:usr_t:s0
tclass=file

AVC avc:  denied  { read } for  pid=239938 comm="sudo" name="pam_env.conf" dev="dm-0" ino=3227906195
scontext=staff_u:staff_r:staff_sudo_t:s0-s0:c0.c1023
tcontext=system_u:object_r:usr_t:s0
tclass=file
```

This is a followup to 169f725b3ff9988de5ab9b628fc45efb8b29d0b2.

Bug: https://bugs.gentoo.org/973082