### PR TITLE
lvm: label dmeventd on all distros, not only gentoo

### DIFF
--- a/policy/modules/system/lvm.fc
+++ b/policy/modules/system/lvm.fc
@@ -21,6 +21,7 @@
 # /usr
 #
 /usr/bin/cryptsetup		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+/usr/bin/dmeventd		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/bin/dmraid			--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/bin/dmsetup		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/bin/dmsetup\.static	--	gen_context(system_u:object_r:lvm_exec_t,s0)
@@ -75,10 +76,6 @@
 /usr/bin/vgscan\.static		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/bin/vgsplit		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/bin/vgwrapper		--	gen_context(system_u:object_r:lvm_exec_t,s0)
-
-ifdef(`distro_gentoo',`
-/usr/bin/dmeventd		--	gen_context(system_u:object_r:lvm_exec_t,s0)
-')
 
 /usr/lib/lvm-10/.*				--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/lib/lvm-200/.*				--	gen_context(system_u:object_r:lvm_exec_t,s0)


### PR DESCRIPTION
dmeventd is shipped by the device-mapper-event package on Fedora, RHEL and Debian (as /usr/sbin/dmeventd), not just Gentoo, but lvm.fc only labeled it lvm_exec_t under ifdef(`distro_gentoo'). Elsewhere it is left bin_t, so systemd's exec of it for dm-event.service does not fire the lvm_exec_t -> lvm_t domain transition; dmeventd then runs in initrc_t and is denied its lvm_runtime_t control fifos, so dm-event.service/.socket fail and lvm2-monitor exits under enforcing.

file_contexts.subs_dist already maps /sbin and /usr/sbin to /usr/bin, so the existing /usr/bin/dmeventd entry covers every layout once it is no longer gated to Gentoo. Drop the ifdef.