### PR TITLE
Alllow needed interactions between devicekit-disk and systemd-logind

### DIFF
--- a/policy/modules/services/devicekit.te
+++ b/policy/modules/services/devicekit.te
@@ -202,6 +202,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_read_logind_sessions_files(devicekit_disk_t)
+	systemd_write_inherited_logind_inhibit_pipes(devicekit_disk_t)
+')
+
+optional_policy(`
 	udev_domtrans_udevadm(devicekit_disk_t)
 	udev_read_runtime_files(devicekit_disk_t)
 ')


### PR DESCRIPTION
Closes: #1178.

This PR allows needed interactions between `devicekit-disk` and `systemd-logind`.