### PR TITLE
file_contexts: make /usr/share/pam equivalent to /etc

### DIFF
--- a/config/file_contexts.subs_dist
+++ b/config/file_contexts.subs_dist
@@ -25,6 +25,7 @@
 /usr/local/lib32 /usr/lib
 /usr/local/lib64 /usr/lib
 /usr/local/lib /usr/lib
+/usr/share/pam /etc
 /var/lib/private /var/lib
 /var/cache/private /var/cache
 /var/log/private /var/log


### PR DESCRIPTION
PAM 1.7.2 makes the vendordir build option the default. This puts PAM's config files in `/usr/share/pam` rather than `/etc`. Unfortunately this makes the default file contexts for these files `usr_t` which breaks many things.

Fix this by adding a file equivalence rule for `/usr/share/pam`.

Bug: https://bugs.gentoo.org/973082
Closes: https://github.com/SELinuxProject/refpolicy/pull/1123