### PR TITLE
Fix su related issue

### DIFF
--- a/policy/modules/admin/su.if
+++ b/policy/modules/admin/su.if
@@ -46,7 +46,7 @@ template(`su_restricted_domain_template', `
 	allow $1_su_t self:capability { audit_control audit_write chown dac_override fowner net_bind_service setgid setuid sys_nice sys_resource };
 	dontaudit $1_su_t self:capability sys_tty_config;
 	allow $1_su_t self:key { search write };
-	allow $1_su_t self:process { setexec setrlimit setsched signal };
+	allow $1_su_t self:process { getcap setexec setrlimit setsched signal };
 	allow $1_su_t self:fifo_file rw_fifo_file_perms;
 	allow $1_su_t self:netlink_audit_socket { create_netlink_socket_perms nlmsg_relay };
 	allow $1_su_t self:unix_stream_socket create_stream_socket_perms;
@@ -161,7 +161,7 @@ template(`su_role_template',`
 
 	allow $1_su_t self:capability { audit_control audit_write chown dac_override fowner net_bind_service setgid setuid sys_nice sys_resource };
 	dontaudit $1_su_t self:capability { net_admin sys_tty_config };
-	allow $1_su_t self:process { setexec setrlimit setsched signal };
+	allow $1_su_t self:process { getcap setexec setrlimit setsched signal };
 	allow $1_su_t self:fifo_file rw_fifo_file_perms;
 	allow $1_su_t self:netlink_audit_socket { create_netlink_socket_perms nlmsg_relay };
 	allow $1_su_t self:key { search write };

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -93,6 +93,8 @@ interface(`auth_use_pam_systemd',`
 	systemd_read_logind_state($1)
 	systemd_use_logind_fds($1)
 
+	fs_getattr_all_fs($1)
+
 	# to read /etc/machine-id
 	files_read_etc_runtime_files($1)
 

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -89,6 +89,7 @@ interface(`auth_use_pam',`
 interface(`auth_use_pam_systemd',`
 	systemd_connect_machined($1)
 	systemd_dbus_chat_logind($1)
+	systemd_stream_connect_logind($1)
 	systemd_read_logind_state($1)
 	systemd_use_logind_fds($1)
 

--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -154,6 +154,7 @@ ifdef(`init_systemd',`
 
 	systemd_connect_machined(local_login_t)
 	systemd_dbus_chat_logind(local_login_t)
+	systemd_stream_connect_logind(local_login_t)
 	systemd_use_logind_fds(local_login_t)
 	systemd_manage_logind_runtime_pipes(local_login_t)
 	systemd_dbus_chat_homed(local_login_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1313,6 +1313,26 @@ interface(`systemd_stream_connect_homed',`
 	stream_connect_pattern($1, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t, systemd_homed_t)
 ')
 
+########################################
+## <summary>
+##   Connect to /run/systemd/io.systemd.Login to
+##   register sessions with systemd-logind.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_stream_connect_logind',`
+	gen_require(`
+		type systemd_logind_t;
+		type systemd_logind_runtime_t;
+	')
+
+	stream_connect_pattern($1, systemd_logind_runtime_t, systemd_logind_runtime_t, systemd_logind_t)
+')
+
 ######################################
 ## <summary>
 ##   Read and write systemd-homework semaphores.


### PR DESCRIPTION
Running `su - SOME_USER' gives us several AVC messages.
This patch series solve them.
In particular, it adds missing systemd varlink interface for logind.