### PR TITLE
mozilla: Add librewolf fork

### DIFF
--- a/policy/modules/apps/mozilla.fc
+++ b/policy/modules/apps/mozilla.fc
@@ -1,6 +1,9 @@
+HOME_DIR/\.cache/librewolf(/.*)?	gen_context(system_u:object_r:mozilla_xdg_cache_t,s0)
 HOME_DIR/\.cache/mozilla(/.*)?	gen_context(system_u:object_r:mozilla_xdg_cache_t,s0)
+HOME_DIR/\.config/librewolf(/.*)?	gen_context(system_u:object_r:mozilla_home_t,s0)
 HOME_DIR/\.config/mozilla(/.*)?	gen_context(system_u:object_r:mozilla_home_t,s0)
 HOME_DIR/\.galeon(/.*)?	gen_context(system_u:object_r:mozilla_home_t,s0)
+HOME_DIR/\.librewolf(/.*)?	gen_context(system_u:object_r:mozilla_home_t,s0)
 HOME_DIR/\.mozilla(/.*)?	gen_context(system_u:object_r:mozilla_home_t,s0)
 HOME_DIR/\.mozilla/plugins(/.*)?	gen_context(system_u:object_r:mozilla_plugin_home_t,s0)
 HOME_DIR/\.netscape(/.*)?	gen_context(system_u:object_r:mozilla_home_t,s0)
@@ -18,6 +21,8 @@ HOME_DIR/zimbrauserdata(/.*)?	gen_context(system_u:object_r:mozilla_plugin_home_
 
 /usr/bin/epiphany	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
 /usr/bin/epiphany-bin	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
+/usr/bin/librewolf	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
+/usr/bin/librewolf-bin	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
 /usr/bin/mozilla	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
 /usr/bin/mozilla-snapshot	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
 /usr/bin/mozilla-[0-9].*	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
@@ -28,6 +33,8 @@ HOME_DIR/zimbrauserdata(/.*)?	gen_context(system_u:object_r:mozilla_plugin_home_
 
 /usr/lib/[^/]*firefox[^/]*/firefox	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
 /usr/lib/[^/]*firefox[^/]*/firefox-bin	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
+/usr/lib/[^/]*librewolf[^/]*/librewolf	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
+/usr/lib/[^/]*librewolf[^/]*/librewolf-bin	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
 /usr/lib/firefox[^/]*/firefox-.*	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
 /usr/lib/firefox[^/]*/mozilla-.*	--	gen_context(system_u:object_r:mozilla_exec_t,s0)
 /usr/lib/galeon/galeon	--	gen_context(system_u:object_r:mozilla_exec_t,s0)

--- a/policy/modules/apps/mozilla.fc
+++ b/policy/modules/apps/mozilla.fc
@@ -1,4 +1,5 @@
 HOME_DIR/\.cache/mozilla(/.*)?	gen_context(system_u:object_r:mozilla_xdg_cache_t,s0)
+HOME_DIR/\.config/mozilla(/.*)?	gen_context(system_u:object_r:mozilla_home_t,s0)
 HOME_DIR/\.galeon(/.*)?	gen_context(system_u:object_r:mozilla_home_t,s0)
 HOME_DIR/\.mozilla(/.*)?	gen_context(system_u:object_r:mozilla_home_t,s0)
 HOME_DIR/\.mozilla/plugins(/.*)?	gen_context(system_u:object_r:mozilla_plugin_home_t,s0)


### PR DESCRIPTION
Apply mozilla firefox types to the firefox-based fork called librewolf.

It also adds the missing `HOME_DIR/\.config/mozilla(/.*)?` file context entry.