### PR TITLE
kernel: allow module loaders to use net_admin

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -16,6 +16,14 @@ gen_require(`
 ## </desc>
 gen_bool(secure_mode_insmod, false)
 
+## <desc>
+## <p>
+## Allow domains that can load kernel modules to use the net_admin
+## capability during module initialization.
+## </p>
+## </desc>
+gen_tunable(kernel_module_load_net_admin, false)
+
 # assertion related attributes
 attribute can_load_kernmodule;
 attribute can_receive_kernel_messages;
@@ -589,6 +597,10 @@ if(secure_mode_insmod) {
 	files_load_kernel_modules(can_load_kernmodule)
 
 	kernel_search_key(can_load_kernmodule)
+}
+
+if (!secure_mode_insmod && kernel_module_load_net_admin) {
+	allow can_load_kernmodule self:capability net_admin;
 }
 
 ########################################

--- a/testing/sechecker.ini
+++ b/testing/sechecker.ini
@@ -245,6 +245,7 @@ exempt_source = arpwatch_t
                 blueman_t
                 bluetooth_t
                 brctl_t
+                can_load_kernmodule # Conditional access (kernel_module_load_net_admin)
                 cgred_t
                 chronyd_t           # Conditional access (chronyd_hwtimestamp)
                 condor_startd_t


### PR DESCRIPTION
The qrtr and qrtr_smd kernel modules register the PF_QIPCRTR network protocol family during module initialization. This requires CAP_NET_ADMIN, but systemd-modules-load runs in systemd_modules_load_t without that capability.

When SELinux is enforcing, systemd-modules-load runs in Loading qrtr modules from modules-load.d fails with EPERM, and the modules are  qrtr modules from modules-load.d fails with EPERM, and the modules are loaded later through modalias autoloading.

Allow systemd-modules-load to use CAP_NET_ADMIN so qrtr modules can be preloaded during boot. This applies to any system using SELinux and building qrtr as loadable kernel modules. The denial is hidden by dontaudit rules and can be observed with semodule -DB:

```
  avc: denied { net_admin } for comm="systemd-modules" capability=12
  scontext=system_u:system_r:systemd_modules_load_t:s0
  tcontext=system_u:system_r:systemd_modules_load_t:s0 tclass=capability
```