### PR TITLE
systemd: Add systemd-tmpfiles read access for tmp files.

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2836,7 +2836,7 @@ interface(`systemd_tmpfilesd_managed',`
 	')
 
 	allow systemd_tmpfiles_t $1:dir { manage_dir_perms relabel_dir_perms  };
-	allow systemd_tmpfiles_t $1:file { create relabel_file_perms setattr unlink write_file_perms };
+	allow systemd_tmpfiles_t $1:file { manage_file_perms relabel_file_perms };
 	allow systemd_tmpfiles_t $1:lnk_file { create read relabel_lnk_file_perms setattr unlink };
 	allow systemd_tmpfiles_t $1:fifo_file { create relabel_fifo_file_perms setattr unlink };
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2203,6 +2203,7 @@ files_manage_generic_tmp_dirs(systemd_tmpfiles_t)
 files_manage_var_dirs(systemd_tmpfiles_t)
 files_manage_var_lib_dirs(systemd_tmpfiles_t)
 files_manage_all_locks(systemd_tmpfiles_t)
+files_read_all_tmp_files(systemd_tmpfiles_t)  # to acquire lock for --clean
 files_purge_tmp(systemd_tmpfiles_t)
 files_read_etc_files(systemd_tmpfiles_t)
 files_read_etc_runtime_files(systemd_tmpfiles_t)


### PR DESCRIPTION
The systemd-tmpfiles --clean will require read
access otherwise it will generate an error:

Opening file "/tmp/systemd-private-20ec5f583cb54e41bd3d7a3dda737b2a-foo.service-4ABCdF/tmp/foo.tmp" failed, proceeding without lock: Permission denied

See:
https://github.com/systemd/systemd/blob/8cceaab8f5c597f207d5c86fcaa280d2e0e3a2b8/src/tmpfiles/tmpfiles.c#L875