### PR TITLE
rauc: new module for the RAUC embedded update framework

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -166,6 +166,25 @@ interface(`kernel_setsched',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to set the
+##	priority of kernel threads.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`kernel_dontaudit_setsched',`
+	gen_require(`
+		type kernel_t;
+	')
+
+	dontaudit $1 kernel_t:process setsched;
+')
+
+########################################
+## <summary>
 ##	Send a SIGCHLD signal to kernel threads.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/rauc.fc
+++ b/policy/modules/services/rauc.fc
@@ -1,0 +1,17 @@
+/slot\.raucs		--	gen_context(system_u:object_r:rauc_status_t,s0)
+
+/etc/rauc(/.*)?		gen_context(system_u:object_r:rauc_conf_t,s0)
+
+/run/rauc(/.*)?		gen_context(system_u:object_r:rauc_runtime_t,s0)
+
+/usr/bin/fw_printenv	--	gen_context(system_u:object_r:rauc_ubootenv_exec_t,s0)
+/usr/bin/fw_setenv	--	gen_context(system_u:object_r:rauc_ubootenv_exec_t,s0)
+/usr/bin/rauc		--	gen_context(system_u:object_r:rauc_exec_t,s0)
+
+/var/cache/rauc(/.*)?	gen_context(system_u:object_r:rauc_bundle_t,s0)
+
+/var/lib/rauc(/.*)?	gen_context(system_u:object_r:rauc_var_lib_t,s0)
+
+/var/lock/fw_printenv\.lock	--	gen_context(system_u:object_r:rauc_lock_t,s0)
+
+/var/log/rauc(/.*)?	gen_context(system_u:object_r:rauc_log_t,s0)

--- a/policy/modules/services/rauc.if
+++ b/policy/modules/services/rauc.if
@@ -1,0 +1,167 @@
+## <summary>Policy for the RAUC embedded update framework.</summary>
+
+########################################
+## <summary>
+##	Execute rauc in the rauc_t domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`rauc_domtrans',`
+	gen_require(`
+		type rauc_t, rauc_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, rauc_exec_t, rauc_t)
+')
+
+########################################
+## <summary>
+##	Send and receive D-Bus messages
+##	from/to rauc over the system bus.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to chat.
+##	</summary>
+## </param>
+#
+interface(`rauc_dbus_chat',`
+	gen_require(`
+		type rauc_t;
+		class dbus send_msg;
+	')
+
+	allow $1 rauc_t:dbus send_msg;
+	allow rauc_t $1:dbus send_msg;
+')
+
+########################################
+## <summary>
+##	Get the attributes of rauc bundle files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rauc_getattr_bundle_files',`
+	gen_require(`
+		type rauc_bundle_t;
+	')
+
+	allow $1 rauc_bundle_t:file getattr_file_perms;
+')
+
+########################################
+## <summary>
+##	Read rauc configuration files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rauc_read_config',`
+	gen_require(`
+		type rauc_conf_t;
+	')
+
+	allow $1 rauc_conf_t:dir list_dir_perms;
+	allow $1 rauc_conf_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Read rauc bundle files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rauc_read_bundle',`
+	gen_require(`
+		type rauc_bundle_t;
+	')
+
+	allow $1 rauc_bundle_t:dir list_dir_perms;
+	allow $1 rauc_bundle_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow rauc to read bundles from a
+##	domain's own labeled storage (e.g. a
+##	data partition or download directory).
+## </summary>
+## <param name="source_type">
+##	<summary>
+##	Type of the storage containing bundles.
+##	</summary>
+## </param>
+#
+interface(`rauc_bundle_source',`
+	gen_require(`
+		type rauc_t;
+	')
+
+	allow rauc_t $1:dir search_dir_perms;
+	allow rauc_t $1:file read_file_perms;
+	allow rauc_t $1:filesystem getattr;
+')
+
+########################################
+## <summary>
+##	All of the rules required to
+##	administer the rauc environment.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+#
+interface(`rauc_admin',`
+	gen_require(`
+		type rauc_t, rauc_bundle_t, rauc_conf_t;
+		type rauc_lock_t, rauc_log_t, rauc_runtime_t;
+		type rauc_status_t, rauc_tmp_t, rauc_var_lib_t;
+	')
+
+	allow $1 rauc_t:process { ptrace signal_perms };
+	ps_process_pattern($1, rauc_t)
+
+	files_search_etc($1)
+	admin_pattern($1, rauc_conf_t)
+
+	files_search_locks($1)
+	admin_pattern($1, rauc_lock_t)
+
+	logging_search_logs($1)
+	admin_pattern($1, rauc_log_t)
+
+	files_search_runtime($1)
+	admin_pattern($1, rauc_runtime_t)
+
+	files_search_tmp($1)
+	admin_pattern($1, rauc_tmp_t)
+
+	files_search_var_lib($1)
+	admin_pattern($1, rauc_var_lib_t)
+
+	admin_pattern($1, rauc_bundle_t)
+	admin_pattern($1, rauc_status_t)
+')

--- a/policy/modules/services/rauc.te
+++ b/policy/modules/services/rauc.te
@@ -1,0 +1,136 @@
+policy_module(rauc, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type rauc_t;
+type rauc_exec_t;
+init_daemon_domain(rauc_t, rauc_exec_t)
+
+type rauc_bundle_t;
+files_type(rauc_bundle_t)
+
+type rauc_conf_t;
+files_config_file(rauc_conf_t)
+
+# Lock file used by the bootloader environment tools.
+type rauc_lock_t;
+files_lock_file(rauc_lock_t)
+
+type rauc_log_t;
+logging_log_file(rauc_log_t)
+
+# Runtime mount tree under /run/rauc (RuntimeDirectory=rauc).
+type rauc_runtime_t;
+files_runtime_file(rauc_runtime_t)
+
+# Slot status file (slot.raucs) written via atomic temp+rename
+# into the root of the target partition.
+type rauc_status_t;
+files_type(rauc_status_t)
+
+type rauc_tmp_t;
+files_tmp_file(rauc_tmp_t)
+
+# Bootloader environment tools (fw_setenv/fw_printenv).
+# Dedicated type: a domain with sys_rawio and raw disk write
+# must not execute arbitrary bin_t.
+type rauc_ubootenv_exec_t;
+application_executable_file(rauc_ubootenv_exec_t)
+
+type rauc_var_lib_t;
+files_type(rauc_var_lib_t)
+
+########################################
+#
+# Local policy
+#
+
+allow rauc_t self:capability { fowner fsetid mknod sys_admin sys_rawio };
+allow rauc_t self:process { setrlimit signal_perms };
+allow rauc_t self:fifo_file rw_fifo_file_perms;
+allow rauc_t self:unix_stream_socket create_stream_socket_perms;
+
+allow rauc_t rauc_bundle_t:dir list_dir_perms;
+allow rauc_t rauc_bundle_t:file read_file_perms;
+
+allow rauc_t rauc_conf_t:dir list_dir_perms;
+allow rauc_t rauc_conf_t:file read_file_perms;
+
+allow rauc_t rauc_lock_t:file manage_file_perms;
+files_lock_filetrans(rauc_t, rauc_lock_t, file)
+
+append_files_pattern(rauc_t, rauc_log_t, rauc_log_t)
+create_files_pattern(rauc_t, rauc_log_t, rauc_log_t)
+logging_log_filetrans(rauc_t, rauc_log_t, file)
+
+manage_dirs_pattern(rauc_t, rauc_runtime_t, rauc_runtime_t)
+manage_files_pattern(rauc_t, rauc_runtime_t, rauc_runtime_t)
+manage_lnk_files_pattern(rauc_t, rauc_runtime_t, rauc_runtime_t)
+allow rauc_t rauc_runtime_t:dir mounton;
+files_runtime_filetrans(rauc_t, rauc_runtime_t, { dir file lnk_file })
+
+allow rauc_t rauc_status_t:file manage_file_perms;
+files_root_filetrans(rauc_t, rauc_status_t, file)
+
+manage_dirs_pattern(rauc_t, rauc_tmp_t, rauc_tmp_t)
+manage_files_pattern(rauc_t, rauc_tmp_t, rauc_tmp_t)
+files_tmp_filetrans(rauc_t, rauc_tmp_t, { dir file })
+
+can_exec(rauc_t, rauc_ubootenv_exec_t)
+allow rauc_t rauc_ubootenv_exec_t:lnk_file read_lnk_file_perms;
+
+manage_dirs_pattern(rauc_t, rauc_var_lib_t, rauc_var_lib_t)
+manage_files_pattern(rauc_t, rauc_var_lib_t, rauc_var_lib_t)
+files_var_lib_filetrans(rauc_t, rauc_var_lib_t, { dir file })
+
+kernel_dontaudit_setsched(rauc_t)
+kernel_read_kernel_sysctls(rauc_t)
+kernel_read_system_state(rauc_t)
+
+corenet_tcp_connect_http_cache_port(rauc_t)
+corenet_tcp_connect_http_port(rauc_t)
+
+dev_read_sysfs(rauc_t)
+dev_read_urand(rauc_t)
+dev_rw_loop_control(rauc_t)
+dev_rw_lvm_control(rauc_t)
+
+files_delete_root_dir_entry(rauc_t)
+files_read_etc_files(rauc_t)
+files_read_etc_runtime_files(rauc_t)
+files_search_runtime(rauc_t)
+
+fs_getattr_tmpfs(rauc_t)
+fs_getattr_xattr_fs(rauc_t)
+fs_mount_xattr_fs(rauc_t)
+fs_remount_xattr_fs(rauc_t)
+fs_unmount_xattr_fs(rauc_t)
+
+storage_raw_read_fixed_disk(rauc_t)
+storage_raw_read_removable_device(rauc_t)
+storage_raw_write_fixed_disk(rauc_t)
+storage_raw_write_removable_device(rauc_t)
+
+logging_send_syslog_msg(rauc_t)
+
+miscfiles_read_generic_certs(rauc_t)
+miscfiles_read_localization(rauc_t)
+
+mount_exec(rauc_t)
+mount_list_runtime(rauc_t)
+
+sysnet_dns_name_resolve(rauc_t)
+
+optional_policy(`
+	dbus_system_bus_client(rauc_t)
+	dbus_connect_system_bus(rauc_t)
+
+	# rauc-mark-good and the admin CLI run as unconfined_t;
+	# the daemon must be allowed to reply over D-Bus.
+	optional_policy(`
+		unconfined_dbus_chat(rauc_t)
+	')
+')

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -370,6 +370,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# probing loop device backing files during bundle installation
+	rauc_getattr_bundle_files(udev_t)
+')
+
+optional_policy(`
 	unconfined_signal(udev_t)
 ')
 

--- a/testing/sechecker.ini
+++ b/testing/sechecker.ini
@@ -140,6 +140,7 @@ exempt_source = acpi_t
                 postgresql_t
                 pppd_t
                 quota_t             # Configure filesystem quotas
+                rauc_t              # Mount update bundles and slot filesystems
                 remote_login_t      # Conditional access (allow_polyinstantiation)
                 resmgrd_t
                 rlogind_t           # Conditional access (allow_polyinstantiation)
@@ -216,6 +217,7 @@ exempt_source = abrt_t              # Conditional access (allow_raw_memory_acces
                 munin_t
                 nagios_checkdisk_plugin_t
                 rasdaemon_t         # Monitors ECC errors
+                rauc_t              # A/B update framework, raw writes to target slot devices
                 resmgrd_t           # Device resource manager
                 rpm_script_t        # Package manager post-install scripts
                 smbmount_t


### PR DESCRIPTION
RAUC (https://rauc.io) is an A/B update framework for embedded Linux, widely used in Yocto/OpenEmbedded systems. It manages signed bundle verification (CMS/X.509), raw block device writes to A/B root/boot slots, D-Bus service (de.pengutronix.rauc), loopback/squashfs/dm-verity bundle mounts, and bootloader interaction (U-Boot fw_setenv).

No SELinux policy exists for RAUC in refpolicy or Fedora selinux-policy. This module confines the RAUC daemon (rauc_t) with verified-on-hardware enforcing-mode operation, zero AVC denials.