### PR TITLE
docker: Allow dockerd to connect to pulseaudio and wayland sockets

### DIFF
--- a/policy/modules/services/docker.te
+++ b/policy/modules/services/docker.te
@@ -5,6 +5,15 @@ policy_module(docker)
 # Declarations
 #
 
+## <desc>
+##	<p>
+##	Determine whether the Docker daemon can connect to user
+##	session services such as PulseAudio and Wayland over
+##	UNIX stream sockets.
+##	</p>
+## </desc>
+gen_tunable(dockerd_connect_user_services, false)
+
 container_engine_domain_template(dockerd)
 container_system_engine(dockerd_t)
 optional_policy(`
@@ -75,6 +84,18 @@ ifdef(`init_systemd',`
 	init_stop_system(dockerd_t)
 	init_get_system_status(dockerd_t)
 	init_stop_generic_units(dockerd_t)
+')
+
+optional_policy(`
+	tunable_policy(`dockerd_connect_user_services',`
+		pulseaudio_stream_connect(dockerd_t)
+	')
+')
+
+optional_policy(`
+	tunable_policy(`dockerd_connect_user_services',`
+		wayland_stream_connect(dockerd_t)
+	')
 ')
 
 ########################################


### PR DESCRIPTION
Add optional policy support to allow the Docker daemon (dockerd_t) to connect to user session services over UNIX stream sockets.

This introduces:
  - pulseaudio_stream_connect(dockerd_t)
  - wayland_stream_connect(dockerd_t)

These interfaces enable dockerd to communicate with PulseAudio and Wayland compositor sockets located under /run/user/$UID, which is required for certain container workloads that need access to the host audio or graphical display.

Both permissions are wrapped in optional_policy blocks to ensure they are only enabled when the corresponding PulseAudio and Wayland policy modules are present.

This change improves compatibility with containerized desktop applications while preserving modular policy design.