### PR TITLE
sysadm.te: sysadm_t auto transition to systemd_passwd_agent_t

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -125,6 +125,9 @@ ifdef(`init_systemd',`
 
 	# Allow sysadm to follow logs in the journal, i.e. with podman logs -f
 	systemd_watch_journal_dirs(sysadm_t)
+
+	# Allow sysadm to spawn systemd-tty-ask-password-agent for ask-password
+	systemd_run_passwd_agent(sysadm_t, sysadm_r)
 ')
 
 tunable_policy(`allow_ptrace',`


### PR DESCRIPTION
When using systemctl to manage services, there will be annoying error message like below:

  root@qemuarm64:~# systemctl start systemd-networkd
  Failed to add a watch for /run/user/0/systemd/ask-password: Permission denied

The AVC message is:

  avc:  denied  { watch } for  pid=615 comm="systemd-tty-ask" \
    path="/run/user/0/systemd/ask-password" dev="tmpfs" ino=24 \
    scontext=root:sysadm_r:sysadm_t:s0-s0:c0.c1023 \
    tcontext=root:object_r:systemd_user_runtime_t:s0 \
    tclass=dir permissive=0

The root cause is that sysadm_t is not automatically transitioned to systemd_passwd_agent_t when spawning the /usr/bin/systemd-tty-ask-password-agent process.