### PR TITLE
systemd-networkd fixes

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -216,6 +216,9 @@ type systemd_networkd_runtime_t alias systemd_networkd_var_run_t;
 files_runtime_file(systemd_networkd_runtime_t)
 init_mountpoint(systemd_networkd_runtime_t)
 
+type systemd_networkd_tmpfs_t;
+files_tmpfs_file(systemd_networkd_tmpfs_t)
+
 type systemd_networkd_unit_t;
 init_unit_file(systemd_networkd_unit_t)
 
@@ -1440,6 +1443,9 @@ manage_dirs_pattern(systemd_networkd_t, systemd_networkd_runtime_t, systemd_netw
 manage_files_pattern(systemd_networkd_t, systemd_networkd_runtime_t, systemd_networkd_runtime_t)
 manage_lnk_files_pattern(systemd_networkd_t, systemd_networkd_runtime_t, systemd_networkd_runtime_t)
 manage_sock_files_pattern(systemd_networkd_t, systemd_networkd_runtime_t, systemd_networkd_runtime_t)
+
+allow systemd_networkd_t systemd_networkd_tmpfs_t:file manage_file_perms;
+fs_tmpfs_filetrans(systemd_networkd_t, systemd_networkd_tmpfs_t, file)
 
 init_var_lib_filetrans(systemd_networkd_t, systemd_networkd_var_lib_t, dir)
 manage_dirs_pattern(systemd_networkd_t, systemd_networkd_var_lib_t, systemd_networkd_var_lib_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -222,6 +222,9 @@ init_unit_file(systemd_networkd_unit_t)
 type systemd_networkd_var_lib_t;
 files_type(systemd_networkd_var_lib_t)
 
+type systemd_networkd_tmpfs_t;
+files_tmpfs_file(systemd_networkd_tmpfs_t)
+
 type systemd_notify_t;
 type systemd_notify_exec_t;
 init_daemon_domain(systemd_notify_t, systemd_notify_exec_t)
@@ -1444,6 +1447,9 @@ manage_sock_files_pattern(systemd_networkd_t, systemd_networkd_runtime_t, system
 init_var_lib_filetrans(systemd_networkd_t, systemd_networkd_var_lib_t, dir)
 manage_dirs_pattern(systemd_networkd_t, systemd_networkd_var_lib_t, systemd_networkd_var_lib_t)
 manage_files_pattern(systemd_networkd_t, systemd_networkd_var_lib_t, systemd_networkd_var_lib_t)
+
+allow systemd_networkd_t systemd_networkd_tmpfs_t:file manage_file_perms;
+fs_tmpfs_filetrans(systemd_networkd_t, systemd_networkd_tmpfs_t, file)
 
 kernel_read_system_state(systemd_networkd_t)
 kernel_read_kernel_sysctls(systemd_networkd_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1476,6 +1476,8 @@ fs_search_cgroup_dirs(systemd_networkd_t)
 fs_read_nsfs_files(systemd_networkd_t)
 fs_watch_memory_pressure(systemd_networkd_t)
 
+mount_list_runtime(systemd_networkd_t)
+
 auth_use_nsswitch(systemd_networkd_t)
 
 init_dgram_send(systemd_networkd_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1487,6 +1487,8 @@ logging_send_syslog_msg(systemd_networkd_t)
 
 miscfiles_read_localization(systemd_networkd_t)
 
+mount_list_runtime(systemd_networkd_t)
+
 sysnet_read_config(systemd_networkd_t)
 
 systemd_log_parse_environment(systemd_networkd_t)


### PR DESCRIPTION
This fixes two systemd-networkd denials that i ran into.

Note that i am pretty new to SELinux, but i tried to take inspiration from existing patterns in systemd.te such as  `systemd_homed_tmpfs_t` and `mount_list_runtime(systemd_user_session_type)`.