### PR TITLE
systemd: allow systemd-logind to read process state from devicekit power

### DIFF
--- a/policy/modules/services/devicekit.if
+++ b/policy/modules/services/devicekit.if
@@ -141,6 +141,25 @@ interface(`devicekit_use_fds_power',`
 
 ########################################
 ## <summary>
+##	Read process state of devicekit
+##	power.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`devicekit_read_power_state',`
+	gen_require(`
+		type devicekit_power_t;
+	')
+
+	ps_process_pattern($1, devicekit_power_t)
+')
+
+########################################
+## <summary>
 ##	Append inherited devicekit log files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1251,6 +1251,7 @@ optional_policy(`
 optional_policy(`
 	devicekit_dbus_chat_disk(systemd_logind_t)
 	devicekit_dbus_chat_power(systemd_logind_t)
+	devicekit_read_power_state(systemd_logind_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Closes: #1206.

When `devicekit power` suspends or powers off the system via `systemd-logind` due to low battery state, the following denials occur:

```
type=AVC msg=audit(1787648859.324:103): avc:  denied  { search } for  pid=946 comm="systemd-logind" name="1244" dev="proc" ino=11734 scontext=system_u:system_r:systemd_logind_t:s0 tcontext=system_u:system_r:devicekit_power_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1787648859.324:103): avc:  denied  { read } for  pid=946 comm="systemd-logind" name="status" dev="proc" ino=11735 scontext=system_u:system_r:systemd_logind_t:s0 tcontext=system_u:system_r:devicekit_power_t:s0 tclass=file permissive=1
type=AVC msg=audit(1787648859.324:103): avc:  denied  { open } for  pid=946 comm="systemd-logind" path="/proc/1244/status" dev="proc" ino=11735 scontext=system_u:system_r:systemd_logind_t:s0 tcontext=system_u:system_r:devicekit_power_t:s0 tclass=file permissive=1
type=SYSCALL msg=audit(1787648859.324:103): arch=c00000b7 syscall=56 success=yes exit=23 a0=ffffffffffffff9c a1=ffffdc72cb30 a2=80000 a3=0 items=1 ppid=1 pid=946 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="systemd-logind" exe="/usr/lib/systemd/systemd-logind" subj=system_u:system_r:systemd_logind_t:s0 key=(null)ARCH=aarch64 SYSCALL=openat AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"
type=CWD msg=audit(1787648859.324:103): cwd="/"
type=PATH msg=audit(1787648859.324:103): item=0 name="/proc/1244/status" inode=11735 dev=00:31 mode=0100444 ouid=0 ogid=0 rdev=00:00 obj=system_u:system_r:devicekit_power_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0OUID="root" OGID="root"
type=PROCTITLE msg=audit(1787648859.324:103): proctitle="/usr/lib/systemd/systemd-logind"
type=AVC msg=audit(1787648859.328:104): avc:  denied  { getattr } for  pid=946 comm="systemd-logind" path="/proc/1244/status" dev="proc" ino=11735 scontext=system_u:system_r:systemd_logind_t:s0 tcontext=system_u:system_r:devicekit_power_t:s0 tclass=file permissive=1
type=SYSCALL msg=audit(1787648859.328:104): arch=c00000b7 syscall=80 success=yes exit=0 a0=17 a1=ffffdc72c918 a2=ffffaa26f120 a3=ffffaa84b460 items=0 ppid=1 pid=946 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="systemd-logind" exe="/usr/lib/systemd/systemd-logind" subj=system_u:system_r:systemd_logind_t:s0 key=(null)ARCH=aarch64 SYSCALL=newfstat AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"
type=PROCTITLE msg=audit(1787648859.328:104): proctitle="/usr/lib/systemd/systemd-logind"
type=AVC msg=audit(1787648859.328:105): avc:  denied  { ioctl } for  pid=946 comm="systemd-logind" path="/proc/1244/status" dev="proc" ino=11735 ioctlcmd=0x542a scontext=system_u:system_r:systemd_logind_t:s0 tcontext=system_u:system_r:devicekit_power_t:s0 tclass=file permissive=1
type=SYSCALL msg=audit(1787648859.328:105): arch=c00000b7 syscall=29 success=no exit=-25 a0=17 a1=802c542a a2=ffffdc72ca38 a3=ffffdc72cac0 items=0 ppid=1 pid=946 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="systemd-logind" exe="/usr/lib/systemd/systemd-logind" subj=system_u:system_r:systemd_logind_t:s0 key=(null)ARCH=aarch64 SYSCALL=ioctl AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"
type=PROCTITLE msg=audit(1787648859.328:105): proctitle="/usr/lib/systemd/systemd-logind"
```

The denials can be reproduced by directly invoking the D-Bus method in the `devicekit_power_t` domain, that might be invoked by `devicekit power` in the case of low battery state:

```
runcon system_u:system_r:devicekit_power_t:s0 \
  dbus-send --system --print-reply \
    --dest=org.freedesktop.login1 \
    /org/freedesktop/login1 \
    org.freedesktop.login1.Manager.PowerOff boolean:true
```