### PR TITLE
wayland: Add wayland_stream_connect interface

### DIFF
--- a/policy/modules/session/wayland.fc
+++ b/policy/modules/session/wayland.fc
@@ -1,1 +1,2 @@
 /run/user/%{USERID}/wayland-.*	-s	gen_context(system_u:object_r:wayland_runtime_t,s0)
+/run/wayland-.*		-s	gen_context(system_u:object_r:wayland_runtime_t,s0)

--- a/policy/modules/session/wayland.if
+++ b/policy/modules/session/wayland.if
@@ -99,3 +99,25 @@ interface(`wayland_client_sandboxed_domain',`
 
 	typeattribute $1 wayland_client_sandboxed;
 ')
+
+#########################################
+## <summary>
+##	Connect to the Wayland compositor
+##	using a UNIX domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`wayland_stream_connect',`
+	gen_require(`
+		type wayland_runtime_t;
+	')
+
+	files_search_runtime($1)
+	userdom_search_user_runtime($1)
+	allow $1 wayland_runtime_t:sock_file write_sock_file_perms;
+	allow $1 wayland_runtime_t:unix_stream_socket connectto;
+')


### PR DESCRIPTION
Add a new interface, wayland_stream_connect(), to allow domains to connect to a Wayland compositor via an UNIX stream socket.

This interface grants the necessary permissions to search the user runtime directory and establish a stream connection to Wayland compositor sockets labeled with wayland_runtime_t.

Typical usage includes enabling confined domains (such as container runtimes or applications) to communicate with the Wayland display server.