### PR TITLE
logging.te: systemd-journald: loose ends

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -518,6 +518,12 @@ ifdef(`init_systemd',`
 	allow syslogd_t self:cap_userns sys_ptrace;
 	allow syslogd_t self:netlink_audit_socket { getattr getopt nlmsg_write read setopt write };
 
+	# socket activation is optional: for consistency with corresponding fc specs
+	filetrans_pattern(syslogd_t, syslogd_runtime_t, devlog_t, sock_file, "dev-log")
+	filetrans_pattern(syslogd_t, syslogd_runtime_t, devlog_t, sock_file, "socket")
+	filetrans_pattern(syslogd_t, syslogd_runtime_t, devlog_t, sock_file, "stdout")
+	filetrans_pattern(syslogd_t, syslogd_runtime_t, devlog_t, sock_file, "syslog")
+
 	# remove /run/log/journal when switching to permanent storage
 	allow syslogd_t var_log_t:dir rmdir;
 


### PR DESCRIPTION
Adds missing file type transition rules so that systemd-journald creates these sockets as per the corresponding fc specs for consistency because socket activation is optional