### PR TITLE
DRAFT: Use init_t for initial userspace SID

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -50,7 +50,11 @@ type kernel_t, can_load_kernmodule;
 domain_base_type(kernel_t)
 role system_r types kernel_t;
 sid kernel gen_context(system_u:system_r:kernel_t,mls_systemhigh)
-sid init gen_context(system_u:system_r:kernel_t,mls_systemhigh)
+
+type init_t;
+domain_type(init_t)
+role system_r types init_t;
+sid init gen_context(system_u:system_r:init_t,mls_systemhigh)
 
 #
 # DebugFS

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -67,12 +67,13 @@ files_type(init_random_seed_t)
 #
 # init_t is the domain of the init process.
 #
-type init_t, initrc_transition_domain;
+gen_require(`
+	type init_t;
+')
+typeattribute init_t initrc_transition_domain;
 type init_exec_t;
-domain_type(init_t)
 domain_entry_file(init_t, init_exec_t)
 kernel_domtrans_to(init_t, init_exec_t)
-role system_r types init_t;
 
 optional_policy(`
 	# required by calico
@@ -208,7 +209,7 @@ files_runtime_filetrans(init_t, initctl_t, fifo_file)
 # Modify utmp.
 allow init_t initrc_runtime_t:file { rw_file_perms setattr };
 
-allow init_t init_tmpfs_t:file manage_file_perms;
+allow init_t init_tmpfs_t:file { manage_file_perms relabelfrom };
 fs_tmpfs_filetrans(init_t, init_tmpfs_t, file)
 
 kernel_read_psi(init_t)
@@ -1183,7 +1184,7 @@ ifdef(`init_systemd',`
 	allow initrc_t init_script_file_type:service { reload start status stop };
 
 	# Access to notify socket for services with Type=notify
-	kernel_dgram_send(initrc_t)
+	init_dgram_send(initrc_t)
 
 	# run systemd misc initializations
 	# in the initrc_t domain, as would be

--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -702,8 +702,8 @@ interface(`logging_send_syslog_msg',`
 		# Allow systemd-journald to check whether the process died
 		allow syslogd_t $1:process signull;
 
-		kernel_dgram_send($1)
-		kernel_stream_connect($1)
+		init_dgram_send($1)
+		init_stream_connect($1)
 	')
 
 ')

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -521,12 +521,11 @@ ifdef(`init_systemd',`
 	# remove /run/log/journal when switching to permanent storage
 	allow syslogd_t var_log_t:dir rmdir;
 
-	kernel_getattr_dgram_sockets(syslogd_t)
 	kernel_read_ring_buffer(syslogd_t)
-	kernel_rw_stream_sockets(syslogd_t)
-	kernel_rw_unix_dgram_sockets(syslogd_t)
+	init_rw_stream_sockets(syslogd_t)
+	allow syslogd_t init_t:unix_dgram_socket { getattr ioctl read write };
 	kernel_rw_netlink_audit_sockets(syslogd_t)
-	kernel_use_fds(syslogd_t)
+	init_use_fds(syslogd_t)
 
 	dev_read_kmsg(syslogd_t)
 	dev_read_urand(syslogd_t)


### PR DESCRIPTION
As discussed in #1165, enabling userspace_initial_context disables some legacy compatibility code in the Linux kernel.  This causes some socket checks that were being ignored to be now be enforced.  This leads to some failures if kernel_t is not unconfined, despite the fact that the initial SID is still kernel_t, both before and after userspace_initial_context.  Unfortunately, the initial userspace context is used long past boot-up, so getting the label right matters, both for security and functionality.

This RFC/DRAFT patch takes a different approach.  Instead of using kernel_t as the initial SID, init_t is used.  A surprisingly small number of fds appear implicated, and therefore not that many permissions need to be converted from kernel_t to init_t.

In addition to comments on the underlying idea, I'm posting this for feedback on the preferred way to use the init_t domain in kernel.te.  I get errors if I try to use the `sid` statement in init.te, maybe because the sid is left undefined in kernel.te?  Thus, the domain must be defined in kernel.te, and it makes things... unpleasant.