### PR TITLE
systemd: Fix denials of systemd-machine-id-commit.service

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1379,6 +1379,7 @@ files_rw_etc_runtime_files(systemd_machine_id_setup_t)
 fs_getattr_cgroup(systemd_machine_id_setup_t)
 fs_search_cgroup_dirs(systemd_machine_id_setup_t)
 fs_getattr_tmpfs(systemd_machine_id_setup_t)
+fs_getattr_xattr_fs(systemd_machine_id_setup_t)
 fs_read_nsfs_files(systemd_machine_id_setup_t)
 fs_unmount_tmpfs(systemd_machine_id_setup_t)
 


### PR DESCRIPTION
Closes: #1228.

This patch fixes the following denials:

```
type=AVC msg=audit(1788873212.881:51): avc:  denied  { getattr } for  pid=877 comm="systemd-machine" name="/" dev="pidfs" ino=1 scontext=system_u:system_r:systemd_machine_id_setup_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0
type=SYSCALL msg=audit(1788873212.881:51): arch=c000003e syscall=138 success=no exit=-13 a0=4 a1=7ffdd993c140 a2=7ffdd993c140 a3=ffffffff items=0 ppid=1 pid=877 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="systemd-machine" exe="/usr/bin/systemd-machine-id-setup" subj=system_u:system_r:systemd_machine_id_setup_t:s0 key=(null)ARCH=x86_64 SYSCALL=fstatfs AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"
type=PROCTITLE msg=audit(1788873212.881:51): proctitle=73797374656D642D6D616368696E652D69642D7365747570002D2D636F6D6D6974
```