### PR TITLE
Fix login error about lacking anon_inodefs on kernel 6.6

### DIFF
--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -9,6 +9,7 @@ type local_login_t;
 domain_interactive_fd(local_login_t)
 auth_login_pgm_domain(local_login_t)
 auth_login_entry_type(local_login_t)
+fs_getattr_all_fs(local_login_t)
 
 type local_login_lock_t;
 files_lock_file(local_login_lock_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -60,6 +60,7 @@ template(`systemd_role_template',`
 	# This domain is per-role because of the below transitions.
 	# See the systemd --user section of systemd.te for the
 	# remainder of the rules.
+	fs_getattr_all_fs($1_systemd_t)
 	allow $1_systemd_t self:process { getsched signal };
 	allow $1_systemd_t self:netlink_kobject_uevent_socket create_socket_perms;
 	allow $1_systemd_t self:netlink_route_socket r_netlink_socket_perms;


### PR DESCRIPTION
For kernel < 6.9, pidfs is not supported. login via pam_systemd chain will give us avc denial error.

Version info about the related softwares:
kernel : 6.6
systemd : 259.5
shadow : 4.19.4
