### PR TITLE
authlogin: guard dbus_system_bus_client calls with optional_policy

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -208,11 +208,9 @@ template(`sudo_role_template',`
 	optional_policy(`
 		auth_use_pam_systemd($1_sudo_t)
 
-		ifdef(`init_systemd',`
-			init_dbus_chat($1_sudo_t)
+		init_dbus_chat($1_sudo_t)
 
-			systemd_read_logind_state($1_sudo_t)
-		')
+		systemd_read_logind_state($1_sudo_t)
 	')
 
 	optional_policy(`

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -286,12 +286,15 @@ ifdef(`distro_debian',`
 ')
 
 ifdef(`init_systemd',`
-	auth_use_pam_systemd(sshd_t)
-	init_dbus_chat(sshd_t)
 	# dynamic users
 	init_stream_connect(sshd_t)
 	init_rw_stream_sockets(sshd_t)
 	systemd_write_inherited_logind_sessions_pipes(sshd_t)
+
+	optional_policy(`
+		auth_use_pam_systemd(sshd_t)
+		init_dbus_chat(sshd_t)
+	')
 ')
 
 tunable_policy(`ssh_sysadm_login',`

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -87,7 +87,6 @@ interface(`auth_use_pam',`
 ## </param>
 #
 interface(`auth_use_pam_systemd',`
-	dbus_system_bus_client($1)
 	systemd_connect_machined($1)
 	systemd_dbus_chat_logind($1)
 	systemd_read_logind_state($1)
@@ -95,6 +94,10 @@ interface(`auth_use_pam_systemd',`
 
 	# to read /etc/machine-id
 	files_read_etc_runtime_files($1)
+
+	optional_policy(`
+		dbus_system_bus_client($1)
+	')
 ')
 
 ########################################

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -168,7 +168,9 @@ ifdef(`distro_ubuntu',`
 ')
 
 ifdef(`init_systemd',`
-	auth_use_pam_systemd(chkpwd_t)
+	optional_policy(`
+		auth_use_pam_systemd(chkpwd_t)
+	')
 ')
 
 optional_policy(`


### PR DESCRIPTION
The dbus policy may not be installed (yet) when installing the systemd
module (for the first time).

Note that it is possible I believe to use systemd w/o DBus at all but
it's quite rare.

Bug: https://bugs.gentoo.org/975996
Signed-off-by: Sam James <sam@gentoo.org>