### PR TITLE
Allow net_admin to the nfsd_t domain

### DIFF
--- a/policy/modules/services/rpc.te
+++ b/policy/modules/services/rpc.te
@@ -313,7 +313,7 @@ optional_policy(`
 # NFSD local policy
 #
 
-allow nfsd_t self:capability { dac_override dac_read_search lease setpcap sys_admin sys_resource };
+allow nfsd_t self:capability { dac_override dac_read_search lease net_admin setpcap sys_admin sys_resource };
 allow nfsd_t self:netlink_generic_socket create_socket_perms;
 allow nfsd_t self:process setcap;
 

--- a/testing/sechecker.ini
+++ b/testing/sechecker.ini
@@ -289,6 +289,7 @@ exempt_source = arpwatch_t
                 netlabel_mgmt_t
                 netutils_t
                 NetworkManager_t
+                nfsd_t			# nfs-utils 2.9.1 added a netlink interface to mountd/exportd to handle sunrpc cache upcalls from the kernel. The netlink interface requires CAP_NET_ADMIN.
                 nsd_t
                 ntop_t
 		opensnitchd_t		# This daemon does very invasive changes to system networking


### PR DESCRIPTION
nfs-utils 2.9.1 added a netlink interface to mountd/exportd to handle sunrpc cache upcalls from the kernel.  The netlink interface requires CAP_NET_ADMIN.

The commit addresses the following AVC denial:
type=AVC msg=audit(1783461620.873:503): avc:  denied  { net_admin } for  pid=57981 comm="rpc.mountd" capability=12  scontext=system_u:system_r:nfsd_t:s0 tcontext=system_u:system_r:nfsd_t:s0 tclass=capability permissive=0