### PR TITLE
fapolicyd: fix issue with tmpfs_t write

### DIFF
--- a/policy/modules/admin/fapolicyd.te
+++ b/policy/modules/admin/fapolicyd.te
@@ -38,6 +38,9 @@ logging_log_file(fapolicyd_log_t)
 type fapolicyd_runtime_t;
 files_runtime_file(fapolicyd_runtime_t)
 
+type fapolicyd_tmpfs_t;
+files_tmpfs_file(fapolicyd_tmpfs_t)
+
 type fagenrules_tmp_t;
 files_tmp_file(fagenrules_tmp_t)
 
@@ -58,6 +61,7 @@ allow fapolicyd_t self:process { setcap setsched };
 
 allow fapolicyd_t fapolicyd_log_t:file { create_file_perms write_file_perms };
 allow fapolicyd_t fapolicyd_runtime_t:dir setattr_dir_perms;
+allow fapolicyd_t fapolicyd_tmpfs_t:file write_inherited_file_perms;
 
 manage_fifo_files_pattern(fapolicyd_t, fapolicyd_runtime_t, fapolicyd_runtime_t)
 manage_files_pattern(fapolicyd_t, fapolicyd_runtime_t, fapolicyd_runtime_t)
@@ -83,6 +87,7 @@ files_watch_all_mount_perm(fapolicyd_t)
 files_watch_all_mount_sb(fapolicyd_t)
 
 fs_getattr_xattr_fs(fapolicyd_t)
+fs_tmpfs_filetrans(fapolicyd_t, fapolicyd_tmpfs_t, file)
 fs_watch_all_fs(fapolicyd_t)
 
 logging_log_filetrans(fapolicyd_t, fapolicyd_log_t, file)


### PR DESCRIPTION
Update to RHEL 9.8, now fapolicyd_t (which is starting /usr/bin/fapolicyd-rpm-loader) now is writing to memfs:rpm_snapshot

node=localhost type=PROCTITLE msg=audit(05/28/2026 14:28:47.058:362): proctitle=fapolicyd-rpm-loader
node=localhost type=SYSCALL msg=audit(05/28/2026 14:28:47.058:362): arch=x86_64 syscall=write success=no exit=EACCES(Permission denied) a0=0x4 a1=0x55f492F86720 a2=0x7d a3=0x7f1e99b1c20 items=0 ppid=4500 pid=4501 auid=unset uid=fapolicyd gid=fapolicyd euid=fapolicyd suid=fapolicyd fsuid=fapolicyd egid=fapolicyd sgid=fapolicyd fsgid=fapolicyd tty=(none) ses=unset comm=fapolicyd-rpm-l exe=/usr/bin/fapolicyd-rpm-loader subj=system_u:system_r:fapolicyd_t:s0 key=(null)
node=localhost type=AVC msg=audit(05/28/2026 14:28:47,058:362): avc: denied { write } for pid=4501 comm=fapolicyd-rpm-l path=/memfd:rpm_snapshot (deleted) dev="tmpfs" ino=2048 scontext=system_u:object_r:fapolicyd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=0