### PR TITLE
Fix /proc/net symlink denials

### DIFF
--- a/policy/modules/services/postgresql.te
+++ b/policy/modules/services/postgresql.te
@@ -304,6 +304,7 @@ manage_sock_files_pattern(postgresql_t, postgresql_runtime_t, postgresql_runtime
 files_runtime_filetrans(postgresql_t, postgresql_runtime_t, { dir file })
 
 kernel_read_kernel_sysctls(postgresql_t)
+kernel_read_network_state_symlinks(postgresql_t)
 kernel_read_system_state(postgresql_t)
 kernel_list_proc(postgresql_t)
 kernel_read_all_sysctls(postgresql_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -111,6 +111,7 @@ template(`systemd_role_template',`
 	fs_watch_cgroup_files($1_systemd_t)
 
 	kernel_dontaudit_getattr_proc($1_systemd_t)
+	kernel_read_network_state_symlinks($1_systemd_t)
 	kernel_read_psi($1_systemd_t)
 
 	# if systemd exists in the initrd, the journal socket stays labeled kernel_t

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1966,6 +1966,7 @@ dev_read_sysfs(systemd_resolved_t)
 
 kernel_read_kernel_sysctls(systemd_resolved_t)
 kernel_read_net_sysctls(systemd_resolved_t)
+kernel_read_network_state_symlinks(systemd_resolved_t)
 kernel_dontaudit_getattr_proc(systemd_resolved_t)
 
 corenet_tcp_bind_generic_node(systemd_resolved_t)


### PR DESCRIPTION
/proc/net changed from proc_t to proc_net_t since
2e810736211785675f0be23a26638cd44c69eaae

Fixes:
avc: denied { read } for pid=333 comm="systemd" name="net" dev="proc" ino=4026531843 scontext=staff_u:staff_r:staff_systemd_t tcontext=system_u:object_r:proc_net_t tclass=lnk_file avc: denied { read } for pid=179 comm="systemd-resolve" name="net" dev="proc" ino=4026531843 scontext=system_u:system_r:systemd_resolved_t tcontext=system_u:object_r:proc_net_t tclass=lnk_file avc: denied { read } for pid=294 comm="postgres" name="net" dev="proc" ino=4026531843 scontext=system_u:system_r:postgresql_t tcontext=system_u:object_r:proc_net_t tclass=lnk_file