### PR TITLE
policy/modules/roles/sysadm.te: grant sysadm_t to check SELinux booleans

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1513,6 +1513,8 @@ template(`userdom_admin_user_template',`
 	# But presently necessary for installing the file_contexts file.
 	seutil_manage_bin_policy($1_t)
 
+	selinux_get_all_booleans($1_t)
+
 	userdom_manage_user_home_content_dirs($1_t)
 	userdom_manage_user_home_content_files($1_t)
 	userdom_manage_user_home_content_symlinks($1_t)


### PR DESCRIPTION
For sysadm, it would be useful to use getsebool to check SELinux settings.