### PR TITLE
systemd: systemd-sysctl needs locales

### DIFF
--- a/policy/modules/system/modutils.te
+++ b/policy/modules/system/modutils.te
@@ -123,7 +123,7 @@ userdom_dontaudit_search_user_home_dirs(kmod_t)
 ifdef(`init_systemd',`
 	# for /run/tmpfiles.d/kmod.conf
 	allow kmod_t kmod_tmpfiles_conf_t:file manage_file_perms;
-	# kmod needs to create /run/tmpdiles.d
+	# kmod needs to create /run/tmpfiles.d
 	systemd_tmpfiles_creator(kmod_t)
 
 	init_rw_stream_sockets(kmod_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -491,6 +491,8 @@ fs_getattr_cgroup(systemd_binfmt_t)
 fs_search_cgroup_dirs(systemd_binfmt_t)
 fs_getattr_nsfs_files(systemd_binfmt_t)
 
+miscfiles_read_localization(systemd_binfmt_t)
+
 ######################################
 #
 # Cgroups local policy
@@ -1336,6 +1338,8 @@ init_stop_transient_units(systemd_machined_t)
 
 logging_send_syslog_msg(systemd_machined_t)
 
+miscfiles_read_localization(systemd_machined_t)
+
 seutil_search_default_contexts(systemd_machined_t)
 
 term_getattr_pty_fs(systemd_machined_t)
@@ -1756,6 +1760,8 @@ kernel_read_kernel_sysctls(systemd_nsresourced_t)
 # for /proc/cmdline
 kernel_read_system_state(systemd_nsresourced_t)
 
+miscfiles_read_localization(systemd_nsresourced_t)
+
 systemd_log_parse_environment(systemd_nsresourced_t)
 
 #######################################
@@ -2075,6 +2081,8 @@ fs_search_ramfs(systemd_sysctl_t)
 fs_search_tmpfs(systemd_sysctl_t)
 fs_getattr_nsfs_files(systemd_sysctl_t)
 
+miscfiles_read_localization(systemd_sysctl_t)
+
 systemd_log_parse_environment(systemd_sysctl_t)
 
 #########################################
@@ -2252,7 +2260,7 @@ logging_setattr_syslogd_tmp_dirs(systemd_tmpfiles_t)
 
 miscfiles_manage_man_pages(systemd_tmpfiles_t)
 miscfiles_relabel_man_cache(systemd_tmpfiles_t)
-miscfiles_getattr_localization(systemd_tmpfiles_t)
+miscfiles_read_localization(systemd_tmpfiles_t)
 
 seutil_read_config(systemd_tmpfiles_t)
 seutil_read_file_contexts(systemd_tmpfiles_t)
@@ -2442,6 +2450,8 @@ init_search_runtime(systemd_userdbd_t)
 init_read_state(systemd_userdbd_t)
 
 kernel_read_kernel_sysctls(systemd_userdbd_t)
+
+miscfiles_read_localization(systemd_userdbd_t)
 
 seutil_search_default_contexts(systemd_userdbd_t)
 


### PR DESCRIPTION
```
AVC avc:  denied  { search } for  pid=1117 comm="systemd-sysctl" name="locale" dev="dm-0" ino=1080894036
scontext=system_u:system_r:systemd_sysctl_t:s0
tcontext=system_u:object_r:locale_t:s0 tclass=dir
```