### PR TITLE
Ensure correct labelling of GPIO chips with an index of 10 or greater

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -45,7 +45,7 @@
 /dev/full		-c	gen_context(system_u:object_r:null_device_t,s0)
 /dev/fw.*		-c	gen_context(system_u:object_r:usb_device_t,s0)
 /dev/gfx		-c	gen_context(system_u:object_r:xserver_misc_device_t,s0)
-/dev/gpiochip[0-9]	-c	gen_context(system_u:object_r:gpiochip_device_t,s0)
+/dev/gpiochip[0-9]+	-c	gen_context(system_u:object_r:gpiochip_device_t,s0)
 /dev/graphics		-c	gen_context(system_u:object_r:xserver_misc_device_t,s0)
 /dev/gtrsc.*		-c	gen_context(system_u:object_r:clock_device_t,s0)
 /dev/hfmodem		-c	gen_context(system_u:object_r:sound_device_t,s0)


### PR DESCRIPTION
Closes: #1179.

A system might contain GPIO chips with an index greater than 9. Those chips aren't labelled correctly at the moment. This PR ensures that those GPIO chips get the correct label `gpiochip_device_t`.