### PR TITLE
Add configfs_t and tracefs_t to mountpoint attribute

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -108,6 +108,7 @@ dev_associate_sysfs(memory_pressure_t)
 
 type configfs_t;
 fs_type(configfs_t)
+files_mountpoint(configfs_t)
 genfscon configfs / gen_context(system_u:object_r:configfs_t,s0)
 
 type cpusetfs_t;
@@ -200,6 +201,7 @@ genfscon v7 / gen_context(system_u:object_r:sysv_t,s0)
 
 type tracefs_t;
 fs_type(tracefs_t)
+files_mountpoint(tracefs_t)
 genfscon tracefs / gen_context(system_u:object_r:tracefs_t,s0)
 
 optional_policy(`


### PR DESCRIPTION
Noticed that these mount points aren't covered by `files_search_all_mountpoints()`. I assume this isn't intentional.