### PR TITLE
portage: label `ebuild`

### DIFF
--- a/policy/modules/admin/portage.fc
+++ b/policy/modules/admin/portage.fc
@@ -14,6 +14,7 @@
 
 /usr/lib/python-exec/python[0-9]\.[0-9]*/glsa-check	--	gen_context(system_u:object_r:portage_exec_t,s0)
 /usr/lib/python-exec/python[0-9]\.[0-9]*/layman	--	gen_context(system_u:object_r:portage_fetch_exec_t,s0)
+/usr/lib/python-exec/python[0-9]\.[0-9]*/ebuild	--	gen_context(system_u:object_r:portage_exec_t,s0)
 /usr/lib/python-exec/python[0-9]\.[0-9]*/emaint	--	gen_context(system_u:object_r:portage_exec_t,s0)
 /usr/lib/python-exec/python[0-9]\.[0-9]*/emerge	--	gen_context(system_u:object_r:portage_exec_t,s0)
 


### PR DESCRIPTION
ebuild(1) may be used directly when developing an ebuild or trying a workaround to a problem.

Closes: https://bugs.gentoo.org/982264