### PR TITLE
seatd: allow self fifo_file read/write for signal handling

### DIFF
--- a/policy/modules/services/seatd.te
+++ b/policy/modules/services/seatd.te
@@ -23,7 +23,7 @@ files_runtime_file(seatd_runtime_t)
 #
 
 allow seatd_t self:capability { chown dac_override sys_admin sys_tty_config };
-allow seatd_t seatd_t:fifo_file rw_fifo_file_perms;
+allow seatd_t self:fifo_file rw_fifo_file_perms;
 allow seatd_t self:unix_stream_socket { accept listen };
 
 allow seatd_t seatd_runtime_t:sock_file manage_sock_file_perms;

--- a/policy/modules/services/seatd.te
+++ b/policy/modules/services/seatd.te
@@ -23,6 +23,7 @@ files_runtime_file(seatd_runtime_t)
 #
 
 allow seatd_t self:capability { chown dac_override sys_admin sys_tty_config };
+allow seatd_t seatd_t:fifo_file rw_fifo_file_perms;
 allow seatd_t self:unix_stream_socket { accept listen };
 
 allow seatd_t seatd_runtime_t:sock_file manage_sock_file_perms;


### PR DESCRIPTION
seatd uses a self-pipe trick to deliver signals to its event loop. The signal handler writes a byte to signal_fds[1] to wake up ppoll() in the main loop:

  static void signal_handler(int sig) {
      write(signal_fds[1], "\0", 1);
  }

Without permission to write to its own fifo_file, SELinux denies the write with EACCES. ppoll() is never woken up, SIGTERM cannot be processed, and seatd hangs until SIGKILL after TimeoutStopSec (90s), causing a ~90 second delay on system reboot.

Add the missing fifo_file permissions to allow seatd to handle signals correctly when running under SELinux enforcement.