### PR TITLE
tpm2: fix tpm2-abrmd D-Bus communication under enforcing mode

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -1148,6 +1148,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	tpm2_run(sysadm_t, sysadm_r)
+	tpm2_dbus_chat_abrmd(sysadm_t)
+')
+
+optional_policy(`
 	transproxy_admin(sysadm_t, sysadm_r)
 ')
 

--- a/policy/modules/services/dbus.te
+++ b/policy/modules/services/dbus.te
@@ -305,6 +305,7 @@ optional_policy(`
 
 optional_policy(`
 	tpm2_rw_abrmd_pipes(system_dbusd_t)
+	tpm2_rw_abrmd_stream_sockets(system_dbusd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/tpm2.if
+++ b/policy/modules/services/tpm2.if
@@ -224,3 +224,23 @@ interface(`tpm2_rw_abrmd_pipes',`
 	allow $1 tpm2_abrmd_t:fd use;
 	allow $1 tpm2_abrmd_t:fifo_file rw_fifo_file_perms;
 ')
+
+########################################
+## <summary>
+##	Read and write tpm2-abrmd unix stream sockets.
+##	This is used by the D-Bus system daemon to communicate
+##	over the socketpair fds passed by tpm2-abrmd to clients.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tpm2_rw_abrmd_stream_sockets',`
+	gen_require(`
+		type tpm2_abrmd_t;
+	')
+	allow $1 tpm2_abrmd_t:fd use;
+	allow $1 tpm2_abrmd_t:unix_stream_socket rw_socket_perms;
+')

--- a/policy/modules/services/tpm2.te
+++ b/policy/modules/services/tpm2.te
@@ -33,8 +33,13 @@ logging_send_syslog_msg(tpm2_abrmd_t)
 
 dev_read_urand(tpm2_abrmd_t)
 
+files_read_etc_files(tpm2_abrmd_t)
+
+miscfiles_read_localization(tpm2_abrmd_t)
+
 optional_policy(`
 	dbus_system_domain(tpm2_abrmd_t, tpm2_abrmd_exec_t)
+	init_dbus_chat(tpm2_abrmd_t)
 ')
 
 

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -275,6 +275,10 @@ allow unconfined_execmem_t self:process { execmem execstack };
 unconfined_domain_noaudit(unconfined_execmem_t)
 
 optional_policy(`
+	tpm2_dbus_chat_abrmd(unconfined_t)
+')
+
+optional_policy(`
 	unconfined_dbus_chat(unconfined_execmem_t)
 ')
 


### PR DESCRIPTION
tpm2-abrmd was crashing on every D-Bus activation attempt under SELinux enforcing mode, causing all tpm2-tools commands to fall back to direct TPM device access with a GDBus warning.

AVC log confirmed the root denial:

```
avc: denied { read write } for comm="dbus-daemon"
scontext=system_u:system_r:system_dbusd_t:s0
tcontext=system_u:system_r:tpm2_abrmd_t:s0
tclass=unix_stream_socket permissive=0
```

tpm2-abrmd uses socketpair(PF_LOCAL, SOCK_STREAM) to create a connected fd pair per client, then passes one end to dbus-daemon via SCM_RIGHTS (D-Bus fd-passing). dbus-daemon needs { read write } on that inherited anonymous socket to relay TPM commands. This is not a connectto — the socket is already connected when the fd is received.

**Files changed:**

- `policy/modules/services/tpm2.if` — add tpm2_rw_abrmd_stream_sockets() granting rw_socket_perms on tpm2_abrmd_t:unix_stream_socket
- `policy/modules/services/dbus.te` — call tpm2_rw_abrmd_stream_sockets(system_dbusd_t) inside the existing optional_policy block alongside tpm2_rw_abrmd_pipes()
- `policy/modules/services/tpm2.te` — add files_read_etc_files (D-Bus config), miscfiles_read_localization (GLib init), and init_dbus_chat (systemd Type=dbus activation) for tpm2_abrmd_t
- `policy/modules/system/unconfined.te` — add tpm2_dbus_chat_abrmd(unconfined_t) in an optional_policy block for interactive root sessions
