### PR TITLE
systemd: resolved fixes

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1979,6 +1979,8 @@ init_dgram_send(systemd_resolved_t)
 init_watch_runtime_dirs(systemd_resolved_t)
 
 miscfiles_read_generic_certs(systemd_resolved_t)
+# /etc/localtime
+miscfiles_read_localization(systemd_resolved_t)
 
 seutil_libselinux_linked(systemd_resolved_t)
 seutil_read_file_contexts(systemd_resolved_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1987,6 +1987,8 @@ seutil_read_file_contexts(systemd_resolved_t)
 
 systemd_log_parse_environment(systemd_resolved_t)
 systemd_read_networkd_runtime(systemd_resolved_t)
+# Resolve hook
+systemd_stream_connect_networkd(systemd_resolved_t)
 systemd_write_notify_socket(systemd_resolved_t)
 
 optional_policy(`


### PR DESCRIPTION
* Allow access to /etc/localtime

```
AVC avc:  denied  { search } for  pid=1175 comm="systemd-resolve" name="zoneinfo" dev="dm-0" ino=1109940635
scontext=system_u:system_r:systemd_resolved_t:s0
tcontext=system_u:object_r:locale_t:s0
tclass=dir

...

AVC avc:  denied  { open } for  pid=1175 comm="systemd-resolve" path="/usr/share/zoneinfo/Europe/London" dev="dm-0" ino=1102721121
scontext=system_u:system_r:systemd_resolved_t:s0
tcontext=system_u:object_r:locale_t:s0
tclass=file
```

* Allow communication with systemd-networkd for resolved hook

From systemd-resolved(8):
> The DNS servers contacted are determined from the global settings in /etc/systemd/resolved.conf,
> the per-link static settings in /etc/systemd/network/*.network files (in case systemd-networkd.service(8)
> is used), the per-link dynamic settings received over DHCP, information provided via resolvectl(1),
> and any DNS server information made available by other system services. See resolved.conf(5) and
> systemd.network(5) for details about systemd's own configuration files for DNS servers.