### PR TITLE
rasdaemon: optionally permit access to IPMI devices

### DIFF
--- a/policy/modules/services/rasdaemon.te
+++ b/policy/modules/services/rasdaemon.te
@@ -17,6 +17,14 @@ files_type(rasdaemon_var_t)
 # Local policy
 #
 
+gen_tunable(rasdaemon_use_ipmitool, false)
+
+## <desc>
+##	<p>
+##	Determine whether rasdaemon can use ipmitool to access IPMI devices.
+##	</p>
+## </desc>
+
 allow rasdaemon_t self:process getsched;
 allow rasdaemon_t self:capability sys_rawio;
 
@@ -39,4 +47,8 @@ fs_rw_tracefs_files(rasdaemon_t)
 
 logging_send_syslog_msg(rasdaemon_t)
 miscfiles_read_localization(rasdaemon_t)
+
+tunable_policy(`rasdaemon_use_ipmitool',`
+	ipmitool_domtrans(rasdaemon_t)
+')
 


### PR DESCRIPTION
rasdaemon can run `ipmitool` to collect extra information. A boolean is added to optionally grant this extra access.

My system shows:
```
node=xyz type=AVC msg=audit(1784664711.246:1123427): avc:  denied  { ioctl } for  pid=1020637 comm="ipmitool" path="/dev/ipmi0" dev="devtmpfs" ino=617 ioctlcmd=0x690b scontext=system_u:system_r:rasdaemon_t:s0 tcontext=system_u:object_r:ipmi_device_t:s0 tclass=chr_file permissive=1
node=xyz type=AVC msg=audit(1784664711.336:1123432): avc:  denied  { read write } for  pid=1020640 comm="ipmitool" name="ipmi0" dev="devtmpfs" ino=617 scontext=system_u:system_r:rasdaemon_t:s0 tcontext=system_u:object_r:ipmi_device_t:s0 tclass=chr_file permissive=1
node=xyz type=AVC msg=audit(1784664711.336:1123432): avc:  denied  { open } for  pid=1020640 comm="ipmitool" path="/dev/ipmi0" dev="devtmpfs" ino=617 scontext=system_u:system_r:rasdaemon_t:s0 tcontext=system_u:object_r:ipmi_device_t:s0 tclass=chr_file permissive=1
```

As the only relevant audit logs.

The rasdaemon process is running
```shell
ipmitool raw 0x0a 0x44 0x00 0x00 0xc0 0x00 0x00 0x00 0x00 0x3a 0xcd 0x00 0xc0 0xbf 0x08 0x00 0x01 0x00
```

```shell
# /usr/sbin/rasdaemon --version
rasdaemon 0.8.0
```