### PR TITLE
ci: Refactor to centralize global variables.

### DIFF
--- a/.github/workflows/build-policy.yml
+++ b/.github/workflows/build-policy.yml
@@ -32,27 +32,17 @@ on:
         required: false
         type: string
         default: "setools"
+      matrix:
+        description: "JSON build matrix from global-vars.yml"
+        required: true
+        type: string
 
 jobs:
   build:
     runs-on: ubuntu-22.04
 
     strategy:
-      matrix:
-        # matrix updates must also be duplicated to validate-policy.yml and diff-policy.yml
-        distro: ["redhat", "debian", "gentoo"]
-        type: ["standard", "mcs", "mls"]
-        monolithic: ["y", "n"]
-        systemd: ["y", "n"]
-        direct_initrc: ["y", "n"]
-        apps-off: ["unconfined", ""]
-        exclude:
-          - { distro: "redhat", systemd: "n" }
-          - { distro: "redhat", direct_initrc: "y" }
-          - { distro: "debian", systemd: "n" }
-          - { distro: "debian", direct_initrc: "y" }
-          - { type: "mls", apps-off: "" }
-          - { systemd: "y", direct_initrc: "y" }
+      matrix: ${{ fromJSON(inputs.matrix) }}
 
     steps:
     - name: Checkout refpolicy sources

--- a/.github/workflows/diff-policy.yml
+++ b/.github/workflows/diff-policy.yml
@@ -23,32 +23,17 @@ on:
         description: "Name of the setools artifact to download"
         required: true
         type: string
+      matrix:
+        description: "JSON build matrix from global-vars.yml"
+        required: true
+        type: string
 
 jobs:
   sediff:
     runs-on: ubuntu-22.04
 
     strategy:
-      matrix:
-        distro: ["redhat", "debian", "gentoo"]
-        type: ["standard", "mcs", "mls"]
-        monolithic: ["y", "n"]
-        systemd: ["y", "n"]
-        direct_initrc: ["y", "n"]
-        apps-off: ["unconfined", ""]
-        exclude:
-          - { distro: "redhat", systemd: "n" }
-          - { distro: "redhat", direct_initrc: "y" }
-          - { distro: "debian", systemd: "n" }
-          - { distro: "debian", direct_initrc: "y" }
-          - { type: "mls", apps-off: "" }
-          - { systemd: "y", direct_initrc: "y" }
-          # above here, the matrix must be the same as in build-policy.yml.
-          # below here, remove duplicate analyses
-          - { monolithic: "n" }
-          - { type: "standard" }
-          - { apps-off: "" }
-          - { systemd: "n" }
+      matrix: ${{ fromJSON(inputs.matrix) }}
 
     env:
       OUTPUT_LOG: diff-${{ matrix.distro }}-${{ matrix.type }}-${{ matrix.monolithic }}-${{ matrix.systemd }}-${{ matrix.direct_initrc }}-${{ matrix.apps-off }}.log

--- a/.github/workflows/global-vars.yml
+++ b/.github/workflows/global-vars.yml
@@ -1,0 +1,96 @@
+name: Global variables
+
+# This is hacky, since GitHub Actions doesn't allow for setting workflow input
+# values from a global env block in tests.yml.
+
+env:
+  # Minimum versions to build refpolicy.
+  PYTHON_VERSION: "3.10"
+  SELINUX_USERSPACE_VERSION: "3.9"
+  # branch for sechecker
+  SECHECKER_VERSION: "4.5"
+  # branch for selint
+  SELINT_VERSION: "v1.5.0"
+
+  USERSPACE_ARTIFACT_NAME: "selinux-userspace.tar.gz"
+  SETOOLS_ARTIFACT_NAME: "setools.whl"
+
+on:
+  workflow_call:
+    outputs:
+      python-version:
+        description: "Python version to use"
+        value: ${{ jobs.populate.outputs.python-version }}
+      selinux-userspace-version:
+        description: "SELinux userspace version"
+        value: ${{ jobs.populate.outputs.selinux-userspace-version }}
+      sechecker-version:
+        description: "SETools/sechecker version"
+        value: ${{ jobs.populate.outputs.sechecker-version }}
+      selint-version:
+        description: "selint version"
+        value: ${{ jobs.populate.outputs.selint-version }}
+      userspace-artifact-name:
+        description: "Name of the userspace artifact"
+        value: ${{ jobs.populate.outputs.userspace-artifact-name }}
+      setools-artifact-name:
+        description: "Name of the setools artifact"
+        value: ${{ jobs.populate.outputs.setools-artifact-name }}
+      build-matrix:
+        description: "Full build matrix for policy builds"
+        value: ${{ jobs.populate.outputs.build-matrix }}
+      analysis-matrix:
+        description: "Reduced matrix for validation and diff analysis"
+        value: ${{ jobs.populate.outputs.analysis-matrix }}
+
+jobs:
+  populate:
+    runs-on: ubuntu-latest
+
+    outputs:
+      python-version: ${{ steps.set.outputs.python-version }}
+      selinux-userspace-version: ${{ steps.set.outputs.selinux-userspace-version }}
+      sechecker-version: ${{ steps.set.outputs.sechecker-version }}
+      selint-version: ${{ steps.set.outputs.selint-version }}
+      userspace-artifact-name: ${{ steps.set.outputs.userspace-artifact-name }}
+      setools-artifact-name: ${{ steps.set.outputs.setools-artifact-name }}
+      build-matrix: ${{ steps.set.outputs.build-matrix }}
+      analysis-matrix: ${{ steps.set.outputs.analysis-matrix }}
+
+    steps:
+      - id: set
+        shell: bash
+        run: |
+          echo "python-version=$PYTHON_VERSION" >> $GITHUB_OUTPUT
+          echo "selinux-userspace-version=$SELINUX_USERSPACE_VERSION" >> $GITHUB_OUTPUT
+          echo "sechecker-version=$SECHECKER_VERSION" >> $GITHUB_OUTPUT
+          echo "selint-version=$SELINT_VERSION" >> $GITHUB_OUTPUT
+          echo "userspace-artifact-name=$USERSPACE_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+          echo "setools-artifact-name=$SETOOLS_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+          build_matrix='{
+            "distro": ["redhat", "debian", "gentoo"],
+            "type": ["standard", "mcs", "mls"],
+            "monolithic": ["y", "n"],
+            "systemd": ["y", "n"],
+            "direct_initrc": ["y", "n"],
+            "apps-off": ["unconfined", ""],
+            "exclude": [
+              {"distro": "redhat", "systemd": "n"},
+              {"distro": "redhat", "direct_initrc": "y"},
+              {"distro": "debian", "systemd": "n"},
+              {"distro": "debian", "direct_initrc": "y"},
+              {"type": "mls", "apps-off": ""},
+              {"systemd": "y", "direct_initrc": "y"}
+            ]
+          }'
+          echo "build-matrix=$(echo $build_matrix | jq -c .)" >> $GITHUB_OUTPUT
+
+          # remove duplicate analyses
+          analysis_extra_excludes='[
+            {"monolithic": "n"},
+            {"type": "standard"},
+            {"apps-off": ""},
+            {"systemd": "n"}
+          ]'
+          analysis_matrix=$(echo "$build_matrix" | jq -c --argjson extra "$analysis_extra_excludes" '.exclude += $extra')
+          echo "analysis-matrix=$analysis_matrix" >> $GITHUB_OUTPUT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,75 +1,74 @@
 name: Build tests
 
-on: [push, pull_request]
-
-env:
-  # Minimum versions to build refpolicy.
-  PYTHON_VERSION: "3.10"
-  SELINUX_USERSPACE_VERSION: "3.9"
-  # branch for sechecker
-  SECHECKER_VERSION: "4.5"
-  # branch for selint
-  SELINT_VERSION: "v1.5.0"
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
+  global_vars:
+    uses: ./.github/workflows/global-vars.yml
+
   lint_branch_policy:
     uses: ./.github/workflows/lint-policy.yml
+    needs: global_vars
     with:
-      python-version: "3.10"
-      selint-version: "v1.5.0"
+      python-version: ${{ needs.global_vars.outputs.python-version }}
+      selint-version: ${{ needs.global_vars.outputs.selint-version }}
 
   build_userspace:
     uses: ./.github/workflows/build-userspace.yml
+    needs: global_vars
     # depend on lint so expensive operations don't run if lint fails
     with:
-      version: "3.9"
-      python-version: "3.10"
-      artifact-name: "selinux-userspace.tar.gz"
+      version: ${{ needs.global_vars.outputs.selinux-userspace-version }}
+      python-version: ${{ needs.global_vars.outputs.python-version }}
+      artifact-name: ${{ needs.global_vars.outputs.userspace-artifact-name }}
 
   build_setools:
     uses: ./.github/workflows/build-setools.yml
-    needs: build_userspace
+    needs: [build_userspace, global_vars]
     with:
-      version: "4.5"
-      python-version: "3.10"
-      artifact-name: "setools.whl"
-      userspace-artifact-name: "selinux-userspace.tar.gz"
+      version: ${{ needs.global_vars.outputs.sechecker-version }}
+      python-version: ${{ needs.global_vars.outputs.python-version }}
+      artifact-name: ${{ needs.global_vars.outputs.setools-artifact-name }}
+      userspace-artifact-name: ${{ needs.global_vars.outputs.userspace-artifact-name }}
 
   build_branch_policy:
     uses: ./.github/workflows/build-policy.yml
-    needs: [lint_branch_policy, build_setools, build_userspace]
+    needs: [lint_branch_policy, build_setools, build_userspace, global_vars]
     with:
-      # Minimum versions to build refpolicy.
-      python-version: "3.10"
-      userspace-artifact-name: "selinux-userspace.tar.gz"
-      setools-artifact-name: "setools.whl"
+      python-version: ${{ needs.global_vars.outputs.python-version }}
+      userspace-artifact-name: ${{ needs.global_vars.outputs.userspace-artifact-name }}
+      setools-artifact-name: ${{ needs.global_vars.outputs.setools-artifact-name }}
+      matrix: ${{ needs.global_vars.outputs.build-matrix }}
 
   validate_branch_policy:
     uses: ./.github/workflows/validate-policy.yml
-    needs: [build_branch_policy, build_setools, build_userspace]
+    needs: [build_branch_policy, build_setools, build_userspace, global_vars]
     with:
-      python-version: "3.10"
-      userspace-artifact-name: "selinux-userspace.tar.gz"
-      setools-artifact-name: "setools.whl"
+      python-version: ${{ needs.global_vars.outputs.python-version }}
+      userspace-artifact-name: ${{ needs.global_vars.outputs.userspace-artifact-name }}
+      setools-artifact-name: ${{ needs.global_vars.outputs.setools-artifact-name }}
+      matrix: ${{ needs.global_vars.outputs.analysis-matrix }}
 
   build_PRtarget_policy:
     uses: ./.github/workflows/build-policy.yml
-    needs: [lint_branch_policy, build_setools, build_userspace]
+    needs: [lint_branch_policy, build_setools, build_userspace, global_vars]
     if: ${{ github.event_name == 'pull_request' }}
     with:
       version: ${{ github.base_ref }}
       artifact-name: "PRbase"
-      python-version: "3.10"
-      userspace-artifact-name: "selinux-userspace.tar.gz"
-      setools-artifact-name: "setools.whl"
+      python-version: ${{ needs.global_vars.outputs.python-version }}
+      userspace-artifact-name: ${{ needs.global_vars.outputs.userspace-artifact-name }}
+      setools-artifact-name: ${{ needs.global_vars.outputs.setools-artifact-name }}
+      matrix: ${{ needs.global_vars.outputs.build-matrix }}
 
   diff_policy:
     uses: ./.github/workflows/diff-policy.yml
-    needs: [build_branch_policy, build_PRtarget_policy, build_setools, build_userspace]
+    needs: [build_branch_policy, build_PRtarget_policy, build_setools, build_userspace, global_vars]
     if: ${{ github.event_name == 'pull_request' }}
     with:
       left: "PRbase"
       right: "refpolicy"
-      python-version: "3.10"
-      userspace-artifact-name: "selinux-userspace.tar.gz"
-      setools-artifact-name: "setools.whl"
+      python-version: ${{ needs.global_vars.outputs.python-version }}
+      userspace-artifact-name: ${{ needs.global_vars.outputs.userspace-artifact-name }}
+      setools-artifact-name: ${{ needs.global_vars.outputs.setools-artifact-name }}
+      matrix: ${{ needs.global_vars.outputs.analysis-matrix }}

--- a/.github/workflows/validate-policy.yml
+++ b/.github/workflows/validate-policy.yml
@@ -15,32 +15,17 @@ on:
         description: "Name of the setools artifact to download"
         required: true
         type: string
+      matrix:
+        description: "JSON build matrix from global-vars.yml"
+        required: true
+        type: string
 
 jobs:
   sechecker:
     runs-on: ubuntu-22.04
 
     strategy:
-      matrix:
-        distro: ["redhat", "debian", "gentoo"]
-        type: ["standard", "mcs", "mls"]
-        monolithic: ["y", "n"]
-        systemd: ["y", "n"]
-        direct_initrc: ["y", "n"]
-        apps-off: ["unconfined", ""]
-        exclude:
-          - { distro: "redhat", systemd: "n" }
-          - { distro: "redhat", direct_initrc: "y" }
-          - { distro: "debian", systemd: "n" }
-          - { distro: "debian", direct_initrc: "y" }
-          - { type: "mls", apps-off: "" }
-          - { systemd: "y", direct_initrc: "y" }
-          # above here, the matrix must be the same as in build-policy.yml.
-          # below here, remove duplicate analyses
-          - { monolithic: "n" }
-          - { type: "standard" }
-          - { apps-off: "" }
-          - { systemd: "n" }
+      matrix: ${{ fromJSON(inputs.matrix) }}
 
     env:
       OUTPUT_LOG: validation-${{ matrix.distro }}-${{ matrix.type }}-${{ matrix.monolithic }}-${{ matrix.systemd }}-${{ matrix.direct_initrc }}-${{ matrix.apps-off }}.log


### PR DESCRIPTION
The top-level env block cannot be accessed from the reuable workflow invocation, resulting in a syntax error like this:

```
(Line: 25, Col: 23): Unrecognized named-value: 'env'. Located at position 1
within expression: env.PYTHON_VERSION, (Line: 26, Col: 23): Unrecognized
named-value: 'env'. Located at position 1 within expression: env.SELINT_VERSION
```