### PR TITLE
authlogin: systemd reads /proc/sys/kernel/random/boot_id via nss

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -492,6 +492,9 @@ files_read_etc_files(nsswitch_domain)
 sysnet_dns_name_resolve(nsswitch_domain)
 
 ifdef(`init_systemd', `
+	# /proc/sys/kernel/random/boot_id
+	kernel_read_kernel_sysctls(nsswitch_domain)
+
 	systemd_stream_connect_userdb(nsswitch_domain)
 	systemd_stream_connect_homed(nsswitch_domain)
 	systemd_stream_connect_nsresourced(nsswitch_domain)


### PR DESCRIPTION
systemd gets there via:
```
...
openat(AT_FDCWD, "/proc/sys/kernel/random/boot_id", O_RDONLY|O_NOCTTY|O_CLOEXEC) = 4
 > /usr/lib64/libc.so.6() [0xa692a]
 > /usr/lib64/libc.so.6(openat64+0x44) [0x138ae4]
 > /usr/lib64/libnss_systemd.so.2() [0x1e739]
 > /usr/lib64/libnss_systemd.so.2() [0x493a6]
 > /usr/lib64/libnss_systemd.so.2() [0x49656]
 > /usr/lib64/libnss_systemd.so.2() [0x369ed]
 > /usr/lib64/libnss_systemd.so.2() [0x40fb6]
 > /usr/lib64/libnss_systemd.so.2(_nss_systemd_getgrnam_r+0x2ac) [0xbe5c]
 > /usr/lib64/libc.so.6(getgrnam_r+0x154) [0x178614]
 > /usr/lib/python3.14/lib-dynload/grp.cpython-314-x86_64-linux-gnu.so() [0x1eda]
...
```

```
AVC avc:  denied  { read } for  pid=60016 comm="pfl" name="boot_id" dev="proc" ino=10376
scontext=system_u:system_r:pfl_t:s0
tcontext=system_u:object_r:sysctl_kernel_t:s0
tclass=file

AVC avc:  denied  { open } for  pid=60016 comm="pfl" path="/proc/sys/kernel/random/boot_id" dev="proc" ino=10376
scontext=system_u:system_r:pfl_t:s0
tcontext=system_u:object_r:sysctl_kernel_t:s0
tclass=file
```