### PR TITLE
run_init: permit to read usr files

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -443,6 +443,7 @@ dev_dontaudit_list_all_dev_nodes(run_init_t)
 domain_use_interactive_fds(run_init_t)
 
 files_read_etc_files(run_init_t)
+files_read_usr_files(run_init_t)
 files_dontaudit_search_all_dirs(run_init_t)
 
 fs_getattr_xattr_fs(run_init_t)


### PR DESCRIPTION
I want to restart a service via run_init and it fail run_init /etc/init.d/ntpd restart
Authenticating root.
run_init: incorrect password for root
authentication failed.

This produce an AVC:
type=AVC msg=audit(1779957506.708:913): avc:  denied  { read } for  pid=1660 comm="run_init" name="faillock.conf" dev="vda" ino=663652 scontext=unconfined_u:unconfined_r:run_init_t tcontext=system_u:object_r:usr_t tclass=file permissive=0

It try to read:
ls -lZ /usr/share/pam/security/faillock.conf
-rw-r--r--. 1 root root system_u:object_r:usr_t 2207 janv. 22 08:00 /usr/share/pam/security/faillock.conf

See: https://bugs.gentoo.org/976175