### PR TITLE
su: use auth_use_pam

### DIFF
--- a/policy/modules/admin/su.if
+++ b/policy/modules/admin/su.if
@@ -78,7 +78,7 @@ template(`su_restricted_domain_template', `
 
 	auth_domtrans_chk_passwd($1_su_t)
 	auth_dontaudit_read_shadow($1_su_t)
-	auth_use_nsswitch($1_su_t)
+	auth_use_pam($1_su_t)
 	auth_create_faillog_files($1_su_t)
 	auth_rw_faillog($1_su_t)
 	auth_setattr_faillog_files($1_su_t)
@@ -186,7 +186,7 @@ template(`su_role_template',`
 
 	auth_domtrans_chk_passwd($1_su_t)
 	auth_dontaudit_read_shadow($1_su_t)
-	auth_use_nsswitch($1_su_t)
+	auth_use_pam($1_su_t)
 	auth_create_faillog_files($1_su_t)
 	auth_rw_faillog($1_su_t)
 	auth_setattr_faillog_files($1_su_t)


### PR DESCRIPTION
su is linked against pam:
```
$ lddtree /bin/su
/bin/su (interpreter => /lib64/ld-linux-x86-64.so.2)
    libpam.so.0 => /usr/lib64/libpam.so.0
        libaudit.so.1 => /usr/lib64/libaudit.so.1
            libcap-ng.so.0 => /usr/lib64/libcap-ng.so.0
    libpam_misc.so.0 => /usr/lib64/libpam_misc.so.0
    libc.so.6 => /usr/lib64/libc.so.6
```

Noticed when looking into the same bug as 169f725b3ff9988de5ab9b628fc45efb8b29d0b2.

Bug: https://bugs.gentoo.org/973082