### PR TITLE
corecommands: Python-exec wrappers has scripts in specific location, …

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -460,6 +460,11 @@ ifdef(`distro_suse', `
 /usr/share/apache2/[^/]*	--	gen_context(system_u:object_r:bin_t,s0)
 ')
 
+ifdef(`distro_gentoo',`
+/usr/lib/python-exec/python-exec2	--	gen_context(system_u:object_r:bin_t,s0)
+/usr/lib/python-exec/python.*/.*	--	gen_context(system_u:object_r:bin_t,s0)
+')
+
 #
 # /var
 #


### PR DESCRIPTION
…mark those as bin_t

Python scripts in Gentoo are symlinks in /usr/bin pointing to python-exec, which then executes scripts living under `/usr/lib/python-exec/python.*/.*`.

---

This has been in our tree in Gentoo since 2014. See https://github.com/SELinuxProject/refpolicy/pull/305 as well.