### PR TITLE
systemd: allow systemd-userwork to speak to systemd-machined

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2424,6 +2424,8 @@ kernel_read_kernel_sysctls(systemd_userdbd_t)
 
 seutil_search_default_contexts(systemd_userdbd_t)
 
+systemd_connect_machined(systemd_userdbd_t)
+
 systemd_log_parse_environment(systemd_userdbd_t)
 
 systemd_stream_connect_nsresourced(systemd_userdbd_t)


### PR DESCRIPTION
We already have `systemd_connect_machined`, so use it for `systemd_userdbd_t`:
```
AVC avc:  denied  { connectto } for  pid=1446 comm="systemd-userwor" path="/run/systemd/userdb/io.systemd.Machine"
scontext=system_u:system_r:systemd_userdbd_t:s0
tcontext=system_u:system_r:systemd_machined_t:s0
tclass=unix_stream_socket
```