### PR TITLE
init: adapt to OpenRC changes

### DIFF
--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -60,10 +60,12 @@ ifdef(`distro_gentoo', `
 /usr/lib/rc/cache(/.*)?		gen_context(system_u:object_r:initrc_state_t,s0)
 /usr/lib/rc/console(/.*)?		gen_context(system_u:object_r:initrc_state_t,s0)
 /usr/lib/rc/init\.d(/.*)?		gen_context(system_u:object_r:initrc_state_t,s0)
+/usr/libexec/rc/console(/.*)?		gen_context(system_u:object_r:initrc_state_t,s0)
 /usr/sbin/rc			--	gen_context(system_u:object_r:rc_exec_t,s0)
 /usr/sbin/openrc		--	gen_context(system_u:object_r:rc_exec_t,s0)
 /usr/sbin/openrc-init		--	gen_context(system_u:object_r:init_exec_t,s0)
 /usr/sbin/openrc-shutdown	--	gen_context(system_u:object_r:init_exec_t,s0)
+/var/cache/rc(/.*)?			gen_context(system_u:object_r:initrc_state_t,s0)
 ')
 
 ifdef(`distro_redhat',`


### PR DESCRIPTION
* Cache has moved to /var/cache/rc, per b71db4053651662a37b42f0b1273a92a870a85aa in openrc.git (note that it says /var/cache/openrc but the commit actually uses /var/cache/rc).

* keymaps are now stored in /usr/libexec/rc/console/keymap. This is since 696e684c722732f0ec0eddf7bd17cf85ca07aeaa in openrc.git.

Bug: https://bugs.gentoo.org/974290