### PR TITLE
kernel: Add init_mountpoint for debugfs_t

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -69,6 +69,10 @@ fs_type(debugfs_t)
 allow debugfs_t self:filesystem associate;
 genfscon debugfs / gen_context(system_u:object_r:debugfs_t,s0)
 
+optional_policy(`
+	init_mountpoint(debugfs_t)
+')	
+
 #
 # kvmFS
 #


### PR DESCRIPTION
With the recent change to remove files_mountpoint for debugfs_t #1225 seeing issues with systemd (on RHEL9) setting up namespaces.  This change added init_mountpoint for debugfs_t so things work again.

node=dsugar-vm type=PROCTITLE msg=audit(1789048016.920:20489): proctitle="(chronyd)"
node=dsugar-vm type=SYSCALL msg=audit(1789048016.920:20489): arch=c000003e syscall=5 success=no exit=-13 a0=5 a1=7ffd6dee30c0 a2=0 a3=0 items=0 ppid=1 pid=5798 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="(chronyd)" exe="/usr/lib/systemd/systemd" subj=system_u:system_r:init_t:s0 key=(null) node=dsugar-vm type=AVC msg=audit(1789048016.920:20489): avc: denied { getattr } for pid=5798 comm="(chronyd)" path="/run/systemd/unit-root/sys/kernel/debug "dev="debugfs" ino=1 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:debugfs_t:s0 tclass=dir permissive=0