### PR TITLE
refpolicy: Add SELinux policy for tqftpserv

### DIFF
--- a/policy/modules/services/tqftpserv.fc
+++ b/policy/modules/services/tqftpserv.fc
@@ -1,0 +1,4 @@
+# File contexts for Qualcomm tqftpserv TFTP service.
+# Label the tqftpserv binary to trigger domain transition on exec.
+
+/usr/bin/tqftpserv	--	gen_context(system_u:object_r:qcom_tqftpserv_exec_t,s0)

--- a/policy/modules/services/tqftpserv.if
+++ b/policy/modules/services/tqftpserv.if
@@ -1,0 +1,3 @@
+## <summary>tqftpserv - Qualcomm TFTP server for modem remote filesystem access</summary>
+## <desc>
+## </desc>

--- a/policy/modules/services/tqftpserv.te
+++ b/policy/modules/services/tqftpserv.te
@@ -1,0 +1,23 @@
+########################################
+#
+# Declarations
+#
+
+type qcom_tqftpserv_t;
+type qcom_tqftpserv_exec_t;
+init_daemon_domain(qcom_tqftpserv_t, qcom_tqftpserv_exec_t)
+
+########################################
+#
+# qcom_tqftpserv local policy
+#
+
+# QRTR socket for modem IPC (EFS remote filesystem protocol)
+allow qcom_tqftpserv_t self:qipcrtr_socket create_socket_perms;
+
+# Generic socket operations
+allow qcom_tqftpserv_t self:socket create_socket_perms;
+
+# net_admin: network socket management
+# dac_read_search: read modem-requested EFS/data paths
+allow qcom_tqftpserv_t self:capability { net_admin dac_read_search };


### PR DESCRIPTION
tqftpserv is the Qualcomm TFTP server for modem remote filesystem (EFS) access. It currently runs under the generic initrc_t domain, lacking the process isolation and least-privilege permissions required under SELinux enforcing mode.

Defined a new policy module qcom_tqftpserv to transition the service into its own confined domain qcom_tqftpserv_t on exec:
- Allow QRTR socket creation for modem IPC communication
- Allow net_admin capability for network socket management
- Allow dac_read_search capability for reading modem-requested
filesystem paths under EFS/data areas

Signed-off-by: Shravan Kumar Kondi <kondishr@qti.qualcomm.com>