### PR TITLE
irqbalance: v1.9.4 added namespacing in the systemd unit.

### DIFF
--- a/policy/modules/services/irqbalance.te
+++ b/policy/modules/services/irqbalance.te
@@ -23,8 +23,9 @@ init_unit_file(irqbalance_unit_t)
 # Local policy
 #
 
-allow irqbalance_t self:capability { setpcap };
-dontaudit irqbalance_t self:capability sys_tty_config;
+# v1.9.4 added namespacing in the systemd unit
+allow irqbalance_t self:{ capability cap_userns } setpcap;
+dontaudit irqbalance_t self:{ capability cap_userns } sys_tty_config;
 allow irqbalance_t self:process { getcap getsched setcap signal_perms };
 allow irqbalance_t self:udp_socket create_socket_perms;
 allow irqbalance_t self:unix_stream_socket create_stream_socket_perms;


### PR DESCRIPTION
Add cap_userns equivalents to standard capability rules since irqbalance v1.9.4 added PrivateUsers=true to the systemd unit.