### PR TITLE
adb: add SELinux policy for adbd and interactive adb shell session

### DIFF
--- a/policy/modules/services/adb.fc
+++ b/policy/modules/services/adb.fc
@@ -1,0 +1,1 @@
+/usr/bin/adbd    --    gen_context(system_u:object_r:adbd_exec_t,s0)

--- a/policy/modules/services/adb.if
+++ b/policy/modules/services/adb.if
@@ -1,0 +1,18 @@
+## <summary>Policy for adb</summary>
+########################################
+## <summary>
+##      Allow processes to inherit adbd file descriptors.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`adb_use_fds',`
+        gen_require(`
+                type adbd_t;
+        ')
+
+        allow $1 adbd_t:fd use;
+')

--- a/policy/modules/services/adb.te
+++ b/policy/modules/services/adb.te
@@ -1,0 +1,145 @@
+policy_module(adb)
+
+########################################
+#
+# Declarations
+#
+########################################
+
+## <desc>
+## <p>
+## Allow extended adb shell functionality for debugging and interactive shell access.
+## </p>
+## </desc>
+gen_tunable(adb_shell_extended_access, false)
+
+## <desc>
+## <p>
+## Allow adb shell sessions to run in unconfined_t instead of the default adb_shell_t
+## domain.
+## </p>
+## </desc>
+gen_tunable(adb_unconfined_shell, false)
+
+type adbd_t;
+type adbd_exec_t;
+init_daemon_domain(adbd_t, adbd_exec_t)
+
+type adb_shell_t;
+domain_type(adb_shell_t)
+
+########################################
+#
+# adbd local policy
+#
+########################################
+
+allow adbd_t self:capability sys_resource;
+
+corecmd_search_bin(adbd_t)
+dev_rw_usbfs(adbd_t)
+files_manage_generic_tmp_dirs(adbd_t)
+files_manage_generic_tmp_files(adbd_t)
+files_read_etc_files(adbd_t)
+logging_read_audit_log(adbd_t)
+logging_read_generic_logs(adbd_t)
+term_use_generic_ptys(adbd_t)
+term_use_ptmx(adbd_t)
+
+optional_policy(`
+	tunable_policy(`adb_unconfined_shell',`
+		unconfined_shell_domtrans(adbd_t)
+	',`
+		corecmd_shell_domtrans(adbd_t, adb_shell_t)
+	')
+')
+
+########################################
+#
+# adb_shell local policy
+#
+########################################
+role system_r types adb_shell_t;
+
+allow adb_shell_t self:process { getcap setpgid signal };
+allow adb_shell_t self:fifo_file rw_inherited_fifo_file_perms;
+
+allow adb_shell_t adbd_t:fd use;
+
+corecmd_exec_bin(adb_shell_t)
+corecmd_shell_entry_type(adb_shell_t)
+
+dev_search_sysfs(adb_shell_t)
+
+files_getattr_var_lib_dirs(adb_shell_t)
+files_list_default(adb_shell_t)
+files_manage_generic_tmp_dirs(adb_shell_t)
+files_manage_generic_tmp_files(adb_shell_t)
+files_read_default_files(adb_shell_t)
+files_read_etc_files(adb_shell_t)
+files_read_mnt_files(adb_shell_t)
+files_read_mnt_symlinks(adb_shell_t)
+files_read_usr_symlinks(adb_shell_t)
+files_read_var_symlinks(adb_shell_t)
+files_search_spool(adb_shell_t)
+files_search_tmp(adb_shell_t)
+files_search_var(adb_shell_t)
+fs_getattr_xattr_fs(adb_shell_t)
+fs_list_auto_mountpoints(adb_shell_t)
+
+kernel_read_kernel_sysctls(adb_shell_t)
+
+logging_list_logs(adb_shell_t)
+logging_manage_generic_logs(adb_shell_t)
+logging_read_audit_log(adb_shell_t)
+logging_read_generic_logs(adb_shell_t)
+logging_rw_generic_log_dirs(adb_shell_t)
+logging_search_logs(adb_shell_t)
+
+seutil_read_config(adb_shell_t)
+
+term_use_generic_ptys(adb_shell_t)
+term_use_ptmx(adb_shell_t)
+
+userdom_search_user_home_dirs(adb_shell_t)
+
+tunable_policy(`adb_shell_extended_access',`
+	corecmd_getattr_all_executables(adb_shell_t)
+	dev_read_kmsg(adb_shell_t)
+	dmesg_exec(adb_shell_t)
+
+	files_manage_var_dirs(adb_shell_t)
+	files_manage_var_files(adb_shell_t)
+	files_read_etc_runtime_files(adb_shell_t)
+	files_read_usr_symlinks(adb_shell_t)
+	init_get_generic_units_status(adb_shell_t)
+	init_get_runtime_units_status(adb_shell_t)
+	init_get_system_status(adb_shell_t)
+
+	init_read_generic_units_symlinks(adb_shell_t)
+	init_reload_generic_units(adb_shell_t)
+	init_stream_connect(adb_shell_t)
+	init_write_runtime_socket(adb_shell_t)
+
+	kernel_read_fs_sysctls(adb_shell_t)
+	kernel_read_ring_buffer(adb_shell_t)
+	kernel_read_vm_sysctls(adb_shell_t)
+
+	mount_exec(adb_shell_t)
+	selinux_get_fs_mount(adb_shell_t)
+	selinux_read_policy(adb_shell_t)
+
+	systemd_dbus_chat_logind(adb_shell_t)
+	systemd_list_journal_dirs(adb_shell_t)
+	systemd_read_journal_files(adb_shell_t)
+	sysnet_domtrans_ifconfig(adb_shell_t)
+	userdom_use_user_terminals(adb_shell_t)
+')
+
+optional_policy(`
+	dbus_system_bus_client(adb_shell_t)
+')
+
+optional_policy(`
+	dnsmasq_domtrans(adb_shell_t)
+')


### PR DESCRIPTION
This patch introduces SELinux policy support for adbd and interactive
adb shell sessions.

It defines the adbd_t and adb_shell_t domains, establishes the
transition between them, and provides the permissions required for
interactive shell operation.

The module also introduces the adb_unconfined_shell tunables,
allowing interactive adb shell sessions to transition to
the unconfined_t domains instead of the default adb_shell_t domain
when enabled.


Additional debugging-related permissions are isolated behind the
adb_shell_extended_access tunable, which remains disabled by default
to preserve the default security posture while allowing developers to
enable extended debugging capabilities when needed.