### PR TITLE
Pipewire/wireplumber

### DIFF
--- a/policy/modules/apps/pipewire.fc
+++ b/policy/modules/apps/pipewire.fc
@@ -3,10 +3,11 @@
 
 # System-service runtime directory (/run/pipewire).
 /run/pipewire(/.*)?		gen_context(system_u:object_r:pipewire_runtime_t,s0)
-/run/user/%{USERID}/pipewire-.*	-s	gen_context(system_u:object_r:pipewire_runtime_t,s0)
 
 # User-session runtime sockets live under $XDG_RUNTIME_DIR/pipewire and are
-# labelled at runtime via userdom_user_runtime_filetrans; no static entry needed.
+# labelled at runtime via userdom_user_runtime_filetrans
+# Static entry added for restorecon
+/run/user/%{USERID}/pipewire-.*		gen_context(system_u:object_r:pipewire_runtime_t,s0)
 
 # Persistent system-service state.
 /var/lib/pipewire(/.*)?		gen_context(system_u:object_r:pipewire_var_lib_t,s0)

--- a/policy/modules/apps/pipewire.if
+++ b/policy/modules/apps/pipewire.if
@@ -258,4 +258,5 @@ interface(`pipewire_client',`
 	')
 
 	typeattribute $1 pipewire_client_domain;
+	dbus_all_session_bus_client($1)
 ')

--- a/policy/modules/apps/pipewire.if
+++ b/policy/modules/apps/pipewire.if
@@ -182,6 +182,27 @@ interface(`pipewire_use_fds',`
 
 ########################################
 ## <summary>
+##	Send and receive messages from
+##	pipewire over dbus.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pipewire_dbus_chat',`
+	gen_require(`
+		type pipewire_t;
+		class dbus send_msg;
+	')
+
+	allow $1 pipewire_t:dbus send_msg;
+	allow pipewire_t $1:dbus send_msg;
+')
+
+########################################
+## <summary>
 ##	Allow a domain to read, write, and map PipeWire shared memory (tmpfs) files.
 ##	These are memfd files passed between the daemon and its clients for
 ##	zero-copy audio buffer sharing.

--- a/policy/modules/apps/pipewire.if
+++ b/policy/modules/apps/pipewire.if
@@ -233,11 +233,8 @@ interface(`pipewire_read_home_files',`
 #
 interface(`pipewire_client',`
 	gen_require(`
-		type pipewire_runtime_t;
+		attribute pipewire_client_domain;
 	')
 
-	allow $1 pipewire_runtime_t:dir list_dir_perms;
-	pipewire_stream_connect($1)
-	pipewire_use_fds($1)
-	pipewire_mmap_rw_tmpfs_files($1)
+	typeattribute $1 pipewire_client_domain;
 ')

--- a/policy/modules/apps/pipewire.if
+++ b/policy/modules/apps/pipewire.if
@@ -203,6 +203,28 @@ interface(`pipewire_dbus_chat',`
 
 ########################################
 ## <summary>
+##	Allow a domain to read, write, and map inherited PipeWire shared memory
+##	(tmpfs) files. These are memfd files passed between the daemon and its
+##	clients for zero-copy audio buffer sharing.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pipewire_mmap_rw_inherited_tmpfs_files',`
+	gen_require(`
+		type pipewire_tmpfs_t;
+	')
+
+	fs_search_tmpfs($1)
+	allow $1 pipewire_tmpfs_t:dir search_dir_perms;
+	allow $1 pipewire_tmpfs_t:file mmap_rw_inherited_file_perms;
+')
+
+########################################
+## <summary>
 ##	Allow a domain to read, write, and map PipeWire shared memory (tmpfs) files.
 ##	These are memfd files passed between the daemon and its clients for
 ##	zero-copy audio buffer sharing.

--- a/policy/modules/apps/pipewire.te
+++ b/policy/modules/apps/pipewire.te
@@ -197,6 +197,6 @@ ifndef(`pipewire_system_service',`
 allow pipewire_client_domain pipewire_runtime_t:dir list_dir_perms;
 pipewire_stream_connect(pipewire_client_domain)
 pipewire_use_fds(pipewire_client_domain)
-pipewire_mmap_rw_tmpfs_files(pipewire_client_domain)
+pipewire_mmap_rw_inherited_tmpfs_files(pipewire_client_domain)
 pipewire_rw_stream_sockets(pipewire_client_domain)
 pipewire_dbus_chat(pipewire_client_domain)

--- a/policy/modules/apps/pipewire.te
+++ b/policy/modules/apps/pipewire.te
@@ -33,6 +33,10 @@ type pipewire_runtime_t;
 files_runtime_file(pipewire_runtime_t)
 userdom_user_runtime_content(pipewire_runtime_t)
 
+optional_policy(`
+	systemd_user_runtime_dir_unlink(pipewire_runtime_t, sock_file)
+')
+
 type pipewire_tmpfs_t;
 userdom_user_tmpfs_file(pipewire_tmpfs_t)
 

--- a/policy/modules/apps/pipewire.te
+++ b/policy/modules/apps/pipewire.te
@@ -153,6 +153,7 @@ ifndef(`pipewire_system_service',`
 	# Runtime socket directory transition under $XDG_RUNTIME_DIR/pipewire.
 	userdom_user_runtime_filetrans(pipewire_t, pipewire_runtime_t, dir, "pipewire")
 	userdom_user_runtime_filetrans(pipewire_t, pipewire_runtime_t, file)
+	userdom_user_runtime_filetrans(pipewire_t, pipewire_runtime_t, sock_file)
 
 	# Session D-Bus (register org.PipeWire.* on the per-user session bus).
 	optional_policy(`

--- a/policy/modules/apps/pipewire.te
+++ b/policy/modules/apps/pipewire.te
@@ -7,6 +7,8 @@ policy_module(pipewire)
 
 attribute_role pipewire_roles;
 
+attribute pipewire_client_domain;
+
 #
 # pipewire_t — the PipeWire multimedia daemon.
 #
@@ -168,3 +170,15 @@ ifndef(`pipewire_system_service',`
 		systemd_user_daemon_domain(staff, pipewire_exec_t, pipewire_t)
 	')
 ')
+
+########################################
+#
+# pipewire_client domain
+#
+# domain that captures requirements to use the pipewire service
+#
+
+allow pipewire_client_domain pipewire_runtime_t:dir list_dir_perms;
+pipewire_stream_connect(pipewire_client_domain)
+pipewire_use_fds(pipewire_client_domain)
+pipewire_mmap_rw_tmpfs_files(pipewire_client_domain)

--- a/policy/modules/apps/pipewire.te
+++ b/policy/modules/apps/pipewire.te
@@ -94,6 +94,8 @@ xdg_search_config_dirs(pipewire_t)
 # ALSA configuration files (/etc/alsa/*, ~/.asoundrc).
 optional_policy(`
 	alsa_read_config(pipewire_t)
+	alsa_read_home_files(pipewire_t)
+	alsa_read_lib(pipewire_t)
 ')
 
 # PulseAudio compatibility layer (pipewire-pulse connects to PulseAudio clients).
@@ -109,6 +111,12 @@ optional_policy(`
 # Read systemd journal for log correlation.
 optional_policy(`
 	systemd_read_journal_files(pipewire_t)
+')
+
+optional_policy(`
+	dbus_list_system_bus_runtime(pipewire_t)
+	dbus_send_system_bus(pipewire_t)
+	dbus_system_bus_client(pipewire_t)
 ')
 
 ########################################
@@ -161,9 +169,6 @@ ifndef(`pipewire_system_service',`
 	optional_policy(`
 		dbus_all_session_bus_client(pipewire_t)
 		dbus_connect_all_session_bus(pipewire_t)
-		dbus_list_system_bus_runtime(pipewire_t)
-		dbus_send_system_bus(pipewire_t)
-		dbus_system_bus_client(pipewire_t)
 		dbus_write_session_runtime_socket(pipewire_t)
 	')
 
@@ -171,6 +176,10 @@ ifndef(`pipewire_system_service',`
 	optional_policy(`
 		systemd_user_daemon_domain(user, pipewire_exec_t, pipewire_t)
 		systemd_user_daemon_domain(staff, pipewire_exec_t, pipewire_t)
+	')
+
+	optional_policy(`
+		xdg_search_config_dirs(pipewire_t)
 	')
 ')
 

--- a/policy/modules/apps/pipewire.te
+++ b/policy/modules/apps/pipewire.te
@@ -56,6 +56,8 @@ manage_sock_files_pattern(pipewire_t, pipewire_runtime_t, pipewire_runtime_t)
 mmap_manage_files_pattern(pipewire_t, pipewire_tmpfs_t, pipewire_tmpfs_t)
 fs_tmpfs_filetrans(pipewire_t, pipewire_tmpfs_t, file)
 
+allow pipewire_t pipewire_client_domain:fd use;
+
 # Audio hardware access.
 dev_read_sound(pipewire_t)
 dev_write_sound(pipewire_t)
@@ -183,3 +185,5 @@ allow pipewire_client_domain pipewire_runtime_t:dir list_dir_perms;
 pipewire_stream_connect(pipewire_client_domain)
 pipewire_use_fds(pipewire_client_domain)
 pipewire_mmap_rw_tmpfs_files(pipewire_client_domain)
+pipewire_rw_stream_sockets(pipewire_client_domain)
+pipewire_dbus_chat(pipewire_client_domain)

--- a/policy/modules/apps/pipewire.te
+++ b/policy/modules/apps/pipewire.te
@@ -96,7 +96,7 @@ optional_policy(`
 
 # PulseAudio compatibility layer (pipewire-pulse connects to PulseAudio clients).
 optional_policy(`
-	pulseaudio_stream_connect(pipewire_t)
+	pulseaudio_provide_server(pipewire_t)
 ')
 
 # Real-time scheduling priority via rtkit-daemon.

--- a/policy/modules/apps/pulseaudio.if
+++ b/policy/modules/apps/pulseaudio.if
@@ -446,3 +446,30 @@ interface(`pulseaudio_rw_tmpfs_files',`
 	fs_search_tmpfs($1)
 	rw_files_pattern($1, pulseaudio_tmpfs_t, pulseaudio_tmpfs_t)
 ')
+
+#######################################
+## <summary>
+##	Allow specified domain to act as a pulseaudio server.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed/allowing access.
+##	</summary>
+## </param>
+#
+interface(`pulseaudio_provide_server',`
+	gen_require(`
+		attribute pulseaudio_client;
+		type pulseaudio_tmp_t;
+	')
+
+	manage_dirs_pattern($1, pulseaudio_tmp_t, pulseaudio_tmp_t)
+	manage_files_pattern($1, pulseaudio_tmp_t, pulseaudio_tmp_t)
+	allow $1 pulseaudio_tmp_t:file map;
+	manage_sock_files_pattern($1, pulseaudio_tmp_t, pulseaudio_tmp_t)
+	userdom_user_runtime_filetrans($1, pulseaudio_tmp_t, dir, "pulse")
+	pulseaudio_stream_connect($1)
+	ps_process_pattern($1, pulseaudio_client)
+
+	allow pulseaudio_client $1:fd use;
+')

--- a/policy/modules/apps/wireplumber.fc
+++ b/policy/modules/apps/wireplumber.fc
@@ -13,3 +13,4 @@
 # User home configuration and state.
 HOME_DIR/\.config/wireplumber(/.*)?	gen_context(system_u:object_r:wireplumber_home_t,s0)
 HOME_DIR/\.local/share/wireplumber(/.*)?	gen_context(system_u:object_r:wireplumber_home_t,s0)
+HOME_DIR/\.local/state/wireplumber(/.*)?	gen_context(system_u:object_r:wireplumber_home_t,s0)

--- a/policy/modules/apps/wireplumber.if
+++ b/policy/modules/apps/wireplumber.if
@@ -66,6 +66,8 @@ template(`wireplumber_role',`
 	wireplumber_mmap_rw_tmpfs_files($2)
 	allow $2 wireplumber_tmpfs_t:file relabel_file_perms;
 
+	wireplumber_dbus_chat($2)
+
 	optional_policy(`
 		systemd_user_app_status($1, wireplumber_t)
 		systemd_user_app_socket_create($1, wireplumber_t, wireplumber_runtime_t)

--- a/policy/modules/apps/wireplumber.te
+++ b/policy/modules/apps/wireplumber.te
@@ -97,12 +97,25 @@ miscfiles_read_localization(wireplumber_t)
 udev_read_runtime_files(wireplumber_t)
 udev_search_runtime(wireplumber_t)
 
-xdg_search_config_dirs(wireplumber_t)
-xdg_manage_data(wireplumber_t)
+optional_policy(`
+	alsa_read_config(wireplumber_t)
+	alsa_read_lib(wireplumber_t)
+')
 
 # D-Bus communication with BlueZ (Bluetooth audio routing).
 optional_policy(`
 	bluetooth_dbus_chat(wireplumber_t)
+	bluetooth_use(wireplumber_t)
+')
+
+# D-Bus communication with power management.
+optional_policy(`
+	devicekit_dbus_chat_power(wireplumber_t)
+')
+
+optional_policy(`
+	dbus_system_bus_client(wireplumber_t)
+	dbus_connect_system_bus(wireplumber_t)
 ')
 
 optional_policy(`
@@ -127,10 +140,7 @@ optional_policy(`
 
 # Connect to the PipeWire daemon socket and map its shared memory buffers.
 optional_policy(`
-	pipewire_mmap_rw_tmpfs_files(wireplumber_t)
-	pipewire_read_home_files(wireplumber_t)
-	pipewire_stream_connect(wireplumber_t)
-	pipewire_use_fds(wireplumber_t)
+	pipewire_client(wireplumber_t)
 ')
 
 # Real-time scheduling priority via rtkit-daemon.
@@ -190,5 +200,12 @@ ifndef(`wireplumber_system_service',`
 	optional_policy(`
 		dbus_all_session_bus_client(wireplumber_t)
 		dbus_connect_all_session_bus(wireplumber_t)
+		dbus_write_session_runtime_socket(wireplumber_t)
+	')
+
+	optional_policy(`
+		xdg_search_data_dirs(wireplumber_t)
+		xdg_search_config_dirs(wireplumber_t)
+		xdg_data_filetrans(wireplumber_t, wireplumber_home_t, dir, "wireplumber")
 	')
 ')

--- a/policy/modules/apps/wireplumber.te
+++ b/policy/modules/apps/wireplumber.te
@@ -62,6 +62,13 @@ auth_use_nsswitch(wireplumber_t)
 
 # Filesystem getattr for device/mount enumeration.
 dev_getattr_fs(wireplumber_t)
+dev_getattr_sysfs(wireplumber_t)
+
+# Sound and video
+dev_read_sound(wireplumber_t)
+dev_write_sound(wireplumber_t)
+dev_read_video_dev(wireplumber_t)
+dev_write_video_dev(wireplumber_t)
 
 # Device enumeration via sysfs.
 dev_getattr_sysfs(wireplumber_t)

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -171,10 +171,6 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		wireplumber_role(staff, staff_t, staff_application_exec_domain, staff_r)
-	')
-
-	optional_policy(`
 		pyzor_role(staff, staff_t, staff_application_exec_domain, staff_r)
 	')
 

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -139,10 +139,6 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		wireplumber_role(user, user_t, user_application_exec_domain, user_r)
-	')
-
-	optional_policy(`
 		pyzor_role(user, user_t, user_application_exec_domain, user_r)
 	')
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2559,10 +2559,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	pipewire_delete_user_sockets(systemd_user_runtime_dir_t)
-')
-
-optional_policy(`
 	pulseaudio_manage_tmp_dirs(systemd_user_runtime_dir_t)
 ')
 

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -969,6 +969,10 @@ template(`userdom_common_user_template',`
 		virt_home_filetrans_svirt_home($1_t, dir, "qemu")
 		virt_home_filetrans_virt_home($1_t, dir, "VirtualMachines")
 	')
+
+	optional_policy(`
+		wireplumber_role($1, $1_t, $1_application_exec_domain, $1_r)
+	')
 ')
 
 #######################################


### PR DESCRIPTION
The new pipewire module needs some changes to work on the desktop.  I've also included @tkanfade's new wireplumber module, and changes atop it that I needed to get everything working.

I'm happy to divide these changes however makes everyone happy, but the current state of refpolicy main is nonfunctional.

There are also some comments about consolidating al of pulseaudio, pipewire, alsa, et. al.  I take no position on that issue beyond also including wireplumber in that discussion.