### PR TITLE
tee_supplicant: Allow qtee_supplicant to access the eMMC RPMB device

### DIFF
--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -912,6 +912,24 @@ interface(`storage_dontaudit_raw_write_removable_device',`
 
 ########################################
 ## <summary>
+#	read or write on removable device interfaces.
+## </summary>
+## <param name="domain">
+##     <summary>
+##     Domain allowed access.
+##     </summary>
+## </param>
+#
+interface(`storage_raw_rw_removable_device',`
+	gen_require(`
+		type removable_device_t;
+	')
+
+	allow $1 removable_device_t:chr_file rw_chr_file_perms;
+')
+
+########################################
+## <summary>
 ##	Allow the caller to directly read
 ##	a tape device.
 ## </summary>

--- a/policy/modules/services/tee_supplicant.te
+++ b/policy/modules/services/tee_supplicant.te
@@ -34,6 +34,13 @@ dev_rw_tee_priv(tee_supplicant_t)
 
 kernel_read_vm_overcommit_sysctl(tee_supplicant_t)
 
+# Allow qtee_supplicant to access the eMMC RPMB device (/dev/mmcblk0rpmb)
+storage_raw_rw_removable_device(tee_supplicant_t)
+
+# Allow qtee_supplicant to search directories labeled default_t
+# (e.g., the "data" directory on mmcblk0pxx)
+files_search_default(tee_supplicant_t)
+
 # Access qtee_supplicant to access UFS BSG device
 storage_read_scsi_generic_cond(tee_supplicant_t,tee_supplicant_qtee)
 storage_write_scsi_generic_cond(tee_supplicant_t,tee_supplicant_qtee)


### PR DESCRIPTION
Add SELinux allow rules for qtee_supplicant to access the eMMC RPMB device, enabling communication with the RPMB partition on eMMC-based systems.

Define a new storage_raw_rw_removable_device() interface to storage.if to allow read or write on removable chr_file interfaces, and use it in tee_supplicant.te to grant qtee_supplicant the necessary chr_file rw_chr_file_perms on removable_device_t.