### PR TITLE
docker: Add tunable for mounting on XDG Downloads directories

### DIFF
--- a/policy/modules/services/docker.te
+++ b/policy/modules/services/docker.te
@@ -14,6 +14,14 @@ policy_module(docker)
 ## </desc>
 gen_tunable(dockerd_connect_user_services, false)
 
+## <desc>
+##	<p>
+##	Determine whether the Docker daemon can mount filesystems
+##	on user XDG Downloads directories.
+##	</p>
+## </desc>
+gen_tunable(dockerd_mounton_xdg_downloads, false)
+
 container_engine_domain_template(dockerd)
 container_system_engine(dockerd_t)
 optional_policy(`
@@ -95,6 +103,12 @@ optional_policy(`
 optional_policy(`
 	tunable_policy(`dockerd_connect_user_services',`
 		wayland_stream_connect(dockerd_t)
+	')
+')
+
+optional_policy(`
+	tunable_policy(`dockerd_mounton_xdg_downloads',`
+		xdg_mounton_downloads(dockerd_t)
 	')
 ')
 

--- a/policy/modules/system/xdg.if
+++ b/policy/modules/system/xdg.if
@@ -1208,6 +1208,26 @@ interface(`xdg_relabel_downloads',`
 
 ########################################
 ## <summary>
+##	Allow mounting on the xdg downloads directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`xdg_mounton_downloads',`
+	gen_require(`
+		type xdg_downloads_t;
+	')
+
+	allow $1 xdg_downloads_t:dir { search_dir_perms mounton_dir_perms };
+
+	userdom_search_user_home_dirs($1)
+')
+
+########################################
+## <summary>
 ##	Watch the xdg pictures home directories
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
1. XDG Policy Enhancement
Added a new SELinux interface: `xdg_mounton_downloads()`.
The interface grants the mounton permission on directories labeled `xdg_downloads_t`.
It also allows searching user home directories, which is required for accessing users' Downloads locations.
This provides a reusable policy interface that other modules can leverage when mount-on access to XDG Downloads directories is needed.

2. Docker Policy Integration
Added a new tunable: `dockerd_mounton_xdg_downloads_dir`.
When enabled, the tunable allows the Docker daemon (dockerd_t) to mount filesystems on user XDG Downloads directories.
The implementation uses the newly added `xdg_mounton_downloads()` interface.
The tunable is disabled by default, preserving existing behavior unless explicitly enabled.