### PR TITLE
git: add type transitions for user home content

### DIFF
--- a/policy/modules/services/git.te
+++ b/policy/modules/services/git.te
@@ -334,6 +334,7 @@ userdom_manage_user_tmp_symlinks(git_client_domain)
 userdom_manage_user_home_content_dirs(git_client_domain)
 userdom_manage_user_home_content_files(git_client_domain)
 userdom_manage_user_home_content_symlinks(git_client_domain)
+userdom_user_home_dir_filetrans_user_home_content(git_client_domain, { dir file lnk_file fifo_file sock_file })
 userdom_user_home_content_filetrans(git_client_domain, git_home_t, dir, ".git")
 userdom_use_user_terminals(git_client_domain)
 


### PR DESCRIPTION
My `~/.lesshst` was getting relabeled as `user_home_dir_t` after running `git log`:

```
avc:  denied  { read } for  pid=2374509 comm="less" name=".lesshst" dev="dm-2" ino=78844139
scontext=staff_u:staff_r:staff_git_t:s0-s0:c0.c1023
tcontext=staff_u:object_r:user_home_dir_t:s0
tclass=file
```

Fix that by adding a type transition for *_git_t where we change user_home_dir_t -> user_home_t.

Note: I'm not sure which types to allow in the second argument. Various git tooling may perform a variety of actions in the user home directory. As such, I've included several types as to maintain labelling robustness. We could debate those.