### PR TITLE
systemd: Fix denials of systemd-modules-load.service

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1403,6 +1403,8 @@ optional_policy(`
 # modules-load local policy
 #
 
+allow systemd_modules_load_t self:key write;
+
 corecmd_exec_shell(systemd_modules_load_t)
 
 fs_getattr_cgroup(systemd_modules_load_t)


### PR DESCRIPTION
Closes: #1234.

This patch fixes the following denials:

```
Apr 05 23:00:03 kernel: audit: type=1400 audit(1302044403.444:7): avc:  denied  { write } for  pid=760 comm="systemd-modules" scontext=system_u:system_r:systemd_modules_load_t:s0 tcontext=system_u:system_r:systemd_modules_load_t:s0 tclass=key permissive=0
Apr 05 23:00:03 kernel: audit: type=1400 audit(1302044403.444:8): avc:  denied  { write } for  pid=760 comm="systemd-modules" scontext=system_u:system_r:systemd_modules_load_t:s0 tcontext=system_u:system_r:systemd_modules_load_t:s0 tclass=key permissive=0
```