### PR TITLE
nfs: allow nfsd_t to create netlink_generic_socket

### DIFF
--- a/policy/modules/services/rpc.te
+++ b/policy/modules/services/rpc.te
@@ -314,6 +314,7 @@ optional_policy(`
 #
 
 allow nfsd_t self:capability { dac_override dac_read_search lease setpcap sys_admin sys_resource };
+allow nfsd_t self:netlink_generic_socket create_socket_perms;
 allow nfsd_t self:process setcap;
 
 allow nfsd_t exports_t:file read_file_perms;


### PR DESCRIPTION
Fix:
avc:  denied  { create } for  pid=375 comm="rpc.mountd" scontext=system_u:system_r:nfsd_t tcontext=system_u:system_r:nfsd_t tclass=netlink_generic_socket permissive=0

type=SYSCALL msg=audit(1781511445.636:69): arch=c000003e syscall=41 success=no exit=-13 a0=10 a1=80003 a2=10 a3=7fb62871cac8 items=0 ppid=370 pid=375 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="rpc.mountd" exe="/usr/sbin/rpc.mountd" subj=system_u:system_r:nfsd_t key=(null) ARCH=x86_64 SYSCALL=socket AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"