### PR TITLE
portage: add some more locations

### DIFF
--- a/policy/modules/admin/portage.fc
+++ b/policy/modules/admin/portage.fc
@@ -26,6 +26,7 @@
 
 /var/db/pkg(/.*)?	gen_context(system_u:object_r:portage_db_t,s0)
 /var/db/repos(/.*)?	gen_context(system_u:object_r:portage_ebuild_t,s0)
+/var/cache/binhost(/.*)?  gen_context(system_u:object_r:portage_ebuild_t,s0)
 /var/cache/binpkgs(/.*)?  gen_context(system_u:object_r:portage_ebuild_t,s0)
 /var/cache/distfiles(/.*)?	gen_context(system_u:object_r:portage_ebuild_t,s0)
 /var/cache/distfiles/cvs-src(/.*)?	gen_context(system_u:object_r:portage_srcrepo_t,s0)

--- a/policy/modules/admin/portage.fc
+++ b/policy/modules/admin/portage.fc
@@ -3,6 +3,7 @@
 /etc/make\.profile	-l	gen_context(system_u:object_r:portage_conf_t,s0)
 /etc/portage(/.*)?	gen_context(system_u:object_r:portage_conf_t,s0)
 /etc/portage/gpg(/.*)?	gen_context(system_u:object_r:portage_gpg_t,s0)
+/etc/portage/gnupg(/.*)?	gen_context(system_u:object_r:portage_gpg_t,s0)
 
 /usr/bin/emerge --	gen_context(system_u:object_r:portage_exec_t,s0)
 /usr/bin/emerge-webrsync				--	gen_context(system_u:object_r:portage_fetch_exec_t,s0)


### PR DESCRIPTION
Portage uses /var/cache/binhost/* for downloaded binpkgs by default
since cf720dae82166593a5deeeffe2c42681ffd57ce5 in portage.git.

Subdirectories under there are for each configured binhost.

The idea is to separate out locally built binpkgs vs those of remote
provenance.

Label it the same as /var/cache/binpkgs.

Signed-off-by: Sam James <sam@gentoo.org>