### PR TITLE
Remove mountpoint attribute from debugfs_t

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -65,7 +65,6 @@ sid init gen_context(system_u:system_r:kernel_t,mls_systemhigh)
 #
 
 type debugfs_t;
-files_mountpoint(debugfs_t)
 fs_type(debugfs_t)
 allow debugfs_t self:filesystem associate;
 genfscon debugfs / gen_context(system_u:object_r:debugfs_t,s0)


### PR DESCRIPTION
See comments in https://github.com/SELinuxProject/refpolicy/pull/1220