### PR TITLE
Enable policy capabilities that require libsepol 3.9, except netlink_xperm.

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -50,6 +50,7 @@ type kernel_t, can_load_kernmodule;
 domain_base_type(kernel_t)
 role system_r types kernel_t;
 sid kernel gen_context(system_u:system_r:kernel_t,mls_systemhigh)
+sid init gen_context(system_u:system_r:kernel_t,mls_systemhigh)
 
 #
 # DebugFS
@@ -228,7 +229,6 @@ sid any_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 sid file_labels		gen_context(system_u:object_r:unlabeled_t,s0)
 sid icmp_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 sid igmp_packet		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
-sid init		gen_context(system_u:object_r:unlabeled_t,s0)
 sid kmod		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 sid policy		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 sid scmp_packet		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)

--- a/policy/policy_capabilities
+++ b/policy/policy_capabilities
@@ -105,7 +105,7 @@ policycap nnp_nosuid_transition;
 # Added checks:
 # (none)
 #
-#policycap genfs_seclabel_symlinks;
+policycap genfs_seclabel_symlinks;
 
 # Always allow FIOCLEX and FIONCLEX ioctl.
 # Requires libsepol 3.4 and kernel 5.18.
@@ -113,7 +113,7 @@ policycap nnp_nosuid_transition;
 # Removed checks:
 # common file/socket: ioctl { 0x5450 0x5451 }
 #
-#policycap ioctl_skip_cloexec;
+policycap ioctl_skip_cloexec;
 
 # Enable separate user space context for processes started before first
 # policy load.
@@ -121,7 +121,7 @@ policycap nnp_nosuid_transition;
 #
 # Added checks:
 # (none)
-#policycap userspace_initial_context;
+policycap userspace_initial_context;
 
 # Enable netlink xperms support. Requires libsepol 3.8+
 # and kernel 6.13.
@@ -144,14 +144,14 @@ policycap nnp_nosuid_transition;
 #
 # Added checks:
 # (none)
-#policycap netif_wildcard;
+policycap netif_wildcard;
 
 # Enable wildcard matching for genfscon paths.
 # Requires libsepol 3.9+ and kernel 6.16+.
 #
 # Added checks:
 # (none)
-#policycap genfs_seclabel_wildcard;
+policycap genfs_seclabel_wildcard;
 
 # Enable per-file labeling for functionfs.
 # Requires libsepol 3.10+ and kernel 6.18+.


### PR DESCRIPTION
This sets the `init` initial sid to `kernel_t` to maintain current behavior with userspace_initial_context enabled.